### PR TITLE
Simplify SubscribeCallback and bump version

### DIFF
--- a/event/convention.go
+++ b/event/convention.go
@@ -43,12 +43,7 @@ func SubscribeCallback(ctx context.Context, subscribable Subscribable, subscribe
 
 	out := make(chan interface{})
 	go func() {
-		for {
-			msg, ok := <-out
-			if !ok {
-				// Channel closed, no need to unsubscribe or drain
-				return
-			}
+		for msg := range out {
 			if !callback(msg) {
 				// Callback is requesting stop so unsubscribe and drain channel
 				subscribable.Unsubscribe(context.Background(), subscriber, query)

--- a/version/version.go
+++ b/version/version.go
@@ -30,9 +30,9 @@ const (
 	// Major version component of the current release
 	versionMajor = 0
 	// Minor version component of the current release
-	versionMinor = 17
+	versionMinor = 18
 	// Patch version component of the current release
-	versionPatch = 1
+	versionPatch = 0
 )
 
 var burrowVersion *VersionIdentifier


### PR DESCRIPTION
This will have us push an appropriately versioned docker base image