### PR TITLE
Fixed broken links in Contributing and README.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Forked from Docker's [contributing guidelines](https://github.com/docker/docker/
 
 ## Developer Certificate of Origin
 
-Please always include "signed-off-by" in your commit message and note this constitutes a developer certification you are contributing a patch under Apache 2.0.  Please find a verbatim copy of the Developer Certificate of Origin in this repository [here](.github/DEVELOPER_CERTIFICATE_OF_ORIGIN.md) or on [developercertificate.org](https://developercertificate.org/).
+Please always include "signed-off-by" in your commit message and note this constitutes a developer certification you are contributing a patch under Apache 2.0.  Please find a verbatim copy of the Developer Certificate of Origin in this repository [here](DEVELOPER_CERTIFICATE_OF_ORIGIN.md) or on [developercertificate.org](https://developercertificate.org/).
 
 ## Bug Reporting
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Burrow has been architected with a longer term vision on security and data priva
 
 ## Installation
 
-`burrow` is intended to be used by the `monax chains` command via [monax](https://monax.io/docs). Available commands such as `make | start | stop | logs | inspect | update` are used for chain lifecycle management.
+`burrow` is intended to be used by the `monax chains` command via [monax](https://monax.io/docs/). Available commands such as `make | start | stop | logs | inspect | update` are used for chain lifecycle management.
 
 ### For Developers
 Dependency management for Burrow is managed with [glide](github.com/Masterminds/glide), and you can build Burrow from source by following


### PR DESCRIPTION
Addresses issue #663 where there was a broken link in README.md (monax link) and the Contributor Guidelines link
Signed-off-by: Joshua Jay Herman <zitterbewegung@gmail.com>
