### PR TITLE
Fixed link to DEVELOPER_CERTIFICATE_OF_ORIGIN.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Forked from Docker's [contributing guidelines](https://github.com/docker/docker/
 
 ## Developer Certificate of Origin
 
-Please always include "signed-off-by" in your commit message and note this constitutes a developer certification you are contributing a patch under Apache 2.0.  Please find a verbatim copy of the Developer Certificate of Origin in this repository [here](.github/DEVELOPER_CERTIFICATE_OF_ORIGIN.md) or on [developercertificate.org](https://developercertificate.org/).
+Please always include "signed-off-by" in your commit message and note this constitutes a developer certification you are contributing a patch under Apache 2.0.  Please find a verbatim copy of the Developer Certificate of Origin in this repository [here](DEVELOPER_CERTIFICATE_OF_ORIGIN.md) or on [developercertificate.org](https://developercertificate.org/).
 
 ## Bug Reporting
 


### PR DESCRIPTION
an extra `.github` lead to https://github.com/hyperledger/burrow/blob/master/.github/.github/DEVELOPER_CERTIFICATE_OF_ORIGIN.md which was 404

Signed-off-by: Mandar Vaze <mandarvaze@gmail.com>