### PR TITLE
Fixed URL for glide in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Burrow has been architected with a longer term vision on security and data priva
 `burrow` is intended to be used by the `monax chains` command via [monax](https://monax.io/docs). Available commands such as `make | start | stop | logs | inspect | update` are used for chain lifecycle management.
 
 ### For Developers
-Dependency management for Burrow is managed with [glide](github.com/Masterminds/glide), and you can build Burrow from source by following
+Dependency management for Burrow is managed with [glide](https://github.com/Masterminds/glide), and you can build Burrow from source by following
 
 - [Install go](https://golang.org/doc/install)
 - Ensure you have `gmp` installed (`sudo apt-get install libgmp3-dev || brew install gmp`)


### PR DESCRIPTION
Without https - the URL was resolved as https://github.com/hyperledger/burrow/blob/master/github.com/Masterminds/glide - which was 404

Signed-off-by: Mandar Vaze <mandarvaze@gmail.com>