### PR TITLE
Disable authenticated peer connections 

### DIFF
--- a/consensus/tendermint/config.go
+++ b/consensus/tendermint/config.go
@@ -33,6 +33,7 @@ func (btc *BurrowTendermintConfig) TendermintConfig() *tm_config.Config {
 		conf.P2P.RootDir = btc.TendermintRoot
 		conf.P2P.Seeds = btc.Seeds
 		conf.P2P.ListenAddress = btc.ListenAddress
+		conf.P2P.AuthEnc = false
 		conf.Moniker = btc.Moniker
 	}
 	// Disable Tendermint RPC


### PR DESCRIPTION
To preserve pre-Tendermint-0.16.0 behaviour in private validator pool.
