### PR TITLE
Add file and json logging instructions.

### DIFF
--- a/logging/config/presets/instructions_test.go
+++ b/logging/config/presets/instructions_test.go
@@ -39,3 +39,13 @@ func TestMinimalPreset(t *testing.T) {
 	//fmt.Println(config.TOMLString(expectedSink), "\n", config.TOMLString(builtSink))
 	assert.Equal(t, config.TOMLString(expectedSink), config.TOMLString(builtSink))
 }
+
+func TestFileOutput(t *testing.T) {
+	path := "foo.log"
+	builtSink, err := BuildSinkConfig(Down, File, path, JSON)
+	require.NoError(t, err)
+	expectedSink := config.Sink().
+		AddSinks(config.Sink().SetOutput(config.FileOutput(path).SetFormat(loggers.JSONFormat)))
+	//fmt.Println(config.TOMLString(expectedSink), "\n", config.TOMLString(builtSink))
+	assert.Equal(t, config.TOMLString(expectedSink), config.TOMLString(builtSink))
+}


### PR DESCRIPTION
With this change, running `burrow configure -l json,file,/tmp/foo.log` produces a burrow config containing:

```toml
[Logging]
  ExcludeTrace = false
  NonBlocking = false
  [Logging.RootSink]
    [Logging.RootSink.Output]
      OutputType = "file"
      Format = "json"
      Path = "/tmp/foo.log"
```