### PR TITLE
Ensure that the full tendermint commit phase has finished before accepting new transactions

### DIFF
--- a/account/state/state_cache.go
+++ b/account/state/state_cache.go
@@ -91,7 +91,6 @@ func (cache *stateCache) UpdateAccount(account acm.Account) error {
 	}
 	accInfo.account = account
 	accInfo.updated = true
-
 	return nil
 }
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -52,6 +52,8 @@ type Tip interface {
 
 // Burrow's portion of the Blockchain state
 type Blockchain interface {
+	// Read locker
+	sync.Locker
 	Root
 	Tip
 	// Returns an immutable copy of the tip

--- a/consensus/tendermint/abci/app.go
+++ b/consensus/tendermint/abci/app.go
@@ -2,6 +2,7 @@ package abci
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	bcm "github.com/hyperledger/burrow/blockchain"
@@ -17,11 +18,12 @@ import (
 
 const responseInfoName = "Burrow"
 
-type abciApp struct {
+type App struct {
 	// State
-	blockchain bcm.MutableBlockchain
-	checker    execution.BatchExecutor
-	committer  execution.BatchCommitter
+	blockchain    bcm.MutableBlockchain
+	checker       execution.BatchExecutor
+	committer     execution.BatchCommitter
+	mempoolLocker sync.Locker
 	// We need to cache these from BeginBlock for when we need actually need it in Commit
 	block *abci_types.RequestBeginBlock
 	// Utility
@@ -30,11 +32,13 @@ type abciApp struct {
 	logger *logging.Logger
 }
 
+var _ abci_types.Application = &App{}
+
 func NewApp(blockchain bcm.MutableBlockchain,
 	checker execution.BatchExecutor,
 	committer execution.BatchCommitter,
-	logger *logging.Logger) abci_types.Application {
-	return &abciApp{
+	logger *logging.Logger) *App {
+	return &App{
 		blockchain: blockchain,
 		checker:    checker,
 		committer:  committer,
@@ -43,7 +47,14 @@ func NewApp(blockchain bcm.MutableBlockchain,
 	}
 }
 
-func (app *abciApp) Info(info abci_types.RequestInfo) abci_types.ResponseInfo {
+// Provide the Mempool lock. When provided we will attempt to acquire this lock in a goroutine during the Commit. We
+// will keep the checker cache locked until we are able to acquire the mempool lock which signals the end of the commit
+// and possible recheck on Tendermint's side.
+func (app *App) SetMempoolLocker(mempoolLocker sync.Locker) {
+	app.mempoolLocker = mempoolLocker
+}
+
+func (app *App) Info(info abci_types.RequestInfo) abci_types.ResponseInfo {
 	tip := app.blockchain.Tip()
 	return abci_types.ResponseInfo{
 		Data:             responseInfoName,
@@ -53,19 +64,19 @@ func (app *abciApp) Info(info abci_types.RequestInfo) abci_types.ResponseInfo {
 	}
 }
 
-func (app *abciApp) SetOption(option abci_types.RequestSetOption) (respSetOption abci_types.ResponseSetOption) {
+func (app *App) SetOption(option abci_types.RequestSetOption) (respSetOption abci_types.ResponseSetOption) {
 	respSetOption.Log = "SetOption not supported"
 	respSetOption.Code = codes.UnsupportedRequestCode
 	return
 }
 
-func (app *abciApp) Query(reqQuery abci_types.RequestQuery) (respQuery abci_types.ResponseQuery) {
+func (app *App) Query(reqQuery abci_types.RequestQuery) (respQuery abci_types.ResponseQuery) {
 	respQuery.Log = "Query not supported"
 	respQuery.Code = codes.UnsupportedRequestCode
 	return
 }
 
-func (app *abciApp) CheckTx(txBytes []byte) abci_types.ResponseCheckTx {
+func (app *App) CheckTx(txBytes []byte) abci_types.ResponseCheckTx {
 	tx, err := app.txDecoder.DecodeTx(txBytes)
 	if err != nil {
 		app.logger.TraceMsg("CheckTx decoding error",
@@ -76,7 +87,6 @@ func (app *abciApp) CheckTx(txBytes []byte) abci_types.ResponseCheckTx {
 			Log:  fmt.Sprintf("Encoding error: %s", err),
 		}
 	}
-	// TODO: map ExecTx errors to sensible ABCI error codes
 	receipt := txs.GenerateReceipt(app.blockchain.ChainID(), tx)
 
 	err = app.checker.Execute(tx)
@@ -104,17 +114,17 @@ func (app *abciApp) CheckTx(txBytes []byte) abci_types.ResponseCheckTx {
 	}
 }
 
-func (app *abciApp) InitChain(chain abci_types.RequestInitChain) (respInitChain abci_types.ResponseInitChain) {
+func (app *App) InitChain(chain abci_types.RequestInitChain) (respInitChain abci_types.ResponseInitChain) {
 	// Could verify agreement on initial validator set here
 	return
 }
 
-func (app *abciApp) BeginBlock(block abci_types.RequestBeginBlock) (respBeginBlock abci_types.ResponseBeginBlock) {
+func (app *App) BeginBlock(block abci_types.RequestBeginBlock) (respBeginBlock abci_types.ResponseBeginBlock) {
 	app.block = &block
 	return
 }
 
-func (app *abciApp) DeliverTx(txBytes []byte) abci_types.ResponseDeliverTx {
+func (app *App) DeliverTx(txBytes []byte) abci_types.ResponseDeliverTx {
 	tx, err := app.txDecoder.DecodeTx(txBytes)
 	if err != nil {
 		app.logger.TraceMsg("DeliverTx decoding error",
@@ -152,12 +162,12 @@ func (app *abciApp) DeliverTx(txBytes []byte) abci_types.ResponseDeliverTx {
 	}
 }
 
-func (app *abciApp) EndBlock(reqEndBlock abci_types.RequestEndBlock) (respEndBlock abci_types.ResponseEndBlock) {
+func (app *App) EndBlock(reqEndBlock abci_types.RequestEndBlock) (respEndBlock abci_types.ResponseEndBlock) {
 	// Validator mutation goes here
 	return
 }
 
-func (app *abciApp) Commit() abci_types.ResponseCommit {
+func (app *App) Commit() abci_types.ResponseCommit {
 	tip := app.blockchain.Tip()
 	app.logger.InfoMsg("Committing block",
 		"tag", "Commit",
@@ -169,12 +179,31 @@ func (app *abciApp) Commit() abci_types.ResponseCommit {
 		"last_block_time", tip.LastBlockTime(),
 		"last_block_hash", tip.LastBlockHash())
 
-	// Commit state before resetting check cache so that the emptied cache servicing some RPC requests will fall through
-	// to committed state when check state is reset
-	// TODO: determine why the ordering of updates does not experience invalid sequence number during recheck. It
-	// seems there is nothing to stop a Transact transaction from querying the checker cache before it has been replayed
-	// all transactions and so would formulate a transaction with the same sequence number as one in mempool.
-	// However this is not observed in v0_tests.go - we need to understand why or create a test that exposes this
+	// Lock the checker while we reset it and possibly while recheckTxs replays transactions
+	app.checker.Lock()
+	defer func() {
+		// Tendermint may replay transactions to the check cache during a recheck, which happens after we have returned
+		// from Commit(). The mempool is locked by Tendermint for the duration of the commit phase; during Commit() and
+		// the subsequent mempool.Update() so we schedule an acquisition of the mempool lock in a goroutine in order to
+		// 'observe' the mempool unlock event that happens later on. By keeping the checker read locked during that
+		// period we can ensure that anything querying the checker (such as service.MempoolAccounts()) will block until
+		// the full Tendermint commit phase has completed.
+		if app.mempoolLocker != nil {
+			go func() {
+				// we won't get this until after the commit and we will acquire strictly after this commit phase has
+				// ended (i.e. when Tendermint's BlockExecutor.Commit() returns
+				app.mempoolLocker.Lock()
+				// Prevent any mempool getting relocked while we unlock - we could just unlock immediately but if a new
+				// commit starts gives goroutines blocked on checker a chance to progress before the next commit phase
+				defer app.mempoolLocker.Unlock()
+				app.checker.Unlock()
+			}()
+		} else {
+			// If we have not be provided with access to the mempool lock
+			app.checker.Unlock()
+		}
+	}()
+
 	appHash, err := app.committer.Commit()
 	if err != nil {
 		return abci_types.ResponseCommit{
@@ -213,7 +242,6 @@ func (app *abciApp) Commit() abci_types.ResponseCommit {
 				app.blockchain.LastBlockHeight(), app.block.Header.Height),
 		}
 	}
-
 	return abci_types.ResponseCommit{
 		Code: codes.TxExecutionSuccessCode,
 		Data: appHash,

--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -55,8 +55,8 @@ func NewNode(
 	// disable Tendermint's RPC
 	conf.RPC.ListenAddress = ""
 
-	app := abci.NewApp(blockchain, checker, committer, logger)
 	nde := &Node{}
+	app := abci.NewApp(blockchain, checker, committer, logger)
 	nde.Node, err = node.NewNode(conf, privValidator,
 		proxy.NewLocalClientCreator(app),
 		func() (*tm_types.GenesisDoc, error) {
@@ -68,6 +68,7 @@ func NewNode(
 	if err != nil {
 		return nil, err
 	}
+	app.SetMempoolLocker(nde.MempoolReactor().Mempool)
 	return nde, nil
 }
 

--- a/core/integration/test_wrapper.go
+++ b/core/integration/test_wrapper.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hyperledger/burrow/logging"
 	"github.com/hyperledger/burrow/logging/config"
 	"github.com/hyperledger/burrow/logging/lifecycle"
+	"github.com/hyperledger/burrow/logging/structure"
 	"github.com/hyperledger/burrow/permission"
 	"github.com/hyperledger/burrow/rpc"
 	tm_config "github.com/tendermint/tendermint/config"
@@ -62,13 +63,8 @@ func TestWrapper(privateAccounts []acm.PrivateAccount, genesisDoc *genesis.Genes
 			ExcludeTrace: false,
 			RootSink: config.Sink().
 				SetTransform(config.FilterTransform(config.IncludeWhenAnyMatches,
-					//"","",
-					"method", "GetAccount",
-					"method", "BroadcastTx",
-					"tag", "sequence",
-					"tag", "Commit",
-					"tag", "CheckTx",
-					"tag", "DeliverTx",
+					structure.ComponentKey, "Tendermint",
+					structure.ScopeKey, "executor.Execute\\(tx txs.Tx\\)",
 				)).
 				//AddSinks(config.Sink().SetTransform(config.FilterTransform(config.ExcludeWhenAnyMatches, "run_call", "false")).
 				AddSinks(config.Sink().SetTransform(config.PruneTransform("log_channel", "trace", "scope", "returns", "run_id", "args")).

--- a/core/kernel.go
+++ b/core/kernel.go
@@ -105,7 +105,7 @@ func NewKernel(ctx context.Context, keyClient keys.KeyClient, privValidator tm_t
 		logger)
 
 	nameReg := state
-	service := rpc.NewService(ctx, state, nameReg, checker, committer, emitter, blockchain, keyClient, transactor,
+	service := rpc.NewService(ctx, state, nameReg, checker, emitter, blockchain, keyClient, transactor,
 		query.NewNodeView(tmNode, txCodec), logger)
 
 	launchers := []process.Launcher{

--- a/execution/accounts.go
+++ b/execution/accounts.go
@@ -10,6 +10,8 @@ import (
 	burrow_sync "github.com/hyperledger/burrow/sync"
 )
 
+// Accounts pairs an underlying state.Reader with a KeyClient to provide a signing variant of an account
+// it also maintains a lock over addresses to provide a linearisation of signing events using SequentialSigningAccount
 type Accounts struct {
 	burrow_sync.RingMutex
 	state.Reader
@@ -35,7 +37,7 @@ func NewAccounts(reader state.Reader, keyClient keys.KeyClient, mutexCount int) 
 	}
 }
 func (accs *Accounts) SigningAccount(address acm.Address, signer acm.Signer) (*SigningAccount, error) {
-	account, err := state.GetMutableAccount(accs.Reader, address)
+	account, err := state.GetMutableAccount(accs, address)
 	if err != nil {
 		return nil, err
 	}

--- a/execution/events/events.go
+++ b/execution/events/events.go
@@ -71,8 +71,8 @@ func SubscribeAccountOutputSendTx(ctx context.Context, subscribable event.Subscr
 		AndEquals(event.TxHashKey, hex.EncodeUpperToString(txHash))
 
 	return event.SubscribeCallback(ctx, subscribable, subscriber, query, func(message interface{}) bool {
-		if eventDataCall, ok := message.(*EventDataTx); ok {
-			if sendTx, ok := eventDataCall.Tx.(*txs.SendTx); ok {
+		if edt, ok := message.(*EventDataTx); ok {
+			if sendTx, ok := edt.Tx.(*txs.SendTx); ok {
 				ch <- sendTx
 			}
 		}

--- a/rpc/tm/methods.go
+++ b/rpc/tm/methods.go
@@ -80,7 +80,7 @@ func GetRoutes(service *rpc.Service, logger *logging.Logger) map[string]*gorpc.R
 
 		// Simulated call
 		Call: gorpc.NewRPCFunc(func(fromAddress, toAddress acm.Address, data []byte) (*rpc.ResultCall, error) {
-			call, err := service.Transactor().Call(service.Accounts(), fromAddress, toAddress, data)
+			call, err := service.Transactor().Call(service.State(), fromAddress, toAddress, data)
 			if err != nil {
 				return nil, err
 			}
@@ -88,7 +88,7 @@ func GetRoutes(service *rpc.Service, logger *logging.Logger) map[string]*gorpc.R
 		}, "fromAddress,toAddress,data"),
 
 		CallCode: gorpc.NewRPCFunc(func(fromAddress acm.Address, code, data []byte) (*rpc.ResultCall, error) {
-			call, err := service.Transactor().CallCode(service.Accounts(), fromAddress, code, data)
+			call, err := service.Transactor().CallCode(service.State(), fromAddress, code, data)
 			if err != nil {
 				return nil, err
 			}

--- a/rpc/v0/integration/v0_test.go
+++ b/rpc/v0/integration/v0_test.go
@@ -63,7 +63,7 @@ func TestTransactCallNoCode(t *testing.T) {
 
 func TestTransactCreate(t *testing.T) {
 	numGoroutines := 100
-	numCreates := 10
+	numCreates := 50
 	wg := new(sync.WaitGroup)
 	wg.Add(numGoroutines)
 	cli := v0.NewV0Client("http://localhost:1337/rpc")


### PR DESCRIPTION
This PR uses a `RWMutex` on the `executor` (i.e. the checker) to make transactor calls wait until Tendermint's commit phase has ended. Our ABCI app acquires the mempool lock as a signal that the commit phase has ended.

The mechanism is as follows:

The `checker` (an `executor`) contains a `StateCache`. The `checker` is passed to the ABCI `App` and also to the `Service`. In the app `CheckTx` updates the checker's state via calls to `Execute`. The checker has a RWMutex and when the checkers `state.Reader` methods are called it acquires a read lock. The write lock however is controlled externally (this allows us to block reads while we update).

The app locks the checker during commit and schedule it to be unlocked as soon as we area able to acquire a lock on tendermint's mempool. The service wraps the checker in an `Accounts` object and the `Transactor` is passed this object. When the `Transactor` tries to sign a transaction it queries the checker it has been passed to get the sequence number. If the checker is locked then this call blocks and this is how we avoid transact calls concurrent with a mempool update (which would result in us signing with a previous sequence number).

Anything that wants to read synchronised mempool state should use the checker. 

