### PR TITLE
Port master to develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ check:
 	@gofmt -l -d ${GOFILES_NOVENDOR}
 	@gofmt -l ${GOFILES_NOVENDOR} | read && echo && echo "Your marmot has found a problem with the formatting style of the code." 1>&2 && exit 1 || true
 
+# Just fix it
+.PHONY: fix
+fix:
+	@goimports -l -w ${GOFILES_NOVENDOR}
+
 # fmt runs gofmt -w on the code, modifying any files that do not match
 # the style guide.
 .PHONY: fmt

--- a/logging/config/config.go
+++ b/logging/config/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type LoggingConfig struct {
-	RootSink         *SinkConfig `toml:"root_sink,omitempty"`
+	RootSink *SinkConfig `toml:"root_sink,omitempty"`
 }
 
 // For encoding a top-level '[logging]' TOML table

--- a/logging/types/info_trace_logger.go
+++ b/logging/types/info_trace_logger.go
@@ -52,7 +52,6 @@ type InfoTraceLogger interface {
 
 	// Hot swap the underlying outputLogger with another one to re-route messages
 	SwapOutput(outputLogger kitlog.Logger)
-
 }
 
 // Interface assertions

--- a/manager/burrow-mint/state/block_cache_test.go
+++ b/manager/burrow-mint/state/block_cache_test.go
@@ -21,8 +21,8 @@ func TestBlockCache_Sync_Accounts(t *testing.T) {
 	// to remove them twice from merkle tree
 	defer func() {
 		if r := recover(); r != nil {
-			t.Fatalf("Consecutive calls to BlockCache.Sync() failed. " +
-					"Is cache dirty?\n Error: %s", r)
+			t.Fatalf("Consecutive calls to BlockCache.Sync() failed. "+
+				"Is cache dirty?\n Error: %s", r)
 		}
 	}()
 	blockCache.Sync()
@@ -46,8 +46,8 @@ func TestBlockCache_Sync_NameReg(t *testing.T) {
 	blockCache.Sync()
 	defer func() {
 		if r := recover(); r != nil {
-			t.Fatalf("Consecutive calls to BlockCache.Sync() failed. " +
-					"Is cache dirty?\n Error: %s", r)
+			t.Fatalf("Consecutive calls to BlockCache.Sync() failed. "+
+				"Is cache dirty?\n Error: %s", r)
 		}
 	}()
 	blockCache.Sync()


### PR DESCRIPTION
This is mostly to make the version bump to 0.16.1 and ancestor of changes on develop so develop is mergeable to master.

I've also taken opportunity to add goimports fix directive that is useful to have in Makefile