### PR TITLE
Add transact fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # burrow changelog
+## v0.16.3
+This release adds an stop-gap fix to the `Transact` method so that it never
+transfers value with the `CallTx` is generates.
+
+We hard-code `amount = fee` so that no value is transferred
+regardless of fee sent. This fixes an invalid jump destination error arising 
+from transferring value to non-payable functions with newer versions of solidity.
+By doing this we can resolve some issues with users of the v0 RPC without making 
+a breaking API change.
+
 ## v0.16.2
 This release finalises our accession to the Hyperledger project and updates our
 root package namespace to github.com/hyperledger/burrow.

--- a/manager/burrow-mint/transactor.go
+++ b/manager/burrow-mint/transactor.go
@@ -176,10 +176,20 @@ func (this *transactor) Transact(privKey, address, data []byte, gasLimit,
 	} else {
 		sequence = acc.Sequence + 1
 	}
-	// fmt.Printf("Sequence %d\n", sequence)
+	// TODO: [Silas] we should consider revising this method and removing fee, or
+	// possibly adding an amount parameter. It is non-sensical to just be able to
+	// set the fee. Our support of fees in general is questionable since at the
+	// moment all we do is deduct the fee effectively leaking token. It is possible
+	// someone may be using the sending of native token to payable functions but
+	// they can be served by broadcasting a token.
+
+	// We hard-code the amount to be equal to the fee which means the CallTx we
+	// generate transfers 0 value, which is the most sensible default since in
+	// recent solidity compilers the EVM generated will throw an error if value
+	// is transferred to a non-payable function.
 	txInput := &txs.TxInput{
 		Address:  pa.Address,
-		Amount:   1,
+		Amount:   fee,
 		Sequence: sequence,
 		PubKey:   pa.PubKey,
 	}


### PR DESCRIPTION
This ensures that `Transact` never sends value, and if fee is passed as '0' it further ensures it will not leak tokens through the fee. The Javascript libraries should opt for '0' fee after this fix is incorporated (they have been hotfixed to send '1' as fee to get same effect against existing Burrow code).