### PR TITLE
Only push tagged version to their quay.io label

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,35 +32,12 @@ test:
     # - echo "Running integration tests..." && cd $REPO && "tests/circle_test.sh" # | tee $CIRCLE_ARTIFACTS/output.log; test ${PIPESTATUS[0]} -eq 0"
 
 deployment:
-  release-0.12:
-    branch: release-0.12
-    commands:
-      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
-      # build docker image and tag the image with the version
-      - tests/build_tool.sh
-      - docker push quay.io/monax/db
-  release-0.16:
-    branch: release-0.16
-    commands:
-      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
-      # build docker image and tag the image with the version
-      - tests/build_tool.sh
-      - docker push quay.io/monax/db
   develop:
     branch: develop
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
-      # build docker image and tag the image with the version
+      # build docker image and tag the image with the version, date, and commit hash
       - tests/build_tool.sh
-      - docker push quay.io/monax/db
-  master:
-    branch: master
-    commands:
-      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
-      # build docker image and tag the image with ':latest'
-      # builds on master are considered immutable so we do not push the version
-      # tag to allow for hotfixes
-      - tests/build_tool.sh latest
       - docker push quay.io/monax/db
   tagged-releases:
     tag: /v[0-9]+(\.[0-9]+)*/

--- a/tests/build_tool.sh
+++ b/tests/build_tool.sh
@@ -18,8 +18,8 @@
 
 # ----------------------------------------------------------
 
-TARGET=burrow
 IMAGE=quay.io/monax/db
+VERSION_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+$"
 
 set -e
 
@@ -28,24 +28,40 @@ then
   REPO=`pwd`
   CI="true"
 else
-  REPO=$GOPATH/src/github.com/hyperledger/$TARGET
+  REPO=$GOPATH/src/github.com/hyperledger/burrow
 fi
 
-release_min=$(cat $REPO/version/version.go | tail -n 1 | cut -d \  -f 4 | tr -d '"')
-release_maj=$(echo $release_min | cut -d . -f 1-2)
+version=$(cat $REPO/version/version.go | tail -n 1 | cut -d \  -f 4 | tr -d '"')
+tag=$(git tag --points-at HEAD)
+
+# Only label a build as a release version when the commit is tagged
+if [[ ${tag} =~ ${VERSION_REGEX} ]] ; then
+    echo "Building release version (tagged $tag)..."
+    # Fail noisily when trying to build a release version that does not match code tag
+    if [[ ! ${tag} = "v$version" ]]; then
+        echo "Build failure: version tag $tag does not match version/version.go version $version"
+        exit 1
+    fi
+else
+    date=$(date +"%Y%m%d")
+    commit=$(git rev-parse --short HEAD)
+    version="$version-dev-$date-$commit"
+    echo "Building non-release version $version..."
+fi
+
 
 # Build
 mkdir -p $REPO/target/docker
 docker build -t $IMAGE:build $REPO
-docker run --rm --entrypoint cat $IMAGE:build /usr/local/bin/$TARGET > $REPO/target/docker/burrow.dockerartefact
+docker run --rm --entrypoint cat $IMAGE:build /usr/local/bin/burrow > $REPO/target/docker/burrow.dockerartefact
 docker run --rm --entrypoint cat $IMAGE:build /usr/local/bin/burrow-client > $REPO/target/docker/burrow-client.dockerartefact
-docker build -t $IMAGE:$release_min -f Dockerfile.deploy $REPO
+docker build -t $IMAGE:$version -f Dockerfile.deploy $REPO
 
 # If provided, tag the image with the label provided
 if [ "$1" ]
 then
-  docker tag $IMAGE:$release_min $IMAGE:$1
-  docker rmi $IMAGE:$release_min
+  docker tag $IMAGE:$version $IMAGE:$1
+  docker rmi $IMAGE:$version
 fi
 
 # Cleanup


### PR DESCRIPTION
This PR:

- Only pushes to quay.io from a tagged version or from develop
- Adds the commit and date to the docker label if building from a commit that is not tagged like a version (e.g. v0.17.0)

So:

- tagged commits should build and push to: `quay.io/monax/db:0.17.0`
- later on, commits to develop will push to `quay.io/monax/db:0.17.0-dev-20172408-c4c4651` (and so on...)

This means we can drop the idea of a 'mutable docker image for pre-release versions' which has been problematic. It also means we do not need to defensively version bump (before we know what kind of bump we want to do) on master/develop and the various pain that comes with version bump commits ending up as unexpected ancestors on branches we did not expect. This should generally remove some busywork.

The big bang of doing a release should be pushing the version tag. Note that if the version tag disagrees with the version in version.go then `build_tool.sh` will fail noisily.