### PR TITLE
Specify log15 time key

### DIFF
--- a/logging/adapters/tendermint_log15/convert.go
+++ b/logging/adapters/tendermint_log15/convert.go
@@ -43,8 +43,9 @@ func LogLineToRecord(keyvals ...interface{}) *log15.Record {
 		Call: call,
 		Ctx:  ctx,
 		KeyNames: log15.RecordKeyNames{
-			Msg: structure.MessageKey,
-			Lvl: structure.LevelKey,
+			Time: structure.TimeKey,
+			Msg:  structure.MessageKey,
+			Lvl:  structure.LevelKey,
 		}}
 }
 


### PR DESCRIPTION
The absence of this was causing an empty string for time key in log output