### PR TITLE
Add Bytecode lexer and remove panic from Splice

### DIFF
--- a/account/address.go
+++ b/account/address.go
@@ -74,7 +74,11 @@ func (address *Address) UnmarshalJSON(data []byte) error {
 }
 
 func (address Address) MarshalJSON() ([]byte, error) {
-	return json.Marshal(hex.EncodeUpperToString(address[:]))
+	text, err := address.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(text))
 }
 
 func (address *Address) UnmarshalText(text []byte) error {

--- a/account/bytecode.go
+++ b/account/bytecode.go
@@ -2,35 +2,95 @@ package account
 
 import (
 	"encoding/json"
+	"fmt"
 
+	"github.com/hyperledger/burrow/execution/evm/asm"
+	"github.com/hyperledger/burrow/execution/evm/asm/bc"
 	"github.com/tmthrgd/go-hex"
 )
 
-// TODO: write a simple lexer that prints the opcodes. Each byte is either an OpCode or part of the Word256 argument
-// to Push[1...32]
 type Bytecode []byte
+
+// Builds new bytecode using the Splice helper to map byte-like and byte-slice-like types to a flat bytecode slice
+func NewBytecode(bytelikes ...interface{}) (Bytecode, error) {
+	return bc.Splice(bytelikes...)
+}
+
+func BytecodeFromHex(hexString string) (Bytecode, error) {
+	var bc Bytecode
+	err := bc.UnmarshalText([]byte(hexString))
+	if err != nil {
+		return nil, err
+	}
+	return bc, nil
+}
 
 func (bc Bytecode) Bytes() []byte {
 	return bc[:]
 }
 
 func (bc Bytecode) String() string {
-	return hex.EncodeToString(bc[:])
+	return hex.EncodeUpperToString(bc[:])
 
 }
 func (bc Bytecode) MarshalJSON() ([]byte, error) {
-	return json.Marshal(hex.EncodeUpperToString(bc[:]))
+	text, err := bc.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(text))
 }
 
-func (bc Bytecode) UnmarshalJSON(data []byte) error {
+func (bc *Bytecode) UnmarshalJSON(data []byte) error {
 	str := new(string)
 	err := json.Unmarshal(data, str)
 	if err != nil {
 		return err
 	}
-	_, err = hex.Decode(bc[:], []byte(*str))
+	err = bc.UnmarshalText([]byte(*str))
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+func (bc Bytecode) MarshalText() ([]byte, error) {
+	return ([]byte)(hex.EncodeUpperToString(bc)), nil
+}
+
+func (bc *Bytecode) UnmarshalText(text []byte) error {
+	*bc = make([]byte, hex.DecodedLen(len(text)))
+	_, err := hex.Decode(*bc, text)
+	return err
+}
+
+// Tokenises the bytecode into opcodes and values
+func (bc Bytecode) Tokens() ([]string, error) {
+	// Overestimate of capacity in the presence of pushes
+	tokens := make([]string, 0, len(bc))
+
+	for i := 0; i < len(bc); i++ {
+		op, ok := asm.GetOpCode(bc[i])
+		if !ok {
+			return tokens, fmt.Errorf("did not recognise byte %#x at position %v as an OpCode:\n %s",
+				bc[i], i, lexingPositionString(bc, i, tokens))
+		}
+		tokens = append(tokens, op.Name())
+		pushes := op.Pushes()
+		if pushes > 0 {
+			// This is a PUSH<N> OpCode so consume N bytes from the input, render them as hex, and skip to next OpCode
+			if i+pushes >= len(bc) {
+				return tokens, fmt.Errorf("token %v of input is %s but not enough input remains to push %v: %s",
+					i, op.Name(), pushes, lexingPositionString(bc, i, tokens))
+			}
+			pushedBytes := bc[i+1 : i+pushes+1]
+			tokens = append(tokens, fmt.Sprintf("0x%s", pushedBytes))
+			i += pushes
+		}
+	}
+	return tokens, nil
+}
+
+func lexingPositionString(bc Bytecode, position int, produced []string) string {
+	return fmt.Sprintf("%v_%v", produced, []byte(bc[position:]))
 }

--- a/account/bytecode_test.go
+++ b/account/bytecode_test.go
@@ -1,0 +1,85 @@
+package account
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hyperledger/burrow/execution/evm/asm"
+	"github.com/hyperledger/burrow/execution/evm/asm/bc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBytecode_MarshalJSON(t *testing.T) {
+	bytecode := Bytecode{
+		73, 234, 48, 252, 174,
+		115, 27, 222, 54, 116,
+		47, 133, 144, 21, 73,
+		245, 21, 234, 26, 50,
+	}
+
+	bs, err := json.Marshal(bytecode)
+	assert.NoError(t, err)
+
+	bytecodeOut := new(Bytecode)
+	err = json.Unmarshal(bs, bytecodeOut)
+
+	assert.Equal(t, bytecode, *bytecodeOut)
+}
+
+func TestBytecode_MarshalText(t *testing.T) {
+	bytecode := Bytecode{
+		73, 234, 48, 252, 174,
+		115, 27, 222, 54, 116,
+		47, 133, 144, 21, 73,
+		245, 21, 234, 26, 50,
+	}
+
+	bs, err := bytecode.MarshalText()
+	assert.NoError(t, err)
+
+	bytecodeOut := new(Bytecode)
+	err = bytecodeOut.UnmarshalText(bs)
+
+	assert.Equal(t, bytecode, *bytecodeOut)
+}
+
+func TestBytecode_Tokens(t *testing.T) {
+	/*
+			pragma solidity ^0.4.0;
+
+			contract SimpleStorage {
+		                function get() public constant returns (address) {
+		        	        return msg.sender;
+		    	        }
+			}
+	*/
+
+	// This bytecode is compiled from Solidity contract above the remix compiler with 0.4.0
+	codeHex := "606060405260808060106000396000f360606040526000357c0100000000000000000000000000000000000000000000000" +
+		"000000000900480636d4ce63c146039576035565b6002565b34600257604860048050506074565b604051808273fffffffffffffff" +
+		"fffffffffffffffffffffffff16815260200191505060405180910390f35b6000339050607d565b9056"
+	bytecode, err := BytecodeFromHex(codeHex)
+	require.NoError(t, err)
+	tokens, err := bytecode.Tokens()
+	require.NoError(t, err)
+	// With added leading zero in hex where needed
+	remixOpcodes := "PUSH1 0x60 PUSH1 0x40 MSTORE PUSH1 0x80 DUP1 PUSH1 0x10 PUSH1 0x00 CODECOPY PUSH1 0x00 RETURN " +
+		"PUSH1 0x60 PUSH1 0x40 MSTORE PUSH1 0x00 CALLDATALOAD " +
+		"PUSH29 0x0100000000000000000000000000000000000000000000000000000000 SWAP1 DIV DUP1 PUSH4 0x6D4CE63C EQ " +
+		"PUSH1 0x39 JUMPI PUSH1 0x35 JUMP JUMPDEST PUSH1 0x02 JUMP JUMPDEST CALLVALUE PUSH1 0x02 JUMPI " +
+		"PUSH1 0x48 PUSH1 0x04 DUP1 POP POP PUSH1 0x74 JUMP JUMPDEST PUSH1 0x40 MLOAD DUP1 DUP3 " +
+		"PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD " +
+		"SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 RETURN JUMPDEST PUSH1 0x00 " +
+		"CALLER SWAP1 POP PUSH1 0x7D JUMP JUMPDEST SWAP1 JUMP"
+	assert.Equal(t, remixOpcodes, strings.Join(tokens, " "))
+
+	// Test empty bytecode
+	tokens, err = Bytecode(nil).Tokens()
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, tokens)
+
+	tokens, err = Bytecode(bc.MustSplice(asm.PUSH3, 1, 2)).Tokens()
+	assert.Error(t, err, "not enough bytes to push")
+}

--- a/binary/word160.go
+++ b/binary/word160.go
@@ -12,3 +12,7 @@ func (w Word160) Word256() (word256 Word256) {
 	copy(word256[Word256Word160Delta:], w[:])
 	return
 }
+
+func (w Word160) Bytes() []byte {
+	return w[:]
+}

--- a/execution/evm/asm/bc/helpers.go
+++ b/execution/evm/asm/bc/helpers.go
@@ -3,54 +3,14 @@ package bc
 import (
 	"fmt"
 
-	"github.com/hyperledger/burrow/account"
-	"github.com/hyperledger/burrow/binary"
 	"github.com/hyperledger/burrow/execution/evm/asm"
 )
 
-// Convenience function to allow us to mix bytes, ints, and OpCodes that
-// represent bytes in an EVM assembly code to make assembly more readable.
-// Also allows us to splice together assembly
-// fragments because any []byte arguments are flattened in the result.
-func Splice(bytelikes ...interface{}) []byte {
-	bytes := make([]byte, len(bytelikes))
-	for i, bytelike := range bytelikes {
-		switch b := bytelike.(type) {
-		case byte:
-			bytes[i] = b
-		case asm.OpCode:
-			bytes[i] = byte(b)
-		case int:
-			bytes[i] = byte(b)
-			if int(bytes[i]) != b {
-				panic(fmt.Sprintf("The int %v does not fit inside a byte", b))
-			}
-		case int64:
-			bytes[i] = byte(b)
-			if int64(bytes[i]) != b {
-				panic(fmt.Sprintf("The int64 %v does not fit inside a byte", b))
-			}
-		case uint64:
-			bytes[i] = byte(b)
-			if uint64(bytes[i]) != b {
-				panic(fmt.Sprintf("The uint64 %v does not fit inside a byte", b))
-			}
-		case binary.Word256:
-			return Concat(bytes[:i], b[:], Splice(bytelikes[i+1:]...))
-		case binary.Word160:
-			return Concat(bytes[:i], b[:], Splice(bytelikes[i+1:]...))
-		case account.Address:
-			return Concat(bytes[:i], b[:], Splice(bytelikes[i+1:]...))
-		case []byte:
-			// splice
-			return Concat(bytes[:i], b, Splice(bytelikes[i+1:]...))
-		default:
-			panic(fmt.Errorf("could not convert %s to a byte or sequence of bytes", bytelike))
-		}
-	}
-	return bytes
+type ByteSlicable interface {
+	Bytes() []byte
 }
 
+// Concatenate multiple byte slices without unnecessary copying
 func Concat(bss ...[]byte) []byte {
 	offset := 0
 	for _, bs := range bss {
@@ -65,4 +25,62 @@ func Concat(bss ...[]byte) []byte {
 		offset += len(bs)
 	}
 	return bytes
+}
+
+// Splice or panic
+func MustSplice(bytelikes ...interface{}) []byte {
+	spliced, err := Splice(bytelikes...)
+	if err != nil {
+		panic(err)
+	}
+	return spliced
+}
+
+// Convenience function to allow us to mix bytes, ints, and OpCodes that
+// represent bytes in an EVM assembly code to make assembly more readable.
+// Also allows us to splice together assembly
+// fragments because any []byte arguments are flattened in the result.
+func Splice(bytelikes ...interface{}) ([]byte, error) {
+	bytes := make([]byte, 0, len(bytelikes))
+	for _, bytelike := range bytelikes {
+		bs, err := byteSlicify(bytelike)
+		if err != nil {
+			return nil, err
+		}
+		bytes = append(bytes, bs...)
+	}
+	return bytes, nil
+}
+
+// Convert anything byte or byte slice like to a byte slice
+func byteSlicify(bytelike interface{}) ([]byte, error) {
+	switch b := bytelike.(type) {
+	case byte:
+		return []byte{b}, nil
+	case asm.OpCode:
+		return []byte{byte(b)}, nil
+	case int:
+		if int(byte(b)) != b {
+			return nil, fmt.Errorf("the int %v does not fit inside a byte", b)
+		}
+		return []byte{byte(b)}, nil
+	case int64:
+		if int64(byte(b)) != b {
+			return nil, fmt.Errorf("the int64 %v does not fit inside a byte", b)
+		}
+		return []byte{byte(b)}, nil
+	case uint64:
+		if uint64(byte(b)) != b {
+			return nil, fmt.Errorf("the uint64 %v does not fit inside a byte", b)
+		}
+		return []byte{byte(b)}, nil
+	case string:
+		return []byte(b), nil
+	case ByteSlicable:
+		return b.Bytes(), nil
+	case []byte:
+		return b, nil
+	default:
+		return nil, fmt.Errorf("could not convert %s to a byte or sequence of bytes", bytelike)
+	}
 }

--- a/execution/evm/asm/opcodes.go
+++ b/execution/evm/asm/opcodes.go
@@ -187,8 +187,7 @@ const (
 	SELFDESTRUCT = 0xff
 )
 
-// Since the opcodes aren't all in order we can't use a regular slice
-var opCodeToString = map[OpCode]string{
+var opCodeNames = map[OpCode]string{
 	// 0x0 range - arithmetic ops
 	STOP:       "STOP",
 	ADD:        "ADD",
@@ -340,18 +339,32 @@ var opCodeToString = map[OpCode]string{
 	SELFDESTRUCT: "SELFDESTRUCT",
 }
 
-func OpCodeName(op OpCode) (name string, isOpcode bool) {
-	name, isOpcode = opCodeToString[op]
-	return name, isOpcode
+func GetOpCode(b byte) (OpCode, bool) {
+	op := OpCode(b)
+	_, isOpcode := opCodeNames[op]
+	return op, isOpcode
+
 }
 
 func (o OpCode) String() string {
-	str := opCodeToString[o]
+	return o.Name()
+}
+
+func (o OpCode) Name() string {
+	str := opCodeNames[o]
 	if len(str) == 0 {
 		return fmt.Sprintf("Missing opcode 0x%x", int(o))
 	}
 
 	return str
+}
+
+// If OpCode is a Push<N> returns the number of bytes pushed (between 1 and 32 inclusive)
+func (o OpCode) Pushes() int {
+	if o >= PUSH1 && o <= PUSH32 {
+		return int(o - PUSH1 + 1)
+	}
+	return 0
 }
 
 //-----------------------------------------------------------------------------

--- a/execution/evm/snative_test.go
+++ b/execution/evm/snative_test.go
@@ -81,7 +81,7 @@ func TestSNativeContractDescription_Dispatch(t *testing.T) {
 	gas := uint64(1000)
 
 	// Should fail since we have no permissions
-	retValue, err := contract.Dispatch(state, caller, bc.Splice(funcID[:],
+	retValue, err := contract.Dispatch(state, caller, bc.MustSplice(funcID[:],
 		grantee.Address(), permFlagToWord256(permission.CreateAccount)), &gas, logger)
 	if !assert.Error(t, err, "Should fail due to lack of permissions") {
 		return
@@ -90,7 +90,7 @@ func TestSNativeContractDescription_Dispatch(t *testing.T) {
 
 	// Grant all permissions and dispatch should success
 	caller.SetPermissions(allAccountPermissions())
-	retValue, err = contract.Dispatch(state, caller, bc.Splice(funcID[:],
+	retValue, err = contract.Dispatch(state, caller, bc.MustSplice(funcID[:],
 		grantee.Address().Word256(), permFlagToWord256(permission.CreateAccount)), &gas, logger)
 	assert.NoError(t, err)
 	assert.Equal(t, retValue, LeftPadBytes([]byte{1}, 32))

--- a/execution/execution_test.go
+++ b/execution/execution_test.go
@@ -1292,7 +1292,7 @@ func callContractCode(contractAddr acm.Address) []byte {
 	retOff, retSize := byte(0x0), byte(0x20)
 
 	// this is the code we want to run (call a contract and return)
-	return bc.Splice(CALLDATASIZE, PUSH1, inputOff, PUSH1, memOff,
+	return bc.MustSplice(CALLDATASIZE, PUSH1, inputOff, PUSH1, memOff,
 		CALLDATACOPY, PUSH1, retSize, PUSH1, retOff, CALLDATASIZE, PUSH1, inOff,
 		PUSH1, value, PUSH20, contractAddr,
 		// Zeno loves us - call with half of the available gas each time we CALL


### PR DESCRIPTION
This adds to the `Bytecode` type to provide a opcode tokeniser which is useful for building test cases and printing human readable EVM code.