### PR TITLE
Don't capture time twice

### DIFF
--- a/logging/adapters/tendermint_log15/convert.go
+++ b/logging/adapters/tendermint_log15/convert.go
@@ -43,9 +43,8 @@ func LogLineToRecord(keyvals ...interface{}) *log15.Record {
 		Call: call,
 		Ctx:  ctx,
 		KeyNames: log15.RecordKeyNames{
-			Time: structure.TimeKey,
-			Msg:  structure.MessageKey,
-			Lvl:  structure.LevelKey,
+			Msg: structure.MessageKey,
+			Lvl: structure.LevelKey,
 		}}
 }
 
@@ -54,7 +53,6 @@ func LogLineToRecord(keyvals ...interface{}) *log15.Record {
 func RecordToLogLine(record *log15.Record) []interface{} {
 	return Concat(
 		Slice(
-			structure.TimeKey, record.Time,
 			structure.CallerKey, record.Call,
 			structure.LevelKey, record.Lvl.String(),
 		),


### PR DESCRIPTION
Leads to vector-valued time that is unprintable. We are adding time to capture logs through `WithMetadata` already