### PR TITLE
[Hotfix] Fix Burrow build dependency on go-clist (develop)

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -144,8 +144,10 @@ imports:
   version: 84d9671090430e8ec80e35b339907e0579b999eb
 - name: github.com/tendermint/go-autofile
   version: 48b17de82914e1ec2f134ce823ba426337d2c518
-- name: github.com/tendermint/go-clist
-  version: 3baa390bbaf7634251c42ad69a8682e7e3990552
+- name: github.com/tendermint/tmlibs
+  version: 91b4b534ad78e442192c8175db92a06a51064064
+  subpackages:
+  - clist
 - name: github.com/tendermint/go-common
   version: f9e3db037330c8a8d61d3966de8473eaf01154fa
   subpackages:
@@ -191,7 +193,8 @@ imports:
   - client
   - testutil
 - name: github.com/tendermint/tendermint
-  version: f6e28c497510dcd266353649a45d6f962fd5001c
+  repo: https://github.com/monax/tendermint.git
+  version: d4904891187ce4c0a676273500bc4d68073d4c64
   subpackages:
   - blockchain
   - consensus

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,5 +29,11 @@ import:
   version: ^0.11.0
 - package: github.com/streadway/simpleuuid
 - package: github.com/Graylog2/go-gelf
+- package: github.com/tendermint/tmlibs
+  version: e4ef2835f0081c2ece83b9c1f777cf071f956e81
+  subpackages:
+  - clist
 - package: github.com/tendermint/tendermint
-  version: ~0.9.2
+  repo: https://github.com/monax/tendermint.git
+  version: go-clist-hotfix-0.9.2
+


### PR DESCRIPTION
This deals with deleted go-clist dependency by updating to use tmlibs version and also depending on a fork of tendermint with updated import.

Making as a hotfix since this will not be an issue once #666 is merged since we will vendor and won't rely on upstream immutability.

Credit to @tommling for getting this started: #662 but also relies on a patched Tendermint I have pushed here: https://github.com/monax/tendermint/tree/go-clist-hotfix-0.9.2