### PR TITLE
Hotfix BlockCache accumulating writes when it shouldn't

### DIFF
--- a/consensus/tendermint/abci/app.go
+++ b/consensus/tendermint/abci/app.go
@@ -178,6 +178,8 @@ func (app *abciApp) Commit() abci_types.ResponseCommit {
 			Log:  fmt.Sprintf("Could not commit block: %s", err),
 		}
 	}
+	// Just kill the cache - it is badly implemented
+	app.committer.Reset()
 
 	logging.InfoMsg(app.logger, "Resetting transaction check cache")
 	app.checker.Reset()


### PR DESCRIPTION
This is a near-term fix for #713. Rather than accumulating a cache across block we just maintain it while a single block of transactions are being applied. This does not logically effect the result of a block.