### PR TITLE
Add install_db target and dirty hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SHELL := /bin/bash
 REPO := $(shell pwd)
 GOFILES_NOVENDOR := $(shell go list -f "{{.Dir}}" ./...)
 PACKAGES_NOVENDOR := $(shell go list ./...)
-COMMIT := $(shell git rev-parse --short HEAD)
+COMMIT := $(shell ./scripts/commit_hash.sh)
 # Bosmarmot integration testing
 BOSMARMOT_PROJECT := github.com/monax/bosmarmot
 BOSMARMOT_GOPATH := ${REPO}/.gopath_bos
@@ -101,6 +101,10 @@ build_race:	check build_race_db build_race_client
 .PHONY: build_db
 build_db:
 	go build -ldflags "-X github.com/hyperledger/burrow/project.commit=${COMMIT}" -o ${REPO}/bin/burrow ./cmd/burrow
+
+.PHONY: install_db
+install_db: build_db
+	cp ${REPO}/bin/burrow ${GOPATH}/bin/burrow
 
 # build burrow-client
 .PHONY: build_client

--- a/scripts/commit_hash.sh
+++ b/scripts/commit_hash.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Gets the git commit hash of the working dir and adds an additional hash of any tracked modified files
+commit=$(git describe --tags)
+dirty=$(git ls-files -m)
+if [[ -n ${dirty} ]]; then
+    commit="$commit+dirty.$(echo ${dirty} | git hash-object --stdin | head -c8)"
+fi
+echo "$commit"
+


### PR DESCRIPTION
Add install_db make target and a hash summarising any tracked changes in
the working directory that will be added to burrow --version output when
burrow is build with a dirty working dir - useful for distinguishing
builds against uncommitted code.