### PR TITLE
Allow callbacks to close subscriptions.

### DIFF
--- a/client/websocket_client.go
+++ b/client/websocket_client.go
@@ -175,8 +175,9 @@ func (burrowNodeWebsocketClient *burrowNodeWebsocketClient) WaitForConfirmation(
 						confirmationChannel <- Confirmation{
 							BlockHash:   latestBlockHash,
 							EventDataTx: eventDataTx,
-							Exception:   fmt.Errorf("transaction confirmed with exception: %v", eventDataTx.Exception),
-							Error:       nil,
+							Exception: fmt.Errorf("transaction confirmed but execution gave exception: %v",
+								eventDataTx.Exception),
+							Error: nil,
 						}
 						return
 					}

--- a/event/convention_test.go
+++ b/event/convention_test.go
@@ -13,8 +13,9 @@ func TestSubscribeCallback(t *testing.T) {
 	ctx := context.Background()
 	em := NewEmitter(loggers.NewNoopInfoTraceLogger())
 	ch := make(chan interface{})
-	SubscribeCallback(ctx, em, "TestSubscribeCallback", MatchAllQueryable(), func(msg interface{}) {
+	SubscribeCallback(ctx, em, "TestSubscribeCallback", MatchAllQueryable(), func(msg interface{}) bool {
 		ch <- msg
+		return true
 	})
 
 	sent := "FROTHY"

--- a/execution/events/events.go
+++ b/execution/events/events.go
@@ -67,12 +67,13 @@ func SubscribeAccountOutputSendTx(ctx context.Context, subscribable event.Subscr
 	query := sendTxQuery.And(event.QueryForEventID(EventStringAccountOutput(address))).
 		AndEquals(event.TxHashKey, hex.EncodeUpperToString(txHash))
 
-	return event.SubscribeCallback(ctx, subscribable, subscriber, query, func(message interface{}) {
+	return event.SubscribeCallback(ctx, subscribable, subscriber, query, func(message interface{}) bool {
 		if eventDataCall, ok := message.(*EventDataTx); ok {
 			if sendTx, ok := eventDataCall.Tx.(*txs.SendTx); ok {
 				ch <- sendTx
 			}
 		}
+		return true
 	})
 }
 

--- a/execution/evm/events/events.go
+++ b/execution/evm/events/events.go
@@ -68,11 +68,12 @@ func SubscribeAccountCall(ctx context.Context, subscribable event.Subscribable, 
 		query = query.AndEquals(event.TxHashKey, hex.EncodeUpperToString(txHash))
 	}
 
-	return event.SubscribeCallback(ctx, subscribable, subscriber, query, func(message interface{}) {
+	return event.SubscribeCallback(ctx, subscribable, subscriber, query, func(message interface{}) bool {
 		eventDataCall, ok := message.(*EventDataCall)
 		if ok {
 			ch <- eventDataCall
 		}
+		return true
 	})
 }
 
@@ -81,11 +82,12 @@ func SubscribeLogEvent(ctx context.Context, subscribable event.Subscribable, sub
 
 	query := event.QueryForEventID(EventStringLogEvent(address))
 
-	return event.SubscribeCallback(ctx, subscribable, subscriber, query, func(message interface{}) {
+	return event.SubscribeCallback(ctx, subscribable, subscriber, query, func(message interface{}) bool {
 		eventDataLog, ok := message.(*EventDataLog)
 		if ok {
 			ch <- eventDataLog
 		}
+		return true
 	})
 }
 

--- a/rpc/result.go
+++ b/rpc/result.go
@@ -192,22 +192,22 @@ func NewResultEvent(event string, eventData interface{}) (*ResultEvent, error) {
 			TMEventData: &ed,
 		}, nil
 
-	case exe_events.EventDataTx:
+	case *exe_events.EventDataTx:
 		return &ResultEvent{
 			Event:       event,
-			EventDataTx: &ed,
+			EventDataTx: ed,
 		}, nil
 
-	case evm_events.EventDataCall:
+	case *evm_events.EventDataCall:
 		return &ResultEvent{
 			Event:         event,
-			EventDataCall: &ed,
+			EventDataCall: ed,
 		}, nil
 
-	case evm_events.EventDataLog:
+	case *evm_events.EventDataLog:
 		return &ResultEvent{
 			Event:        event,
-			EventDataLog: &ed,
+			EventDataLog: ed,
 		}, nil
 
 	default:

--- a/rpc/tm/server.go
+++ b/rpc/tm/server.go
@@ -30,7 +30,7 @@ func StartServer(service rpc.Service, pattern, listenAddress string, emitter eve
 	logger logging_types.InfoTraceLogger) (net.Listener, error) {
 
 	logger = logger.With(structure.ComponentKey, "RPC_TM")
-	routes := GetRoutes(service)
+	routes := GetRoutes(service, logger)
 	mux := http.NewServeMux()
 	wm := rpcserver.NewWebsocketManager(routes, rpcserver.EventSubscriber(tendermint.SubscribableAsEventBus(emitter)))
 	mux.HandleFunc(pattern, wm.WebsocketHandler)

--- a/rpc/v0/subscriptions.go
+++ b/rpc/v0/subscriptions.go
@@ -106,10 +106,11 @@ func (subs *Subscriptions) Add(eventId string) (string, error) {
 		return "", err
 	}
 	cache := newSubscriptionsCache()
-	err = subs.service.Subscribe(context.Background(), subId, eventId, func(resultEvent *rpc.ResultEvent) {
+	err = subs.service.Subscribe(context.Background(), subId, eventId, func(resultEvent *rpc.ResultEvent) bool {
 		cache.mtx.Lock()
 		defer cache.mtx.Unlock()
 		cache.events = append(cache.events, resultEvent)
+		return true
 	})
 	if err != nil {
 		return "", err

--- a/rpc/v0/websocket_service.go
+++ b/rpc/v0/websocket_service.go
@@ -125,8 +125,9 @@ func (ws *WebsocketService) EventSubscribe(request *rpc.RPCRequest,
 		return nil, rpc.INTERNAL_ERROR, err
 	}
 
-	err = ws.service.Subscribe(context.Background(), subId, eventId, func(resultEvent *rpc.ResultEvent) {
+	err = ws.service.Subscribe(context.Background(), subId, eventId, func(resultEvent *rpc.ResultEvent) bool {
 		ws.writeResponse(subId, resultEvent, session)
+		return true
 	})
 	if err != nil {
 		return nil, rpc.INTERNAL_ERROR, err


### PR DESCRIPTION
I noticed that we were accumulating subscriptions that were repeatedly trying to write their results to closed websockets. This is wasteful and leaks memory. This PR allows callbacks to signal they are finished even if the subscription is not explicitly closed when we fail to write a response to a websocket, which happens either when it is closed or the `writeChan` buffer is full - we can't tell which currently, but the buffer default is 1000 messages. It seems reasonable to drop a subscription if a subscriber is failing to keep up with this many messages.

Also since event types are now fired as pointers `ResultEvent` constructed needed to be changed.