### PR TITLE
Protect against panics in websocket process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ test: check
 
 .PHONY: test_integration
 test_integration:
-	@go get -u github.com/monax/keys/cmd/monax-keys
+	@go get -u github.com/monax/bosmarmot/keys/cmd/monax-keys
 	@go test ./keys/integration -tags integration
 	@go test ./rpc/tm/integration -tags integration
 


### PR DESCRIPTION
This is an updated version of: https://github.com/hyperledger/burrow/pull/625

We seem to be protected from panics on 1337 in the `JSONService` already