### PR TITLE
Making case and naming conventions consistent

### DIFF
--- a/execution/events/events.go
+++ b/execution/events/events.go
@@ -22,9 +22,9 @@ func EventStringRebond() string                        { return "Rebond" }
 
 // All txs fire EventDataTx, but only CallTx might have Return or Exception
 type EventDataTx struct {
-	Tx        txs.Tx `json:"tx"`
-	Return    []byte `json:"return"`
-	Exception string `json:"exception"`
+	Tx        txs.Tx
+	Return    []byte
+	Exception string
 }
 
 // For re-use
@@ -33,9 +33,9 @@ var sendTxQuery = event.NewQueryBuilder().
 	AndEquals(event.TxTypeKey, reflect.TypeOf(&txs.SendTx{}).String())
 
 type eventDataTx struct {
-	Tx        txs.Wrapper `json:"tx"`
-	Return    []byte      `json:"return"`
-	Exception string      `json:"exception"`
+	Tx        txs.Wrapper
+	Return    []byte
+	Exception string
 }
 
 func (edTx EventDataTx) MarshalJSON() ([]byte, error) {

--- a/execution/evm/events/events.go
+++ b/execution/evm/events/events.go
@@ -33,27 +33,27 @@ func EventStringLogEvent(addr acm.Address) string    { return fmt.Sprintf("Log/%
 
 // EventDataCall fires when we call a contract, and when a contract calls another contract
 type EventDataCall struct {
-	CallData  *CallData   `json:"call_data"`
-	Origin    acm.Address `json:"origin"`
-	TxID      []byte      `json:"tx_id"`
-	Return    []byte      `json:"return"`
-	Exception string      `json:"exception"`
+	CallData  *CallData
+	Origin    acm.Address
+	TxID      []byte
+	Return    []byte
+	Exception string
 }
 
 type CallData struct {
-	Caller acm.Address `json:"caller"`
-	Callee acm.Address `json:"callee"`
-	Data   []byte      `json:"data"`
-	Value  uint64      `json:"value"`
-	Gas    uint64      `json:"gas"`
+	Caller acm.Address
+	Callee acm.Address
+	Data   []byte
+	Value  uint64
+	Gas    uint64
 }
 
 // EventDataLog fires when a contract executes the LOG opcode
 type EventDataLog struct {
-	Address acm.Address `json:"address"`
-	Topics  []Word256   `json:"topics"`
-	Data    []byte      `json:"data"`
-	Height  uint64      `json:"height"`
+	Address acm.Address
+	Topics  []Word256
+	Data    []byte
+	Height  uint64
 }
 
 // Publish/Subscribe

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -1053,17 +1053,17 @@ func getOrMakeOutputs(accountGetter acm.Getter, accs map[acm.Address]acm.Mutable
 // for all time.
 func checkInputPubKey(acc acm.MutableAccount, in *txs.TxInput) error {
 	if acc.PublicKey().Unwrap() == nil {
-		if in.PubKey.Unwrap() == nil {
+		if in.PublicKey.Unwrap() == nil {
 			return txs.ErrTxUnknownPubKey
 		}
-		addressFromPubKey := in.PubKey.Address()
+		addressFromPubKey := in.PublicKey.Address()
 		addressFromAccount := acc.Address()
 		if addressFromPubKey != addressFromAccount {
 			return txs.ErrTxInvalidPubKey
 		}
-		acc.SetPublicKey(in.PubKey)
+		acc.SetPublicKey(in.PublicKey)
 	} else {
-		in.PubKey = acm.PublicKey{}
+		in.PublicKey = acm.PublicKey{}
 	}
 	return nil
 }

--- a/execution/namereg.go
+++ b/execution/namereg.go
@@ -29,8 +29,8 @@ type NameRegIterable interface {
 }
 
 type NameRegEntry struct {
-	Name    string          `json:"name"`    // registered name for the entry
-	Owner   account.Address `json:"owner"`   // address that created the entry
-	Data    string          `json:"data"`    // data to store under this name
-	Expires uint64          `json:"expires"` // block at which this entry expires
+	Name    string          // registered name for the entry
+	Owner   account.Address // address that created the entry
+	Data    string          // data to store under this name
+	Expires uint64          // block at which this entry expires
 }

--- a/execution/state_test.go
+++ b/execution/state_test.go
@@ -500,10 +500,10 @@ func TestCreates(t *testing.T) {
 	// call the pre-factory, triggering the factory to run a create
 	tx := &txs.CallTx{
 		Input: &txs.TxInput{
-			Address:  acc0.Address(),
-			Amount:   1,
-			Sequence: acc0.Sequence() + 1,
-			PubKey:   acc0PubKey,
+			Address:   acc0.Address(),
+			Amount:    1,
+			Sequence:  acc0.Sequence() + 1,
+			PublicKey: acc0PubKey,
 		},
 		Address:  addressPtr(acc1),
 		GasLimit: 10000,
@@ -524,10 +524,10 @@ func TestCreates(t *testing.T) {
 	// call the pre-factory, triggering the factory to run a create
 	tx = &txs.CallTx{
 		Input: &txs.TxInput{
-			Address:  acc0.Address(),
-			Amount:   1,
-			Sequence: acc0.Sequence() + 1,
-			PubKey:   acc0PubKey,
+			Address:   acc0.Address(),
+			Amount:    1,
+			Sequence:  acc0.Sequence() + 1,
+			PublicKey: acc0PubKey,
 		},
 		Address:  addressPtr(acc1),
 		GasLimit: 100000,
@@ -580,10 +580,10 @@ func TestContractSend(t *testing.T) {
 	// call the contract, triggering the send
 	tx := &txs.CallTx{
 		Input: &txs.TxInput{
-			Address:  acc0.Address(),
-			Amount:   sendAmt,
-			Sequence: acc0.Sequence() + 1,
-			PubKey:   acc0PubKey,
+			Address:   acc0.Address(),
+			Amount:    sendAmt,
+			Sequence:  acc0.Sequence() + 1,
+			PublicKey: acc0PubKey,
 		},
 		Address:  addressPtr(acc1),
 		GasLimit: 1000,
@@ -617,10 +617,10 @@ func TestMerklePanic(t *testing.T) {
 		tx := &txs.SendTx{
 			Inputs: []*txs.TxInput{
 				{
-					Address:  acc0.Address(),
-					Amount:   1,
-					Sequence: acc0.Sequence() + 1,
-					PubKey:   acc0PubKey,
+					Address:   acc0.Address(),
+					Amount:    1,
+					Sequence:  acc0.Sequence() + 1,
+					PublicKey: acc0PubKey,
 				},
 			},
 			Outputs: []*txs.TxOutput{
@@ -648,10 +648,10 @@ func TestMerklePanic(t *testing.T) {
 		stateCallTx.UpdateAccount(newAcc1)
 		tx := &txs.CallTx{
 			Input: &txs.TxInput{
-				Address:  acc0.Address(),
-				Amount:   1,
-				Sequence: acc0.Sequence() + 1,
-				PubKey:   acc0PubKey,
+				Address:   acc0.Address(),
+				Amount:    1,
+				Sequence:  acc0.Sequence() + 1,
+				PublicKey: acc0PubKey,
 			},
 			Address:  addressPtr(acc1),
 			GasLimit: 10,
@@ -684,10 +684,10 @@ func TestTxs(t *testing.T) {
 		tx := &txs.SendTx{
 			Inputs: []*txs.TxInput{
 				{
-					Address:  acc0.Address(),
-					Amount:   1,
-					Sequence: acc0.Sequence() + 1,
-					PubKey:   acc0PubKey,
+					Address:   acc0.Address(),
+					Amount:    1,
+					Sequence:  acc0.Sequence() + 1,
+					PublicKey: acc0PubKey,
 				},
 			},
 			Outputs: []*txs.TxOutput{
@@ -723,10 +723,10 @@ func TestTxs(t *testing.T) {
 		stateCallTx.UpdateAccount(newAcc1)
 		tx := &txs.CallTx{
 			Input: &txs.TxInput{
-				Address:  acc0.Address(),
-				Amount:   1,
-				Sequence: acc0.Sequence() + 1,
-				PubKey:   acc0PubKey,
+				Address:   acc0.Address(),
+				Amount:    1,
+				Sequence:  acc0.Sequence() + 1,
+				PublicKey: acc0PubKey,
 			},
 			Address:  addressPtr(acc1),
 			GasLimit: 10,
@@ -774,10 +774,10 @@ proof-of-work chain as proof of what happened while they were gone `
 		stateNameTx := state.Copy()
 		tx := &txs.NameTx{
 			Input: &txs.TxInput{
-				Address:  acc0.Address(),
-				Amount:   entryAmount,
-				Sequence: acc0.Sequence() + 1,
-				PubKey:   acc0PubKey,
+				Address:   acc0.Address(),
+				Amount:    entryAmount,
+				Sequence:  acc0.Sequence() + 1,
+				PublicKey: acc0PubKey,
 			},
 			Name: entryName,
 			Data: entryData,

--- a/execution/transactor.go
+++ b/execution/transactor.go
@@ -202,10 +202,10 @@ func (trans *transactor) Transact(privKey []byte, address *acm.Address, data []b
 	// recent solidity compilers the EVM generated will throw an error if value
 	// is transferred to a non-payable function.
 	txInput := &txs.TxInput{
-		Address:  pa.Address(),
-		Amount:   fee,
-		Sequence: sequence,
-		PubKey:   pa.PublicKey(),
+		Address:   pa.Address(),
+		Amount:    fee,
+		Sequence:  sequence,
+		PublicKey: pa.PublicKey(),
 	}
 	tx := &txs.CallTx{
 		Input:    txInput,
@@ -290,10 +290,10 @@ func (trans *transactor) Send(privKey []byte, toAddress acm.Address, amount uint
 	tx := txs.NewSendTx()
 
 	txInput := &txs.TxInput{
-		Address:  pa.Address(),
-		Amount:   amount,
-		Sequence: sequence,
-		PubKey:   pa.PublicKey(),
+		Address:   pa.Address(),
+		Amount:    amount,
+		Sequence:  sequence,
+		PublicKey: pa.PublicKey(),
 	}
 
 	tx.Inputs = append(tx.Inputs, txInput)
@@ -393,17 +393,17 @@ func (trans *transactor) SignTx(tx txs.Tx, privAccounts []acm.PrivateAccount) (t
 	switch tx.(type) {
 	case *txs.NameTx:
 		nameTx := tx.(*txs.NameTx)
-		nameTx.Input.PubKey = privAccounts[0].PublicKey()
+		nameTx.Input.PublicKey = privAccounts[0].PublicKey()
 		nameTx.Input.Signature = acm.ChainSign(privAccounts[0], chainID, nameTx)
 	case *txs.SendTx:
 		sendTx := tx.(*txs.SendTx)
 		for i, input := range sendTx.Inputs {
-			input.PubKey = privAccounts[i].PublicKey()
+			input.PublicKey = privAccounts[i].PublicKey()
 			input.Signature = acm.ChainSign(privAccounts[i], chainID, sendTx)
 		}
 	case *txs.CallTx:
 		callTx := tx.(*txs.CallTx)
-		callTx.Input.PubKey = privAccounts[0].PublicKey()
+		callTx.Input.PublicKey = privAccounts[0].PublicKey()
 		callTx.Input.Signature = acm.ChainSign(privAccounts[0], chainID, callTx)
 	case *txs.BondTx:
 		bondTx := tx.(*txs.BondTx)
@@ -411,7 +411,7 @@ func (trans *transactor) SignTx(tx txs.Tx, privAccounts []acm.PrivateAccount) (t
 		// the rest to the inputs
 		bondTx.Signature = acm.ChainSign(privAccounts[0], chainID, bondTx)
 		for i, input := range bondTx.Inputs {
-			input.PubKey = privAccounts[i+1].PublicKey()
+			input.PublicKey = privAccounts[i+1].PublicKey()
 			input.Signature = acm.ChainSign(privAccounts[i+1], chainID, bondTx)
 		}
 	case *txs.UnbondTx:

--- a/rpc/result.go
+++ b/rpc/result.go
@@ -167,8 +167,7 @@ type ResultSignTx struct {
 }
 
 type ResultEvent struct {
-	Event string
-	// TODO: move ResultEvent sum type here
+	Event         string
 	TMEventData   *tm_types.TMEventData     `json:",omitempty"`
 	EventDataTx   *exe_events.EventDataTx   `json:",omitempty"`
 	EventDataCall *evm_events.EventDataCall `json:",omitempty"`

--- a/txs/tx.go
+++ b/txs/tx.go
@@ -149,7 +149,7 @@ type (
 		Amount    uint64
 		Sequence  uint64
 		Signature acm.Signature
-		PubKey    acm.PublicKey
+		PublicKey acm.PublicKey
 	}
 
 	TxOutput struct {
@@ -205,7 +205,7 @@ func (txIn *TxInput) WriteSignBytes(w io.Writer, n *int, err *error) {
 }
 
 func (txIn *TxInput) String() string {
-	return fmt.Sprintf("TxInput{%s,%v,%v,%v,%v}", txIn.Address, txIn.Amount, txIn.Sequence, txIn.Signature, txIn.PubKey)
+	return fmt.Sprintf("TxInput{%s,%v,%v,%v,%v}", txIn.Address, txIn.Amount, txIn.Sequence, txIn.Signature, txIn.PublicKey)
 }
 
 //-----------------------------------------------------------------------------

--- a/txs/tx_utils.go
+++ b/txs/tx_utils.go
@@ -46,10 +46,10 @@ func (tx *SendTx) AddInput(st acm.Getter, pubkey acm.PublicKey, amt uint64) erro
 func (tx *SendTx) AddInputWithSequence(pubkey acm.PublicKey, amt uint64, sequence uint64) error {
 	addr := pubkey.Address()
 	tx.Inputs = append(tx.Inputs, &TxInput{
-		Address:  addr,
-		Amount:   amt,
-		Sequence: sequence,
-		PubKey:   pubkey,
+		Address:   addr,
+		Amount:    amt,
+		Sequence:  sequence,
+		PublicKey: pubkey,
 	})
 	return nil
 }
@@ -66,7 +66,7 @@ func (tx *SendTx) SignInput(chainID string, i int, privAccount acm.PrivateAccoun
 	if i >= len(tx.Inputs) {
 		return fmt.Errorf("Index %v is greater than number of inputs (%v)", i, len(tx.Inputs))
 	}
-	tx.Inputs[i].PubKey = privAccount.PublicKey()
+	tx.Inputs[i].PublicKey = privAccount.PublicKey()
 	tx.Inputs[i].Signature = acm.ChainSign(privAccount, chainID, tx)
 	return nil
 }
@@ -93,10 +93,10 @@ func NewCallTx(st acm.Getter, from acm.PublicKey, to *acm.Address, data []byte,
 func NewCallTxWithSequence(from acm.PublicKey, to *acm.Address, data []byte,
 	amt, gasLimit, fee, sequence uint64) *CallTx {
 	input := &TxInput{
-		Address:  from.Address(),
-		Amount:   amt,
-		Sequence: sequence,
-		PubKey:   from,
+		Address:   from.Address(),
+		Amount:    amt,
+		Sequence:  sequence,
+		PublicKey: from,
 	}
 
 	return &CallTx{
@@ -109,7 +109,7 @@ func NewCallTxWithSequence(from acm.PublicKey, to *acm.Address, data []byte,
 }
 
 func (tx *CallTx) Sign(chainID string, privAccount acm.PrivateAccount) {
-	tx.Input.PubKey = privAccount.PublicKey()
+	tx.Input.PublicKey = privAccount.PublicKey()
 	tx.Input.Signature = acm.ChainSign(privAccount, chainID, tx)
 }
 
@@ -132,10 +132,10 @@ func NewNameTx(st acm.Getter, from acm.PublicKey, name, data string, amt, fee ui
 
 func NewNameTxWithSequence(from acm.PublicKey, name, data string, amt, fee, sequence uint64) *NameTx {
 	input := &TxInput{
-		Address:  from.Address(),
-		Amount:   amt,
-		Sequence: sequence,
-		PubKey:   from,
+		Address:   from.Address(),
+		Amount:    amt,
+		Sequence:  sequence,
+		PublicKey: from,
 	}
 
 	return &NameTx{
@@ -147,7 +147,7 @@ func NewNameTxWithSequence(from acm.PublicKey, name, data string, amt, fee, sequ
 }
 
 func (tx *NameTx) Sign(chainID string, privAccount acm.PrivateAccount) {
-	tx.Input.PubKey = privAccount.PublicKey()
+	tx.Input.PublicKey = privAccount.PublicKey()
 	tx.Input.Signature = acm.ChainSign(privAccount, chainID, tx)
 }
 
@@ -176,10 +176,10 @@ func (tx *BondTx) AddInput(st acm.Getter, pubkey acm.PublicKey, amt uint64) erro
 
 func (tx *BondTx) AddInputWithSequence(pubkey acm.PublicKey, amt uint64, sequence uint64) error {
 	tx.Inputs = append(tx.Inputs, &TxInput{
-		Address:  pubkey.Address(),
-		Amount:   amt,
-		Sequence: sequence,
-		PubKey:   pubkey,
+		Address:   pubkey.Address(),
+		Amount:    amt,
+		Sequence:  sequence,
+		PublicKey: pubkey,
 	})
 	return nil
 }
@@ -201,7 +201,7 @@ func (tx *BondTx) SignInput(chainID string, i int, privAccount acm.PrivateAccoun
 	if i >= len(tx.Inputs) {
 		return fmt.Errorf("Index %v is greater than number of inputs (%v)", i, len(tx.Inputs))
 	}
-	tx.Inputs[i].PubKey = privAccount.PublicKey()
+	tx.Inputs[i].PublicKey = privAccount.PublicKey()
 	tx.Inputs[i].Signature = acm.ChainSign(privAccount, chainID, tx)
 	return nil
 }
@@ -253,10 +253,10 @@ func NewPermissionsTx(st acm.Getter, from acm.PublicKey, args ptypes.PermArgs) (
 
 func NewPermissionsTxWithSequence(from acm.PublicKey, args ptypes.PermArgs, sequence uint64) *PermissionsTx {
 	input := &TxInput{
-		Address:  from.Address(),
-		Amount:   1, // NOTE: amounts can't be 0 ...
-		Sequence: sequence,
-		PubKey:   from,
+		Address:   from.Address(),
+		Amount:    1, // NOTE: amounts can't be 0 ...
+		Sequence:  sequence,
+		PublicKey: from,
 	}
 
 	return &PermissionsTx{
@@ -266,6 +266,6 @@ func NewPermissionsTxWithSequence(from acm.PublicKey, args ptypes.PermArgs, sequ
 }
 
 func (tx *PermissionsTx) Sign(chainID string, privAccount acm.PrivateAccount) {
-	tx.Input.PubKey = privAccount.PublicKey()
+	tx.Input.PublicKey = privAccount.PublicKey()
 	tx.Input.Signature = acm.ChainSign(privAccount, chainID, tx)
 }


### PR DESCRIPTION
for return types shared by the RPC - leaving v0 only one as they were
(for now). This is for integration in Bosmarmot.
