### PR TITLE
Ensure check and build included in pre-release CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,13 @@ jobs:
           at: .
       - run: make test_integration
 
+  build:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run: make build
+
   release:
     <<: *defaults
     steps:
@@ -77,10 +84,17 @@ workflows:
           filters:
             <<: *tags_filters
 
+      - build:
+          requires:
+            - checkout_code
+          filters:
+            <<: *tags_filters
+
       - release:
           requires:
             - test
             - test_integration
+            - build
           filters:
             # tags filters and branch filters are applied disjunctively, so we
             # will still build tags not on develop (i.e. including tagged

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ build_race_client:
 
 # test burrow
 .PHONY: test
-test:
+test: check
 	@go test ${PACKAGES_NOVENDOR}
 
 .PHONY: test_integration

--- a/version/version.go
+++ b/version/version.go
@@ -93,7 +93,7 @@ func (v *VersionIdentifier) GetMinorVersionString() string {
 }
 
 // Return the plain version string without the ClientIdentifier
-func  GetSemanticVersionString() string { return burrowVersion.GetSemanticVersionString() }
+func GetSemanticVersionString() string { return burrowVersion.GetSemanticVersionString() }
 func (v *VersionIdentifier) GetSemanticVersionString() string {
 	return fmt.Sprintf("%d.%d.%d", v.MajorVersion,
 		v.MinorVersion, v.PatchVersion)


### PR DESCRIPTION
Missing a check (gofmt etc) in our pre-develop branch CI, thus failure when PRing to master not spotted when PRing to develop. Fixed here.