### PR TITLE
Glide dev install patch 660

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -144,8 +144,10 @@ imports:
   version: 84d9671090430e8ec80e35b339907e0579b999eb
 - name: github.com/tendermint/go-autofile
   version: 48b17de82914e1ec2f134ce823ba426337d2c518
-- name: github.com/tendermint/go-clist
-  version: 3baa390bbaf7634251c42ad69a8682e7e3990552
+- name: github.com/tendermint/tmlibs
+  version: 91b4b534ad78e442192c8175db92a06a51064064
+  subpackages:
+  - clist
 - name: github.com/tendermint/go-common
   version: f9e3db037330c8a8d61d3966de8473eaf01154fa
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,5 +29,10 @@ import:
   version: ^0.11.0
 - package: github.com/streadway/simpleuuid
 - package: github.com/Graylog2/go-gelf
+- package: github.com/tendermint/tmlibs
+  version: e4ef2835f0081c2ece83b9c1f777cf071f956e81
+  subpackages:
+  - clist
 - package: github.com/tendermint/tendermint
   version: ~0.9.2
+


### PR DESCRIPTION
**Summary:**
As per issue 660, fix the dependency missing issue when using glide-install. This is mainly a work around while burrow catches up to a slightly newer tendermint version.


**Why the pull request?**
Basically, v0.9.2 tries to pull
```
[WARN]	Unable to checkout github.com/tendermint/go-clist
[ERROR]	Error looking for github.com/tendermint/go-clist: Unable to get repository: Cloning into '/home/t/.glide/cache/src/https-github.com-tendermint-go-clist'...
ERROR: Repository not found.
```
but go-clist now lives in a subpacjage of github.com/tendermint/tmlibz

Unfortunately, not all the packages were migrated so we have some issues with multiple versions i.e.:
```
[ERROR]	Unable to import from github.com/tendermint/go-p2p. Err: Import github.com/tendermint/tmlibs repeated with different versions '' and 'develop'
```

**What does it do?**
Simply points glide to package it needs.
