### PR TITLE
Upgrade CI to docker 1.10.0 to fix remove image issue

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,21 +1,21 @@
 machine:
   environment:
     GOPATH: $HOME/.go_workspace
-    REPO: ${GOPATH}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
-    DOCKER_VERSION: 1.9.1
-    DOCKER_MACHINE_VERSION: 0.6.0
+    REPO: ${GOPATH}/src/github.com/hyperledger/burrow
     GO15VENDOREXPERIMENT: 1
+  pre:
+    - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
+  services:
+    - docker
   post:
     - git config --global user.email "billings@monax.io"
     - git config --global user.name "Billings the Bot"
-    - rm -rf ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}
-    - mkdir -p ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}
-    - cp -r ${HOME}/${CIRCLE_PROJECT_REPONAME} ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}/.
+    - rm -rf ${GOPATH%%:*}/src/github.com/hyperledger
+    - mkdir -p ${GOPATH%%:*}/src/github.com/hyperledger
+    - cp -r ${HOME}/${CIRCLE_PROJECT_REPONAME} ${GOPATH%%:*}/src/github.com/hyperledger/.
 
 dependencies:
   override:
-    - sudo curl -L -o /usr/bin/docker http://s3-external-1.amazonaws.com/circle-downloads/docker-$DOCKER_VERSION-circleci; sudo chmod 0775 /usr/bin/docker; sudo usermod -a -G docker $USER; true
-    - sudo service docker start
     - sudo apt-get update && sudo apt-get install -y libgmp3-dev
     - sudo apt-get install jq curl && go get github.com/Masterminds/glide
 

--- a/tests/build_tool.sh
+++ b/tests/build_tool.sh
@@ -52,8 +52,5 @@ fi
 rm $REPO/target/docker/burrow.dockerartefact
 rm $REPO/target/docker/burrow-client.dockerartefact
 
-# CircleCI seems to have an issues removing this build, in any case it is not necessary on CI
-if [ ! "$CI" ]
-then
-  docker rmi -f $IMAGE:build
-fi
+# Remove build image so we don't push it when we push all tags
+docker rmi -f $IMAGE:build


### PR DESCRIPTION
This PR:

- Upgrades to Circle approved docker 1.10.0
- Fixes issue where build image could not be removed
- Reintroduces removal of build image so it is not pushed
- Stops using repo username and instead hard codes hyperledger/burrow so CI will work against forks