### PR TITLE
Fix permissioning related issues from Bosmarmot integration

### DIFF
--- a/client/node_client.go
+++ b/client/node_client.go
@@ -181,7 +181,7 @@ func (burrowNodeClient *burrowNodeClient) QueryContractCode(address acm.Address,
 	// have a single address that is the contract to query.
 	callResult, err := tendermint_client.CallCode(client, address, code, data)
 	if err != nil {
-		err = fmt.Errorf("error connnecting to node (%s) to query contract code at (%s) with data (%X) and code (%X)",
+		err = fmt.Errorf("error connnecting to node (%s) to query contract code at (%s) with data (%X) and code (%X): %v",
 			burrowNodeClient.broadcastRPC, address, data, code, err.Error())
 		return nil, uint64(0), err
 	}
@@ -193,12 +193,12 @@ func (burrowNodeClient *burrowNodeClient) GetAccount(address acm.Address) (acm.A
 	client := rpcclient.NewJSONRPCClient(burrowNodeClient.broadcastRPC)
 	account, err := tendermint_client.GetAccount(client, address)
 	if err != nil {
-		err = fmt.Errorf("Error connecting to node (%s) to fetch account (%s): %s",
+		err = fmt.Errorf("error connecting to node (%s) to fetch account (%s): %s",
 			burrowNodeClient.broadcastRPC, address, err.Error())
 		return nil, err
 	}
 	if account == nil {
-		err = fmt.Errorf("Unknown account %X at node (%s)", address, burrowNodeClient.broadcastRPC)
+		err = fmt.Errorf("unknown account %X at node (%s)", address, burrowNodeClient.broadcastRPC)
 		return nil, err
 	}
 
@@ -225,7 +225,7 @@ func (burrowNodeClient *burrowNodeClient) GetName(name string) (owner acm.Addres
 	client := rpcclient.NewJSONRPCClient(burrowNodeClient.broadcastRPC)
 	entryResult, err := tendermint_client.GetName(client, name)
 	if err != nil {
-		err = fmt.Errorf("Error connecting to node (%s) to get name registrar entry for name (%s)",
+		err = fmt.Errorf("error connecting to node (%s) to get name registrar entry for name (%s)",
 			burrowNodeClient.broadcastRPC, name)
 		return acm.ZeroAddress, "", 0, err
 	}
@@ -244,7 +244,7 @@ func (burrowNodeClient *burrowNodeClient) ListValidators() (blockHeight uint64,
 	client := rpcclient.NewJSONRPCClient(burrowNodeClient.broadcastRPC)
 	validatorsResult, err := tendermint_client.ListValidators(client)
 	if err != nil {
-		err = fmt.Errorf("Error connecting to node (%s) to get validators", burrowNodeClient.broadcastRPC)
+		err = fmt.Errorf("error connecting to node (%s) to get validators", burrowNodeClient.broadcastRPC)
 		return
 	}
 	// unwrap return results

--- a/client/rpc/client_test.go
+++ b/client/rpc/client_test.go
@@ -165,6 +165,6 @@ func testPermissions(t *testing.T,
 
 	bs, err := json.Marshal(tx.PermArgs)
 	require.NoError(t, err)
-	expected := fmt.Sprintf(`{"PermFlag":256,"Address":"%s","Permission":256,"Value":true}`, permAddressString)
+	expected := fmt.Sprintf(`{"PermFlag":256,"Address":"%s","Permission":1,"Value":true}`, permAddressString)
 	assert.Equal(t, expected, string(bs))
 }

--- a/client/rpc/client_test.go
+++ b/client/rpc/client_test.go
@@ -15,6 +15,7 @@
 package rpc
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -22,19 +23,32 @@ import (
 
 	mockclient "github.com/hyperledger/burrow/client/mock"
 	mockkeys "github.com/hyperledger/burrow/keys/mock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func Test(t *testing.T) {
+func TestSend(t *testing.T) {
 	mockKeyClient := mockkeys.NewMockKeyClient()
 	mockNodeClient := mockclient.NewMockNodeClient()
 	testSend(t, mockNodeClient, mockKeyClient)
+}
+
+func TestCall(t *testing.T) {
+	mockKeyClient := mockkeys.NewMockKeyClient()
+	mockNodeClient := mockclient.NewMockNodeClient()
 	testCall(t, mockNodeClient, mockKeyClient)
+}
+
+func TestName(t *testing.T) {
+	mockKeyClient := mockkeys.NewMockKeyClient()
+	mockNodeClient := mockclient.NewMockNodeClient()
 	testName(t, mockNodeClient, mockKeyClient)
+}
+
+func TestPermissions(t *testing.T) {
+	mockKeyClient := mockkeys.NewMockKeyClient()
+	mockNodeClient := mockclient.NewMockNodeClient()
 	testPermissions(t, mockNodeClient, mockKeyClient)
-	// t.Run("BondTransaction", )
-	// t.Run("UnbondTransaction", )
-	// t.Run("RebondTransaction", )
 }
 
 func testSend(t *testing.T,
@@ -142,11 +156,15 @@ func testPermissions(t *testing.T,
 	// unset sequence so that we retrieve sequence from account
 	sequenceString := ""
 
-	_, err := Permissions(nodeClient, keyClient, publicKeyString, addressString,
-		sequenceString, "setBase", []string{permAddressString, "root", "true"})
+	tx, err := Permissions(nodeClient, keyClient, publicKeyString, addressString,
+		sequenceString, "setBase", permAddressString, "root", "", "true")
 	if err != nil {
 		t.Logf("Error in PermissionsTx: %s", err)
 		t.Fail()
 	}
-	// TODO: test content of Transaction
+
+	bs, err := json.Marshal(tx.PermArgs)
+	require.NoError(t, err)
+	expected := fmt.Sprintf(`{"PermFlag":256,"Address":"%s","Permission":256,"Value":true}`, permAddressString)
+	assert.Equal(t, expected, string(bs))
 }

--- a/client/rpc/client_util.go
+++ b/client/rpc/client_util.go
@@ -23,8 +23,6 @@ import (
 	"github.com/hyperledger/burrow/client"
 	"github.com/hyperledger/burrow/keys"
 	"github.com/hyperledger/burrow/logging"
-	"github.com/hyperledger/burrow/permission"
-	ptypes "github.com/hyperledger/burrow/permission/types"
 	"github.com/hyperledger/burrow/txs"
 )
 
@@ -76,18 +74,6 @@ func signTx(keyClient keys.KeyClient, chainID string, tx_ txs.Tx) (acm.Address, 
 	default:
 		return acm.ZeroAddress, nil, fmt.Errorf("unknown transaction type for signTx: %#v", tx_)
 	}
-}
-
-func decodeAddressPermFlag(addrS, permFlagS string) (addr acm.Address, pFlag ptypes.PermFlag, err error) {
-	var addrBytes []byte
-	if addrBytes, err = hex.DecodeString(addrS); err != nil {
-		copy(addr[:], addrBytes)
-		return
-	}
-	if pFlag, err = permission.PermStringToFlag(permFlagS); err != nil {
-		return
-	}
-	return
 }
 
 func checkCommon(nodeClient client.NodeClient, keyClient keys.KeyClient, pubkey, addr, amtS,

--- a/execution/evm/snative.go
+++ b/execution/evm/snative.go
@@ -359,8 +359,11 @@ func hasBase(state acm.StateWriter, caller acm.Account, args []byte, gas *uint64
 	}
 	hasPermission := HasPermission(state, acc, permN)
 	permInt := byteFromBool(hasPermission)
-	logger.Trace("function", "hasBase", "address", address.String(),
-		"perm_flag", fmt.Sprintf("%b", permN), "has_permission", hasPermission)
+	logger.Trace("function", "hasBase",
+		"address", address.String(),
+		"account_base_permissions", acc.Permissions().Base,
+		"perm_flag", fmt.Sprintf("%b", permN),
+		"has_permission", hasPermission)
 	return LeftPadWord256([]byte{permInt}).Bytes(), nil
 }
 

--- a/execution/evm/snative.go
+++ b/execution/evm/snative.go
@@ -230,8 +230,7 @@ func NewSNativeContract(comment, name string,
 func (contract *SNativeContractDescription) Dispatch(state acm.StateWriter, caller acm.Account,
 	args []byte, gas *uint64, logger logging_types.InfoTraceLogger) (output []byte, err error) {
 
-	logger = logger.WithPrefix(structure.ComponentKey, "SNatives").
-		With(structure.ScopeKey, "Dispatch", "contract_name", contract.Name)
+	logger = logger.With(structure.ScopeKey, "Dispatch", "contract_name", contract.Name)
 
 	if len(args) < abi.FunctionSelectorLength {
 		return nil, fmt.Errorf("SNatives dispatch requires a 4-byte function "+

--- a/execution/evm/vm.go
+++ b/execution/evm/vm.go
@@ -108,15 +108,8 @@ func (vm *VM) SetPublisher(publisher event.Publisher) {
 // If the perm is not defined in the acc nor set by default in GlobalPermissions,
 // this function returns false.
 func HasPermission(state acm.StateWriter, acc acm.Account, perm ptypes.PermFlag) bool {
-	v, err := acc.Permissions().Base.Get(perm)
-	if _, ok := err.(ptypes.ErrValueNotSet); ok {
-		if state == nil {
-			// In this case the permission is unknown
-			return false
-		}
-		return HasPermission(nil, permission.GlobalPermissionsAccount(state), perm)
-	}
-	return v
+	value, _ := acc.Permissions().Base.Compose(permission.GlobalAccountPermissions(state).Base).Get(perm)
+	return value
 }
 
 func (vm *VM) fireCallEvent(exception *string, output *[]byte, callerAddress, calleeAddress acm.Address, input []byte, value uint64, gas *uint64) {

--- a/execution/evm/vm.go
+++ b/execution/evm/vm.go
@@ -27,7 +27,6 @@ import (
 	"github.com/hyperledger/burrow/execution/evm/events"
 	"github.com/hyperledger/burrow/execution/evm/sha3"
 	"github.com/hyperledger/burrow/logging"
-	"github.com/hyperledger/burrow/logging/structure"
 	logging_types "github.com/hyperledger/burrow/logging/types"
 	"github.com/hyperledger/burrow/permission"
 	ptypes "github.com/hyperledger/burrow/permission/types"
@@ -89,12 +88,12 @@ func NewVM(state acm.StateWriter, memoryProvider func() Memory, params Params, o
 		origin:         origin,
 		callDepth:      0,
 		txid:           txid,
-		logger:         logger.WithPrefix(structure.ComponentKey, "EVM"),
+		logger:         logging.WithScope(logger, "NewVM"),
 	}
 }
 
 func (vm *VM) Debugf(format string, a ...interface{}) {
-	logging.TraceMsg(vm.logger, fmt.Sprintf(format, a...))
+	logging.TraceMsg(vm.logger, fmt.Sprintf(format, a...), "tag", "vm_debug")
 }
 
 // satisfies go_events.Eventable

--- a/execution/evm/vm_test.go
+++ b/execution/evm/vm_test.go
@@ -507,3 +507,24 @@ func TestConcat(t *testing.T) {
 		[]byte{0x01, 0x02, 0x03, 0x04},
 		Concat([]byte{0x01, 0x02}, []byte{0x03, 0x04}))
 }
+
+func TestSubslice(t *testing.T) {
+	const size = 10
+	data := make([]byte, size)
+	for i := 0; i < size; i++ {
+		data[i] = byte(i)
+	}
+	for n := int64(0); n < size; n++ {
+		data = data[:n]
+		for offset := int64(-size); offset < size; offset++ {
+			for length := int64(-size); length < size; length++ {
+				_, ok := subslice(data, offset, length)
+				if offset < 0 || length < 0 || n < offset {
+					assert.False(t, ok)
+				} else {
+					assert.True(t, ok)
+				}
+			}
+		}
+	}
+}

--- a/execution/execution_test.go
+++ b/execution/execution_test.go
@@ -1195,7 +1195,7 @@ func testSNativeTx(t *testing.T, expectPass bool, batchCommitter *executor, perm
 		acc.MutablePermissions().Base.Set(perm, true)
 		batchCommitter.blockCache.UpdateAccount(acc)
 	}
-	tx, _ := txs.NewPermissionsTx(batchCommitter.blockCache, users[0].PublicKey(), &snativeArgs)
+	tx, _ := txs.NewPermissionsTx(batchCommitter.blockCache, users[0].PublicKey(), snativeArgs)
 	tx.Sign(testChainID, users[0])
 	err := batchCommitter.Execute(tx)
 	if expectPass {
@@ -1254,13 +1254,13 @@ func snativePermTestInputCALL(name string, user acm.PrivateAccount, perm ptypes.
 func snativePermTestInputTx(name string, user acm.PrivateAccount, perm ptypes.PermFlag, val bool) (snativeArgs permission.PermArgs) {
 	switch name {
 	case "hasBase":
-		snativeArgs = *permission.HasBaseArgs(user.Address(), perm)
+		snativeArgs = permission.HasBaseArgs(user.Address(), perm)
 	case "unsetBase":
-		snativeArgs = *permission.UnsetBaseArgs(user.Address(), perm)
+		snativeArgs = permission.UnsetBaseArgs(user.Address(), perm)
 	case "setBase":
-		snativeArgs = *permission.SetBaseArgs(user.Address(), perm, val)
+		snativeArgs = permission.SetBaseArgs(user.Address(), perm, val)
 	case "setGlobal":
-		snativeArgs = *permission.SetGlobalArgs(perm, val)
+		snativeArgs = permission.SetGlobalArgs(perm, val)
 	}
 	return
 }
@@ -1282,11 +1282,11 @@ func snativeRoleTestInputCALL(name string, user acm.PrivateAccount,
 func snativeRoleTestInputTx(name string, user acm.PrivateAccount, role string) (snativeArgs permission.PermArgs) {
 	switch name {
 	case "hasRole":
-		snativeArgs = *permission.HasRoleArgs(user.Address(), role)
+		snativeArgs = permission.HasRoleArgs(user.Address(), role)
 	case "addRole":
-		snativeArgs = *permission.AddRoleArgs(user.Address(), role)
+		snativeArgs = permission.AddRoleArgs(user.Address(), role)
 	case "removeRole":
-		snativeArgs = *permission.RemoveRoleArgs(user.Address(), role)
+		snativeArgs = permission.RemoveRoleArgs(user.Address(), role)
 	}
 	return
 }

--- a/genesis/spec/genesis_spec_test.go
+++ b/genesis/spec/genesis_spec_test.go
@@ -1,7 +1,6 @@
 package spec
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hyperledger/burrow/keys"
@@ -80,12 +79,5 @@ func TestGenesisSpec_GenesisDoc(t *testing.T) {
 	assert.Equal(t, genesisDoc.Accounts[0].PublicKey, genesisDoc.Validators[0].PublicKey)
 }
 
-func TestJSONRoundTrip(t *testing.T) {
-
-	var a []byte
-
-	b := []byte{1, 2, 3}
-
-	c := append(b, a...)
-	fmt.Println(c)
+func TestTemplateAccount_AccountPermissions(t *testing.T) {
 }

--- a/logging/config/filter_test.go
+++ b/logging/config/filter_test.go
@@ -91,7 +91,8 @@ func TestIncludeAllFilterPredicate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, fp([]interface{}{"Foo", "bar", "Shoes", 42}))
 	// Don't filter, it has all the required key values
-	assert.False(t, fp([]interface{}{"Foo", "bar", "Planks", 0.2, "Shoes", 42, "Bosh", "Bish"}))
+	assert.False(t, fp([]interface{}{"Foo", "bar", "Planks", 0.2, "Shoes", 42, "imBoshy", "unBishy"}))
+	assert.True(t, fp([]interface{}{"Foo", "bar", "Planks", 0.23, "Shoes", 42, "imBoshy", "unBishy"}))
 	assert.True(t, fp([]interface{}{"Food", 0.2, "Shoes", 42}))
 }
 

--- a/logging/config/presets/instructions_test.go
+++ b/logging/config/presets/instructions_test.go
@@ -3,8 +3,6 @@ package presets
 import (
 	"testing"
 
-	"fmt"
-
 	"github.com/hyperledger/burrow/logging/config"
 	"github.com/hyperledger/burrow/logging/loggers"
 	"github.com/hyperledger/burrow/logging/structure"

--- a/logging/config/sinks.go
+++ b/logging/config/sinks.go
@@ -322,9 +322,9 @@ func BuildOutputLogger(outputConfig *OutputConfig) (kitlog.Logger, error) {
 	case File:
 		return loggers.NewFileLogger(outputConfig.FileConfig.Path, outputConfig.Format)
 	case Stdout:
-		return loggers.NewStreamLogger(os.Stdout, outputConfig.Format), nil
+		return loggers.NewStreamLogger(os.Stdout, outputConfig.Format)
 	case Stderr:
-		return loggers.NewStreamLogger(os.Stderr, outputConfig.Format), nil
+		return loggers.NewStreamLogger(os.Stderr, outputConfig.Format)
 	default:
 		return nil, fmt.Errorf("could not build logger for output: '%s'",
 			outputConfig.OutputType)

--- a/logging/lifecycle/lifecycle.go
+++ b/logging/lifecycle/lifecycle.go
@@ -41,8 +41,12 @@ import (
 func NewLoggerFromLoggingConfig(loggingConfig *config.LoggingConfig) (types.InfoTraceLogger, error) {
 	var logger types.InfoTraceLogger
 	var errCh channels.Channel
+	var err error
 	if loggingConfig == nil {
-		logger, errCh = NewStdErrLogger()
+		logger, errCh, err = NewStdErrLogger()
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		outputLogger, err := infoTraceLoggerFromLoggingConfig(loggingConfig)
 		if err != nil {
@@ -74,9 +78,13 @@ func SwapOutputLoggersFromLoggingConfig(logger types.InfoTraceLogger,
 	return nil
 }
 
-func NewStdErrLogger() (types.InfoTraceLogger, channels.Channel) {
-	logger := loggers.NewStreamLogger(os.Stderr, "terminal")
-	return NewLogger(logger)
+func NewStdErrLogger() (types.InfoTraceLogger, channels.Channel, error) {
+	logger, err := loggers.NewStreamLogger(os.Stderr, loggers.TerminalFormat)
+	if err != nil {
+		return nil, nil, err
+	}
+	itLogger, errCh := NewLogger(logger)
+	return itLogger, errCh, nil
 }
 
 // Provided a standard logger that outputs to the supplied underlying outputLogger

--- a/logging/loggers/burrow_format_logger.go
+++ b/logging/loggers/burrow_format_logger.go
@@ -41,21 +41,17 @@ func (bfl *burrowFormatLogger) Log(keyvals ...interface{}) error {
 		return fmt.Errorf("log line contains an odd number of elements so "+
 			"was dropped: %v", keyvals)
 	}
-	return bfl.logger.Log(structure.MapKeyValues(keyvals, burrowFormatKeyValueMapper)...)
-}
-
-func burrowFormatKeyValueMapper(key, value interface{}) (interface{}, interface{}) {
-	switch key {
-	default:
-		switch v := value.(type) {
-		case []byte:
-			return key, fmt.Sprintf("%X", v)
-		case time.Time:
-			return key, v.Format(time.RFC3339Nano)
-		}
-
-	}
-	return key, fmt.Sprintf("%v", value)
+	return bfl.logger.Log(structure.MapKeyValues(keyvals,
+		func(key interface{}, value interface{}) (interface{}, interface{}) {
+			switch v := value.(type) {
+			case string:
+			case []byte:
+				value = fmt.Sprintf("%X", v)
+			case time.Time:
+				value = v.Format(time.RFC3339Nano)
+			}
+			return structure.StringifyKey(key), value
+		})...)
 }
 
 func BurrowFormatLogger(logger kitlog.Logger) *burrowFormatLogger {

--- a/logging/loggers/output_loggers_test.go
+++ b/logging/loggers/output_loggers_test.go
@@ -32,12 +32,24 @@ func TestNewFileLogger(t *testing.T) {
 
 func TestNewStreamLogger(t *testing.T) {
 	buf := new(bytes.Buffer)
-	logger := NewStreamLogger(buf, LogfmtFormat)
-	err := logger.Log("oh", "my")
+	logger, err := NewStreamLogger(buf, LogfmtFormat)
+	require.NoError(t, err)
+	err = logger.Log("oh", "my")
 	require.NoError(t, err)
 
 	err = logging.Sync(logger)
 	require.NoError(t, err)
 
 	assert.Equal(t, "oh=my\n", string(buf.Bytes()))
+}
+
+func TestNewTemplateLogger(t *testing.T) {
+	buf := new(bytes.Buffer)
+	logger, err := NewTemplateLogger(buf, "Why Hello {{.name}}", []byte{'\n'})
+	require.NoError(t, err)
+	err = logger.Log("name", "Marjorie Stewart-Baxter", "fingertip_width_cm", float32(1.34))
+	require.NoError(t, err)
+	err = logger.Log("name", "Fred")
+	require.NoError(t, err)
+	assert.Equal(t, "Why Hello Marjorie Stewart-Baxter\nWhy Hello Fred\n", buf.String())
 }

--- a/logging/loggers/vector_valued_logger_test.go
+++ b/logging/loggers/vector_valued_logger_test.go
@@ -17,6 +17,7 @@ package loggers
 import (
 	"testing"
 
+	"github.com/hyperledger/burrow/logging/structure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,6 +27,6 @@ func TestVectorValuedLogger(t *testing.T) {
 	vvl.Log("foo", "bar", "seen", 1, "seen", 3, "seen", 2)
 	lls, err := logger.logLines(1)
 	assert.NoError(t, err)
-	assert.Equal(t, []interface{}{"foo", "bar", "seen", []interface{}{1, 3, 2}},
+	assert.Equal(t, []interface{}{"foo", "bar", "seen", structure.Vector{1, 3, 2}},
 		lls[0])
 }

--- a/logging/structure/structure_test.go
+++ b/logging/structure/structure_test.go
@@ -27,6 +27,24 @@ func TestValuesAndContext(t *testing.T) {
 	assert.Equal(t, []interface{}{"dog", 2, "fork", 5}, ctx)
 }
 
+func TestKeyValuesMap(t *testing.T) {
+	keyvals := []interface{}{
+		[][]interface{}{{2}}, 3,
+		"hello", 1,
+		"fish", 3,
+		"dog", 2,
+		"fork", 5,
+	}
+	vals := KeyValuesMap(keyvals)
+	assert.Equal(t, map[string]interface{}{
+		"[[2]]": 3,
+		"hello": 1,
+		"fish":  3,
+		"dog":   2,
+		"fork":  5,
+	}, vals)
+}
+
 func TestVectorise(t *testing.T) {
 	kvs := []interface{}{
 		"scope", "lawnmower",
@@ -41,12 +59,17 @@ func TestVectorise(t *testing.T) {
 	kvsVector := Vectorise(kvs, "occupation", "scope")
 	// Vectorise scope
 	assert.Equal(t, []interface{}{
-		"scope", []interface{}{"lawnmower", "hose pipe", "rake"},
+		"scope", Vector{"lawnmower", "hose pipe", "rake"},
 		"hub", "budub",
 		"occupation", "fish brewer",
-		"flub", []interface{}{"dub", "brub"},
+		"flub", Vector{"dub", "brub"},
 	},
 		kvsVector)
+}
+
+func TestVector_String(t *testing.T) {
+	vec := Vector{"one", "two", "grue"}
+	assert.Equal(t, "[one two grue]", vec.String())
 }
 
 func TestRemoveKeys(t *testing.T) {

--- a/logging/structure/structure_test.go
+++ b/logging/structure/structure_test.go
@@ -23,7 +23,7 @@ import (
 func TestValuesAndContext(t *testing.T) {
 	keyvals := []interface{}{"hello", 1, "dog", 2, "fish", 3, "fork", 5}
 	vals, ctx := ValuesAndContext(keyvals, "hello", "fish")
-	assert.Equal(t, map[interface{}]interface{}{"hello": 1, "fish": 3}, vals)
+	assert.Equal(t, map[string]interface{}{"hello": 1, "fish": 3}, vals)
 	assert.Equal(t, []interface{}{"dog", 2, "fork", 5}, ctx)
 }
 

--- a/permission/permissions.go
+++ b/permission/permissions.go
@@ -97,7 +97,8 @@ var (
 //--------------------------------------------------------------------------------
 // string utilities
 
-// PermFlagToString assumes the permFlag is valid, else returns "#-UNKNOWN-#"
+// Returns the string name of a single bit non-composite PermFlag, or otherwise UnknownString
+// See BasePermissionsToStringList to generate a string representation of a composite PermFlag
 func PermFlagToString(pf types.PermFlag) string {
 	switch pf {
 	case AllPermFlags:
@@ -184,5 +185,10 @@ func GlobalPermissionsAccount(state acm.Getter) acm.Account {
 
 // Get global permissions from the account at GlobalPermissionsAddress
 func GlobalAccountPermissions(state acm.Getter) types.AccountPermissions {
+	if state == nil {
+		return types.AccountPermissions{
+			Roles: []string{},
+		}
+	}
 	return GlobalPermissionsAccount(state).Permissions()
 }

--- a/permission/permissions.go
+++ b/permission/permissions.go
@@ -98,82 +98,80 @@ var (
 // string utilities
 
 // PermFlagToString assumes the permFlag is valid, else returns "#-UNKNOWN-#"
-func PermFlagToString(pf types.PermFlag) (perm string) {
+func PermFlagToString(pf types.PermFlag) string {
 	switch pf {
 	case AllPermFlags:
-		perm = AllString
+		return AllString
 	case Root:
-		perm = RootString
+		return RootString
 	case Send:
-		perm = SendString
+		return SendString
 	case Call:
-		perm = CallString
+		return CallString
 	case CreateContract:
-		perm = CreateContractString
+		return CreateContractString
 	case CreateAccount:
-		perm = CreateAccountString
+		return CreateAccountString
 	case Bond:
-		perm = BondString
+		return BondString
 	case Name:
-		perm = NameString
+		return NameString
 	case HasBase:
-		perm = HasBaseString
+		return HasBaseString
 	case SetBase:
-		perm = SetBaseString
+		return SetBaseString
 	case UnsetBase:
-		perm = UnsetBaseString
+		return UnsetBaseString
 	case SetGlobal:
-		perm = SetGlobalString
+		return SetGlobalString
 	case HasRole:
-		perm = HasRoleString
+		return HasRoleString
 	case AddRole:
-		perm = AddRoleString
+		return AddRoleString
 	case RemoveRole:
-		perm = RemoveRoleString
+		return RemoveRoleString
 	default:
-		perm = UnknownString
+		return UnknownString
 	}
-	return
 }
 
 // PermStringToFlag maps camel- and snake case strings to the
 // the corresponding permission flag.
-func PermStringToFlag(perm string) (pf types.PermFlag, err error) {
+func PermStringToFlag(perm string) (types.PermFlag, error) {
 	switch strings.ToLower(perm) {
 	case AllString:
-		pf = AllPermFlags
+		return AllPermFlags, nil
 	case RootString:
-		pf = Root
+		return Root, nil
 	case SendString:
-		pf = Send
+		return Send, nil
 	case CallString:
-		pf = Call
+		return Call, nil
 	case CreateContractString, "createcontract", "create_contract":
-		pf = CreateContract
+		return CreateContract, nil
 	case CreateAccountString, "createaccount", "create_account":
-		pf = CreateAccount
+		return CreateAccount, nil
 	case BondString:
-		pf = Bond
+		return Bond, nil
 	case NameString:
-		pf = Name
+		return Name, nil
 	case HasBaseString, "hasbase", "has_base":
-		pf = HasBase
+		return HasBase, nil
 	case SetBaseString, "setbase", "set_base":
-		pf = SetBase
+		return SetBase, nil
 	case UnsetBaseString, "unsetbase", "unset_base":
-		pf = UnsetBase
+		return UnsetBase, nil
 	case SetGlobalString, "setglobal", "set_global":
-		pf = SetGlobal
+		return SetGlobal, nil
 	case HasRoleString, "hasrole", "has_role":
-		pf = HasRole
+		return HasRole, nil
 	case AddRoleString, "addrole", "add_role":
-		pf = AddRole
+		return AddRole, nil
 	case RemoveRoleString, "removerole", "rmrole", "rm_role":
-		pf = RemoveRole
+		return RemoveRole, nil
 	default:
-		err = fmt.Errorf("unknown permission %s", perm)
+		return 0, fmt.Errorf("unknown permission %s", perm)
 	}
-	return
 }
 
 func GlobalPermissionsAccount(state acm.Getter) acm.Account {

--- a/permission/permissions_test.go
+++ b/permission/permissions_test.go
@@ -1,0 +1,11 @@
+package permission
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllPermissions(t *testing.T) {
+	assert.Equal(t, AllPermFlags, DefaultPermFlags|AddRole|RemoveRole|SetBase|UnsetBase|Root|SetGlobal)
+}

--- a/permission/snatives.go
+++ b/permission/snatives.go
@@ -35,12 +35,12 @@ type PermArgs struct {
 
 func (pa PermArgs) String() string {
 	body := make([]string, 0, 5)
-	body = append(body, fmt.Sprintf("PermFlag: %s", PermFlagToString(pa.PermFlag)))
+	body = append(body, fmt.Sprintf("PermFlag: %s", PermissionsString(pa.PermFlag)))
 	if pa.Address != nil {
 		body = append(body, fmt.Sprintf("Address: %s", *pa.Address))
 	}
 	if pa.Permission != nil {
-		body = append(body, fmt.Sprintf("Permission: %s", PermFlagToString(*pa.Permission)))
+		body = append(body, fmt.Sprintf("Permission: %s", PermissionsString(*pa.Permission)))
 	}
 	if pa.Role != nil {
 		body = append(body, fmt.Sprintf("Role: %s", *pa.Role))

--- a/permission/snatives.go
+++ b/permission/snatives.go
@@ -15,6 +15,9 @@
 package permission
 
 import (
+	"fmt"
+	"strings"
+
 	acm "github.com/hyperledger/burrow/account"
 	"github.com/hyperledger/burrow/permission/types"
 )
@@ -24,65 +27,104 @@ import (
 
 type PermArgs struct {
 	PermFlag   types.PermFlag
-	Address    acm.Address    `json:",omitempty"`
-	Permission types.PermFlag `json:",omitempty"`
-	Role       string         `json:",omitempty"`
-	Value      bool           `json:",omitempty"`
+	Address    *acm.Address    `json:",omitempty"`
+	Permission *types.PermFlag `json:",omitempty"`
+	Role       *string         `json:",omitempty"`
+	Value      *bool           `json:",omitempty"`
 }
 
-func HasBaseArgs(address acm.Address, permission types.PermFlag) *PermArgs {
-	return &PermArgs{
+func (pa PermArgs) String() string {
+	body := make([]string, 0, 5)
+	body = append(body, fmt.Sprintf("PermFlag: %s", PermFlagToString(pa.PermFlag)))
+	if pa.Address != nil {
+		body = append(body, fmt.Sprintf("Address: %s", *pa.Address))
+	}
+	if pa.Permission != nil {
+		body = append(body, fmt.Sprintf("Permission: %s", PermFlagToString(*pa.Permission)))
+	}
+	if pa.Role != nil {
+		body = append(body, fmt.Sprintf("Role: %s", *pa.Role))
+	}
+	if pa.Value != nil {
+		body = append(body, fmt.Sprintf("Value: %v", *pa.Value))
+	}
+	return fmt.Sprintf("PermArgs{%s}", strings.Join(body, ", "))
+}
+
+func (pa PermArgs) EnsureValid() error {
+	pf := pa.PermFlag
+	// Address
+	if pa.Address == nil && pf != SetGlobal {
+		return fmt.Errorf("PermArgs for PermFlag %v requires Address to be provided but was nil", pf)
+	}
+	if pf == HasRole || pf == AddRole || pf == RemoveRole {
+		// Role
+		if pa.Role == nil {
+			return fmt.Errorf("PermArgs for PermFlag %v requires Role to be provided but was nil", pf)
+		}
+		// Permission
+	} else if pa.Permission == nil {
+		return fmt.Errorf("PermArgs for PermFlag %v requires Permission to be provided but was nil", pf)
+		// Value
+	} else if (pf == SetBase || pf == SetGlobal) && pa.Value == nil {
+		return fmt.Errorf("PermArgs for PermFlag %v requires Value to be provided but was nil", pf)
+	}
+	return nil
+}
+
+func HasBaseArgs(address acm.Address, permission types.PermFlag) PermArgs {
+	return PermArgs{
 		PermFlag:   HasBase,
-		Address:    address,
-		Permission: permission,
+		Address:    &address,
+		Permission: &permission,
 	}
 }
 
-func SetBaseArgs(address acm.Address, permission types.PermFlag, value bool) *PermArgs {
-	return &PermArgs{
+func SetBaseArgs(address acm.Address, permission types.PermFlag, value bool) PermArgs {
+	return PermArgs{
 		PermFlag:   SetBase,
-		Address:    address,
-		Permission: permission,
-		Value:      value,
+		Address:    &address,
+		Permission: &permission,
+		Value:      &value,
 	}
 }
 
-func UnsetBaseArgs(address acm.Address, permission types.PermFlag) *PermArgs {
-	return &PermArgs{
+func UnsetBaseArgs(address acm.Address, permission types.PermFlag) PermArgs {
+	return PermArgs{
 		PermFlag:   UnsetBase,
-		Address:    address,
-		Permission: permission,
+		Address:    &address,
+		Permission: &permission,
 	}
 }
 
-func SetGlobalArgs(permission types.PermFlag, value bool) *PermArgs {
-	return &PermArgs{
+func SetGlobalArgs(permission types.PermFlag, value bool) PermArgs {
+	return PermArgs{
 		PermFlag:   SetGlobal,
-		Permission: permission,
-		Value:      value,
+		Permission: &permission,
+		Value:      &value,
 	}
 }
 
-func HasRoleArgs(address acm.Address, role string) *PermArgs {
-	return &PermArgs{
+func HasRoleArgs(address acm.Address, role string) PermArgs {
+	return PermArgs{
 		PermFlag: HasRole,
-		Address:  address,
-		Role:     role,
+		Address:  &address,
+		Role:     &role,
 	}
 }
 
-func AddRoleArgs(address acm.Address, role string) *PermArgs {
-	return &PermArgs{
+func AddRoleArgs(address acm.Address, role string) PermArgs {
+	return PermArgs{
 		PermFlag: AddRole,
-		Address:  address,
-		Role:     role,
+		Address:  &address,
+		Role:     &role,
 	}
 }
 
-func RemoveRoleArgs(address acm.Address, role string) *PermArgs {
-	return &PermArgs{
+func RemoveRoleArgs(address acm.Address, role string) PermArgs {
+	return PermArgs{
 		PermFlag: RemoveRole,
-		Address:  address,
-		Role:     role,
+		Address:  &address,
+		Role:     &role,
 	}
 }

--- a/permission/snatives_test.go
+++ b/permission/snatives_test.go
@@ -9,13 +9,13 @@ import (
 func TestPermArgs_String(t *testing.T) {
 	role := "foo"
 	value := true
-	permission := AddRole
+	permission := AddRole | RemoveRole
 	permArgs := PermArgs{
 		PermFlag:   SetBase,
 		Permission: &permission,
 		Role:       &role,
 		Value:      &value,
 	}
-	assert.Equal(t, "PermArgs{PermFlag: 0b100000000, Permission: 0b1000000000000, Role: foo, Value: true}",
+	assert.Equal(t, "PermArgs{PermFlag: setBase, Permission: addRole | removeRole, Role: foo, Value: true}",
 		permArgs.String())
 }

--- a/permission/snatives_test.go
+++ b/permission/snatives_test.go
@@ -1,0 +1,21 @@
+package permission
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPermArgs_String(t *testing.T) {
+	role := "foo"
+	value := true
+	permission := AddRole
+	permArgs := PermArgs{
+		PermFlag:   SetBase,
+		Permission: &permission,
+		Role:       &role,
+		Value:      &value,
+	}
+	assert.Equal(t, "PermArgs{PermFlag: 0b100000000, Permission: 0b1000000000000, Role: foo, Value: true}",
+		permArgs.String())
+}

--- a/permission/types/base_permissions.go
+++ b/permission/types/base_permissions.go
@@ -29,58 +29,68 @@ type BasePermissions struct {
 	SetBit PermFlag
 }
 
-// Get a permission value. ty should be a power of 2.
-// ErrValueNotSet is returned if the permission's set bit is off,
+// Gets the permission value.
+// ErrValueNotSet is returned if the permission's set bits are not all on,
 // and should be caught by caller so the global permission can be fetched
-func (p BasePermissions) Get(ty PermFlag) (bool, error) {
+func (bp BasePermissions) Get(ty PermFlag) (bool, error) {
 	if ty == 0 {
 		return false, ErrInvalidPermission(ty)
 	}
-	if p.SetBit&ty == 0 {
+	if !bp.IsSet(ty) {
 		return false, ErrValueNotSet(ty)
 	}
-	return p.Perms&ty > 0, nil
+	return bp.Perms&ty == ty, nil
 }
 
 // Set a permission bit. Will set the permission's set bit to true.
-func (p *BasePermissions) Set(ty PermFlag, value bool) error {
+func (bp *BasePermissions) Set(ty PermFlag, value bool) error {
 	if ty == 0 {
 		return ErrInvalidPermission(ty)
 	}
-	p.SetBit |= ty
+	bp.SetBit |= ty
 	if value {
-		p.Perms |= ty
+		bp.Perms |= ty
 	} else {
-		p.Perms &= ^ty
+		bp.Perms &= ^ty
 	}
 	return nil
 }
 
-// Set the permission's set bit to false
-func (p *BasePermissions) Unset(ty PermFlag) error {
+// Set the permission's set bits to false
+func (bp *BasePermissions) Unset(ty PermFlag) error {
 	if ty == 0 {
 		return ErrInvalidPermission(ty)
 	}
-	p.SetBit &= ^ty
+	bp.SetBit &= ^ty
 	return nil
 }
 
 // Check if the permission is set
-func (p BasePermissions) IsSet(ty PermFlag) bool {
+func (bp BasePermissions) IsSet(ty PermFlag) bool {
 	if ty == 0 {
 		return false
 	}
-	return p.SetBit&ty > 0
+	return bp.SetBit&ty == ty
 }
 
 // Returns the Perms PermFlag masked with SetBit bit field to give the resultant
 // permissions enabled by this BasePermissions
-func (p BasePermissions) ResultantPerms() PermFlag {
-	return p.Perms & p.SetBit
+func (bp BasePermissions) ResultantPerms() PermFlag {
+	return bp.Perms & bp.SetBit
 }
 
-func (p BasePermissions) String() string {
-	return fmt.Sprintf("Base: %b; Set: %b", p.Perms, p.SetBit)
+// Returns a BasePermission that matches any permissions set on this BasePermission
+// and falls through to any permissions set on the bpFallthrough
+func (bp BasePermissions) Compose(bpFallthrough BasePermissions) BasePermissions {
+	return BasePermissions{
+		// Combine set perm flags from bp with set perm flags in fallthrough NOT set in bp
+		Perms:  (bp.Perms & bp.SetBit) | (bpFallthrough.Perms & (^bp.SetBit & bpFallthrough.SetBit)),
+		SetBit: bp.SetBit | bpFallthrough.SetBit,
+	}
+}
+
+func (bp BasePermissions) String() string {
+	return fmt.Sprintf("Base: %b; Set: %b", bp.Perms, bp.SetBit)
 }
 
 //---------------------------------------------------------------------------------------------

--- a/permission/types/base_permissions_test.go
+++ b/permission/types/base_permissions_test.go
@@ -1,0 +1,112 @@
+package types
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasePermissions_Get(t *testing.T) {
+	allPermsString := "11111111111111"
+
+	hasPermission, err := testHasPermission(t,
+		"100001000110",
+		allPermsString,
+		"100001000110")
+	assert.NoError(t, err)
+	assert.True(t, hasPermission)
+
+	hasPermission, err = testHasPermission(t,
+		allPermsString,
+		allPermsString,
+		"100000000")
+	assert.NoError(t, err)
+	assert.True(t, hasPermission)
+
+	unset := "00100001000111"
+	hasPermission, err = testHasPermission(t,
+		unset,
+		"11011110111000",
+		unset)
+	assert.Equal(t, ErrValueNotSet(PermFlagFromString(t, unset)), err)
+	assert.False(t, hasPermission)
+
+	hasPermission, err = testHasPermission(t,
+		"00100001000111",
+		"11011110111000",
+		"00100001000111")
+	assert.Error(t, err)
+	assert.False(t, hasPermission)
+}
+
+func TestBasePermissions_Compose(t *testing.T) {
+	assertComposition(t,
+		"101010",
+		"111000",
+		"111111",
+		"111111",
+		"101111")
+
+	assertComposition(t,
+		"101010",
+		"111111",
+		"111111",
+		"111111",
+		"101010")
+
+	assertComposition(t,
+		"101010",
+		"000001",
+		"111111",
+		"000000",
+		"000000")
+
+	assertComposition(t,
+		"101010",
+		"000001",
+		"111111",
+		"001100",
+		"001100")
+
+	assertComposition(t,
+		"101010",
+		"000101",
+		"111111",
+		"001100",
+		"001000")
+
+	assertComposition(t,
+		"000000",
+		"010101",
+		"111111",
+		"111111",
+		"101010")
+}
+
+func assertComposition(t *testing.T, perms, setBit, permsFallback, setBitFallback, permsResultant string) {
+	composed := BasePermissionsFromStrings(t, perms, setBit).
+		Compose(BasePermissionsFromStrings(t, permsFallback, setBitFallback)).ResultantPerms()
+	expected := PermFlagFromString(t, permsResultant)
+	if !assert.Equal(t, expected, composed) {
+		t.Errorf("\nexpected: %014b\nactual:   %014b", expected, composed)
+	}
+}
+
+func testHasPermission(t *testing.T, perms, setBit, permsToCheck string) (bool, error) {
+	return BasePermissionsFromStrings(t, perms, setBit).Get(PermFlagFromString(t, permsToCheck))
+}
+
+func BasePermissionsFromStrings(t *testing.T, perms, setBit string) BasePermissions {
+	return BasePermissions{
+		Perms:  PermFlagFromString(t, perms),
+		SetBit: PermFlagFromString(t, setBit),
+	}
+}
+
+func PermFlagFromString(t *testing.T, binaryString string) PermFlag {
+	permFlag, err := strconv.ParseUint(binaryString, 2, 64)
+	require.NoError(t, err)
+	return PermFlag(permFlag)
+}

--- a/permission/util_test.go
+++ b/permission/util_test.go
@@ -3,6 +3,7 @@ package permission
 import (
 	"testing"
 
+	"github.com/hyperledger/burrow/permission/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,4 +20,34 @@ func TestBasePermissionsFromStringList(t *testing.T) {
 	permFlag = AllPermFlags
 	assert.Equal(t, permFlag, basePerms.Perms)
 	assert.Equal(t, permFlag, basePerms.SetBit)
+
+	basePerms, err = BasePermissionsFromStringList([]string{"justHaveALittleRest"})
+	assert.Error(t, err)
+}
+
+func TestBasePermissionsToStringList(t *testing.T) {
+	permStrings, err := BasePermissionsToStringList(allSetBasePermission(Root | HasRole | SetBase | Call))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"root", "call", "setBase", "hasRole"}, permStrings)
+
+	permStrings, err = BasePermissionsToStringList(allSetBasePermission(AllPermFlags))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"root", "send", "call", "createContract", "createAccount", "bond", "name", "hasBase",
+		"setBase", "unsetBase", "setGlobal", "hasRole", "addRole", "removeRole"}, permStrings)
+
+	permStrings, err = BasePermissionsToStringList(allSetBasePermission(AllPermFlags + 1))
+	assert.Error(t, err)
+}
+
+func TestBasePermissionsString(t *testing.T) {
+	permissionString := BasePermissionsString(allSetBasePermission(AllPermFlags &^ Root))
+	assert.Equal(t, "send | call | createContract | createAccount | bond | name | hasBase | "+
+		"setBase | unsetBase | setGlobal | hasRole | addRole | removeRole", permissionString)
+}
+
+func allSetBasePermission(perms types.PermFlag) types.BasePermissions {
+	return types.BasePermissions{
+		Perms:  perms,
+		SetBit: perms,
+	}
 }

--- a/permission/util_test.go
+++ b/permission/util_test.go
@@ -13,4 +13,10 @@ func TestBasePermissionsFromStringList(t *testing.T) {
 	permFlag := HasRole | CreateContract | Send
 	assert.Equal(t, permFlag, basePerms.Perms)
 	assert.Equal(t, permFlag, basePerms.SetBit)
+
+	basePerms, err = BasePermissionsFromStringList([]string{AllString})
+	require.NoError(t, err)
+	permFlag = AllPermFlags
+	assert.Equal(t, permFlag, basePerms.Perms)
+	assert.Equal(t, permFlag, basePerms.SetBit)
 }

--- a/rpc/tm/integration/shared.go
+++ b/rpc/tm/integration/shared.go
@@ -81,7 +81,7 @@ func TestWrapper(runner func() int) int {
 	tmConf := tm_config.DefaultConfig()
 	logger := loggers.NewNoopInfoTraceLogger()
 	if debugLogging {
-		logger, _ = lifecycle.NewStdErrLogger()
+		logger, _, _ = lifecycle.NewStdErrLogger()
 	}
 
 	privValidator := validator.NewPrivValidatorMemory(privateAccounts[0], privateAccounts[0])

--- a/txs/tx.go
+++ b/txs/tx.go
@@ -374,8 +374,8 @@ func (tx *RebondTx) String() string {
 //-----------------------------------------------------------------------------
 
 type PermissionsTx struct {
-	Input    *TxInput         `json:"input"`
-	PermArgs *ptypes.PermArgs `json:"args"`
+	Input    *TxInput
+	PermArgs ptypes.PermArgs
 }
 
 func (tx *PermissionsTx) WriteSignBytes(chainID string, w io.Writer, n *int, err *error) {
@@ -422,9 +422,10 @@ func GenerateReceipt(chainId string, tx Tx) Receipt {
 
 // Contract: This function is deterministic and completely reversible.
 func jsonEscape(str string) string {
+	// TODO: escape without panic
 	escapedBytes, err := json.Marshal(str)
 	if err != nil {
-		panic(fmt.Sprintf("error json-escaping a string", str))
+		panic(fmt.Errorf("error json-escaping string: %s", str))
 	}
 	return string(escapedBytes)
 }

--- a/txs/tx_utils.go
+++ b/txs/tx_utils.go
@@ -237,7 +237,7 @@ func (tx *RebondTx) Sign(chainID string, privAccount acm.PrivateAccount) {
 //----------------------------------------------------------------------------
 // PermissionsTx interface for creating tx
 
-func NewPermissionsTx(st acm.Getter, from acm.PublicKey, args *ptypes.PermArgs) (*PermissionsTx, error) {
+func NewPermissionsTx(st acm.Getter, from acm.PublicKey, args ptypes.PermArgs) (*PermissionsTx, error) {
 	addr := from.Address()
 	acc, err := st.GetAccount(addr)
 	if err != nil {
@@ -251,7 +251,7 @@ func NewPermissionsTx(st acm.Getter, from acm.PublicKey, args *ptypes.PermArgs) 
 	return NewPermissionsTxWithSequence(from, args, sequence), nil
 }
 
-func NewPermissionsTxWithSequence(from acm.PublicKey, args *ptypes.PermArgs, sequence uint64) *PermissionsTx {
+func NewPermissionsTxWithSequence(from acm.PublicKey, args ptypes.PermArgs, sequence uint64) *PermissionsTx {
 	input := &TxInput{
 		Address:  from.Address(),
 		Amount:   1, // NOTE: amounts can't be 0 ...

--- a/util/snatives/cmd/main.go
+++ b/util/snatives/cmd/main.go
@@ -26,7 +26,6 @@ func main() {
 	contracts := evm.SNativeContracts()
 	// Index of next contract
 	i := 1
-	fmt.Print("pragma solidity >=0.0.0;\n\n")
 	for _, contract := range contracts {
 		solidity, err := templates.NewSolidityContract(contract).Solidity()
 		if err != nil {


### PR DESCRIPTION
This PR all comes out of work integrating the Bosmarmot (EPM) tests. In a couple of places we previously swallowed errors that meant some issue have always been here but were not previously noticed.

It consists of three commits:
1. Some additional logging features I found I wanted when debugging (template format logging and some other serialisation cleanup)

2. Fixes and tidies up the Permissions method in client in Burrow which was dropping some fields from `PermArgs` (with corresponding changes in Bosmarmot to follow)

3. General clean up of permission checking - in particular to avoid unnecessary panics and support composite permissions checking - which I was surprised to find unsupported. Our tests seem to expect it but some swallowed errors allowed them to pass in the past.

Once merged to develop this can be vendored into Bosmarmot where the integration tests are now all passing.

Also fixes #667 - subslice function being able to panic with negative index