### PR TITLE
Ensure storing zero value removes the key rather than panics

### DIFF
--- a/account/state/state.go
+++ b/account/state/state.go
@@ -33,7 +33,7 @@ type StorageGetter interface {
 }
 
 type StorageSetter interface {
-	// Store a 32-byte value at key for the account at address
+	// Store a 32-byte value at key for the account at address, setting to Zero256 removes the key
 	SetStorage(address acm.Address, key, value binary.Word256) error
 }
 

--- a/execution/state.go
+++ b/execution/state.go
@@ -235,7 +235,11 @@ func (s *State) GetStorage(address acm.Address, key binary.Word256) (binary.Word
 func (s *State) SetStorage(address acm.Address, key, value binary.Word256) error {
 	s.Lock()
 	defer s.Unlock()
-	s.tree.Set(prefixedKey(storagePrefix, address.Bytes(), key.Bytes()), value.Bytes())
+	if value == binary.Zero256 {
+		s.tree.Remove(key.Bytes())
+	} else {
+		s.tree.Set(prefixedKey(storagePrefix, address.Bytes(), key.Bytes()), value.Bytes())
+	}
 	return nil
 }
 


### PR DESCRIPTION
`SetStorage` with a zero value is meant to indicate removal but in new IAVL would cause a panic. This resolves that by calling remove on underlying tree when a nil value is passed to execution state

See: https://github.com/hyperledger/burrow/blob/develop/vendor/github.com/tendermint/iavl/tree.go#L92