### PR TITLE
Fix accidental compositing of logging config

### DIFF
--- a/cmd/burrow/main.go
+++ b/cmd/burrow/main.go
@@ -31,6 +31,9 @@ func main() {
 	burrow.Action = func() {
 		// We need to reflect on whether this obscures where values are coming from
 		conf := config.DefaultBurrowConfig()
+		// We treat logging a little differently in that if anything is set for logging we will not
+		// set default outputs
+		conf.Logging = nil
 		err := source.EachOf(
 			burrowConfigProvider(*configOpt),
 			source.FirstOf(
@@ -38,6 +41,10 @@ func main() {
 				// Try working directory
 				genesisDocProvider(config.DefaultGenesisDocJSONFileName, true)),
 		).Apply(conf)
+		// If no logging config was provided use the default
+		if conf.Logging == nil {
+			conf.Logging = logging_config.DefaultNodeLoggingConfig()
+		}
 		if err != nil {
 			fatalf("could not obtain config: %v", err)
 		}


### PR DESCRIPTION
We use the default config as a base (so you only need to set non-default values) but in the case of the recursive logging structure this means that when you explicitly set a logging config it gets merged into the default that just outputs unfiltered thus breaking custom logging config. This fixes that.