### PR TITLE
remove volume from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ ENV REPO /go/src/github.com/hyperledger/burrow
 ENV USER monax
 ENV MONAX_PATH /home/$USER/.monax
 RUN addgroup -g 101 -S $USER && adduser -S -D -u 1000 $USER $USER
-VOLUME $MONAX_PATH
 WORKDIR $MONAX_PATH
 USER $USER:$USER
 


### PR DESCRIPTION
This negatively affects downstream images who will be locked into root ownership of `$MONAX_PATH`. Removing the `VOLUME` invocation allows for normal transfer of ownership of the `$MONAX_PATH` by downstream images, and within this image.