### PR TITLE
Change hasBase to return bool

### DIFF
--- a/manager/burrow-mint/evm/native.go
+++ b/manager/burrow-mint/evm/native.go
@@ -24,8 +24,8 @@ import (
 
 var registeredNativeContracts = make(map[Word256]NativeContract)
 
-func RegisteredNativeContract(addr Word256) bool {
-	_, ok := registeredNativeContracts[addr]
+func RegisteredNativeContract(address Word256) bool {
+	_, ok := registeredNativeContracts[address]
 	return ok
 }
 

--- a/manager/burrow-mint/evm/snative.go
+++ b/manager/burrow-mint/evm/snative.go
@@ -165,7 +165,7 @@ func SNativeContracts() map[string]*SNativeContractDescription {
 				[]abi.Arg{
 					arg("_account", abi.AddressTypeName),
 					arg("_permission", permFlagTypeName)},
-				ret("result", permFlagTypeName),
+				ret("result", abi.BoolTypeName),
 				ptypes.HasBase,
 				hasBase},
 

--- a/manager/burrow-mint/pipe.go
+++ b/manager/burrow-mint/pipe.go
@@ -409,6 +409,11 @@ func (pipe *burrowMintPipe) DumpStorage(address []byte) (*rpc_tm_types.ResultDum
 // TODO: [ben] resolve incompatibilities in byte representation for 0.12.0 release
 func (pipe *burrowMintPipe) Call(fromAddress, toAddress, data []byte) (*rpc_tm_types.ResultCall,
 	error) {
+	if vm.RegisteredNativeContract(word256.LeftPadWord256(toAddress)) {
+		return nil, fmt.Errorf("Attempt to call native contract at address "+
+			"%X, but native contracts can not be called directly. Use a deployed "+
+			"contract that calls the native function instead.", toAddress)
+	}
 	st := pipe.burrowMint.GetState()
 	cache := state.NewBlockCache(st)
 	outAcc := cache.GetAccount(toAddress)

--- a/manager/burrow-mint/state/execution.go
+++ b/manager/burrow-mint/state/execution.go
@@ -431,7 +431,10 @@ func ExecTx(blockCache *BlockCache, tx txs.Tx, runCall bool, evc events.Fireable
 			}
 			// check if its a native contract
 			if vm.RegisteredNativeContract(LeftPadWord256(tx.Address)) {
-				return fmt.Errorf("NativeContracts can not be called using CallTx. Use a contract or the appropriate tx type (eg. PermissionsTx, NameTx)")
+				return fmt.Errorf("Attempt to call a native contract at %X, "+
+					"but native contracts cannot be called using CallTx. Use a "+
+					"contract that calls the native contract or the appropriate tx "+
+					"type (eg. PermissionsTx, NameTx).", tx.Address)
 			}
 
 			// Output account may be nil if we are still in mempool and contract was created in same block as this tx


### PR DESCRIPTION
This change was inadvertently omitted from #500, it changes the return type of `hasBase` to bool to match the other predicate methods.

I've also added an error message if one attempts to call an snative directly (simulated call as in query-contract) which mirrors the error message given in execution.go when doing the same via a `CallTx`.