### PR TITLE
fix key management on known accounts; add chain name flags

### DIFF
--- a/cmd/burrow/main.go
+++ b/cmd/burrow/main.go
@@ -82,8 +82,9 @@ func main() {
 			rootOpt := cmd.IntOpt("r root-accounts", 0, "Number of preset Root type accounts")
 			developerOpt := cmd.IntOpt("d developer-accounts", 0, "Number of preset Developer type accounts")
 			participantsOpt := cmd.IntOpt("p participant-accounts", 1, "Number of preset Participant type accounts")
+			chainNameOpt := cmd.StringOpt("n chain-name", "", "Default chain name")
 
-			cmd.Spec = "[--full-accounts] [--validator-accounts] [--root-accounts] [--developer-accounts] [--participant-accounts] [--toml]"
+			cmd.Spec = "[--full-accounts] [--validator-accounts] [--root-accounts] [--developer-accounts] [--participant-accounts] [--chain-name] [--toml]"
 
 			cmd.Action = func() {
 				specs := make([]spec.GenesisSpec, 0, *participantsOpt+*fullOpt)
@@ -103,6 +104,7 @@ func main() {
 					specs = append(specs, spec.ParticipantAccount(i))
 				}
 				genesisSpec := spec.MergeGenesisSpecs(specs...)
+				genesisSpec.ChainName = *chainNameOpt
 				if *tomlOpt {
 					os.Stdout.WriteString(source.TOMLString(genesisSpec))
 				} else {
@@ -142,9 +144,11 @@ func main() {
 				"including logging opcodes and dumping EVM tokens to disk these can be later pruned from the "+
 				"generated config.")
 
+			chainNameOpt := cmd.StringOpt("n chain-name", "", "Default chain name")
+
 			cmd.Spec = "[--keys-url=<keys URL>] [--genesis-spec=<GenesisSpec file> | --genesis-doc=<GenesisDoc file>] " +
-				"[--validator-index=<index>] [--toml-in] [--json-out] [--logging=<logging program>] " +
-				"[--describe-logging] [--debug]"
+				"[--validator-index=<index>] [--chain-name] [--toml-in] [--json-out] " +
+				"[--logging=<logging program>] [--describe-logging] [--debug]"
 
 			cmd.Action = func() {
 				conf := config.DefaultBurrowConfig()
@@ -224,6 +228,8 @@ func main() {
 						VMOptions: []execution.VMOption{execution.DumpTokens, execution.DebugOpcodes},
 					}
 				}
+
+				conf.GenesisDoc.ChainName = *chainNameOpt
 
 				if *jsonOutOpt {
 					os.Stdout.WriteString(conf.JSONString())

--- a/genesis/spec/genesis_spec.go
+++ b/genesis/spec/genesis_spec.go
@@ -127,11 +127,12 @@ func (ta TemplateAccount) RealisePubKeyAndAddress(keyClient keys.KeyClient) (pub
 			return
 		}
 	} else {
-		address := ta.PublicKey.Address()
+		address = ta.PublicKey.Address()
 		if ta.Address != nil && *ta.Address != address {
 			err = fmt.Errorf("template address %s does not match public key derived address %s", ta.Address,
 				ta.PublicKey)
 		}
+		pubKey = *ta.PublicKey
 	}
 	return
 }


### PR DESCRIPTION
this PR integrates two changes:

* the addition of a `--chain-name` flag to both `burrow configure` and `burrow spec`. since we write the output via both commands, it should be overwrite-able by both commands. if we want to only allow the flag to exist in one place it should go in `burrow configure` rather than in burrow spec.
* fixing of a problem when the genesisSpec was given known accounts. the result of those known account|pubKeys were not properly passed through the parser. 