### PR TITLE
Network spec

### DIFF
--- a/config/source/source.go
+++ b/config/source/source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/cep21/xdgbasedir"
 	"github.com/imdario/mergo"
+	"regexp"
 )
 
 // If passed this identifier try to read config from STDIN
@@ -30,6 +31,16 @@ type ConfigProvider interface {
 }
 
 var _ ConfigProvider = &configSource{}
+
+type Format string
+
+const (
+	JSON    Format = "JSON"
+	TOML    Format = "TOML"
+	Unknown Format = ""
+)
+
+var jsonRegex = regexp.MustCompile(`\s*{`)
 
 type configSource struct {
 	from  string
@@ -116,26 +127,14 @@ func EachOf(providers ...ConfigProvider) *configSource {
 	return Cascade(os.Stderr, false, providers...)
 }
 
-// Try to source config from provided JSON file, is skipNonExistent is true then the provider will fall-through (skip)
-// when the file doesn't exist, rather than returning an error
-func JSONFile(configFile string, skipNonExistent bool) *configSource {
+// Try to source config from provided file detecting the file format, is skipNonExistent is true then the provider will
+// fall-through (skip) when the file doesn't exist, rather than returning an error
+func File(configFile string, skipNonExistent bool) *configSource {
 	return &configSource{
 		skip: ShouldSkipFile(configFile, skipNonExistent),
 		from: fmt.Sprintf("JSON config file at '%s'", configFile),
 		apply: func(baseConfig interface{}) error {
-			return FromJSONFile(configFile, baseConfig)
-		},
-	}
-}
-
-// Try to source config from provided TOML file, is skipNonExistent is true then the provider will fall-through (skip)
-// when the file doesn't exist, rather than returning an error
-func TOMLFile(configFile string, skipNonExistent bool) *configSource {
-	return &configSource{
-		skip: ShouldSkipFile(configFile, skipNonExistent),
-		from: fmt.Sprintf("TOML config file at '%s'", configFile),
-		apply: func(baseConfig interface{}) error {
-			return FromTOMLFile(configFile, baseConfig)
+			return FromFile(configFile, baseConfig)
 		},
 	}
 }
@@ -157,7 +156,7 @@ func XDGBaseDir(configFileName string) *configSource {
 			if err != nil {
 				return err
 			}
-			return FromTOMLFile(configFile, baseConfig)
+			return FromFile(configFile, baseConfig)
 		},
 	}
 }
@@ -183,22 +182,13 @@ func Default(defaultConfig interface{}) *configSource {
 	}
 }
 
-func FromJSONFile(configFile string, conf interface{}) error {
+func FromFile(configFile string, conf interface{}) error {
 	bs, err := ReadFile(configFile)
 	if err != nil {
 		return err
 	}
 
-	return FromJSONString(string(bs), conf)
-}
-
-func FromTOMLFile(configFile string, conf interface{}) error {
-	bs, err := ReadFile(configFile)
-	if err != nil {
-		return err
-	}
-
-	return FromTOMLString(string(bs), conf)
+	return FromString(string(bs), conf)
 }
 
 func FromTOMLString(tomlString string, conf interface{}) error {
@@ -207,6 +197,24 @@ func FromTOMLString(tomlString string, conf interface{}) error {
 		return err
 	}
 	return nil
+}
+
+func FromString(configString string, conf interface{}) error {
+	switch DetectFormat(configString) {
+	case JSON:
+		return FromJSONString(configString, conf)
+	case TOML:
+		return FromTOMLString(configString, conf)
+	default:
+		return fmt.Errorf("unknown configuration format:\n%s", configString)
+	}
+}
+
+func DetectFormat(configString string) Format {
+	if jsonRegex.MatchString(configString) {
+		return JSON
+	}
+	return TOML
 }
 
 func FromJSONString(jsonString string, conf interface{}) error {

--- a/config/source/source_test.go
+++ b/config/source/source_test.go
@@ -31,7 +31,7 @@ func TestFile(t *testing.T) {
 	file := writeConfigFile(t, newTestConfig())
 	defer os.Remove(file)
 	conf := new(animalConfig)
-	err := TOMLFile(file, false).Apply(conf)
+	err := File(file, false).Apply(conf)
 	assert.NoError(t, err)
 	assert.Equal(t, tomlString, TOMLString(conf))
 }
@@ -42,7 +42,7 @@ func TestCascade(t *testing.T) {
 	conf := newTestConfig()
 	err := Cascade(os.Stderr, true,
 		Environment(envVar),
-		TOMLFile("", false)).Apply(conf)
+		File("", false)).Apply(conf)
 	assert.NoError(t, err)
 	assert.Equal(t, newTestConfig(), conf)
 
@@ -53,7 +53,7 @@ func TestCascade(t *testing.T) {
 	conf = new(animalConfig)
 	err = Cascade(os.Stderr, true,
 		Environment(envVar),
-		TOMLFile(file, false)).Apply(conf)
+		File(file, false)).Apply(conf)
 	assert.NoError(t, err)
 	assert.Equal(t, TOMLString(fileConfig), TOMLString(conf))
 
@@ -66,9 +66,16 @@ func TestCascade(t *testing.T) {
 	conf = newTestConfig()
 	err = Cascade(os.Stderr, true,
 		Environment(envVar),
-		TOMLFile(file, false)).Apply(conf)
+		File(file, false)).Apply(conf)
 	assert.NoError(t, err)
 	assert.Equal(t, TOMLString(envConfig), TOMLString(conf))
+}
+
+func TestDetectFormat(t *testing.T) {
+	assert.Equal(t, TOML, DetectFormat(""))
+	assert.Equal(t, JSON, DetectFormat("{"))
+	assert.Equal(t, JSON, DetectFormat("\n\n\t    \n\n      {"))
+	assert.Equal(t, TOML, DetectFormat("[Tendermint]\n  Seeds =\"foobar@val0\"}"))
 }
 
 func writeConfigFile(t *testing.T, conf interface{}) string {

--- a/keys/mock/key_client_mock.go
+++ b/keys/mock/key_client_mock.go
@@ -18,11 +18,18 @@ import (
 	"crypto/rand"
 	"fmt"
 
+	"bytes"
+	"text/template"
+
+	"encoding/base64"
+
 	acm "github.com/hyperledger/burrow/account"
 	. "github.com/hyperledger/burrow/keys"
 	"github.com/tendermint/ed25519"
 	crypto "github.com/tendermint/go-crypto"
+	"github.com/tmthrgd/go-hex"
 	"golang.org/x/crypto/ripemd160"
+	"github.com/pkg/errors"
 )
 
 //---------------------------------------------------------------------
@@ -30,14 +37,35 @@ import (
 
 // Simple ed25519 key structure for mock purposes with ripemd160 address
 type MockKey struct {
+	Name       string
 	Address    acm.Address
-	PrivateKey [ed25519.PrivateKeySize]byte
 	PublicKey  []byte
+	PrivateKey []byte
 }
 
-func newMockKey() (*MockKey, error) {
+const DefaultDumpKeysFormat = `{
+  "Keys": [<< range $index, $key := . >><< if $index>>,<< end >>
+    {
+      "Name": "<< $key.Name >>",
+      "Address": "<< $key.Address >>",
+      "PublicKey": "<< $key.PublicKeyBase64 >>",
+      "PrivateKey": "<< $key.PrivateKeyBase64 >>"
+    }<< end >>
+  ]
+}`
+
+const LeftTemplateDelim = "<<"
+const RightTemplateDelim = ">>"
+
+var DefaultDumpKeysTemplate = template.Must(template.New("MockKeyClient_DumpKeys").
+	Delims(LeftTemplateDelim, RightTemplateDelim).
+	Parse(DefaultDumpKeysFormat))
+
+func newMockKey(name string) (*MockKey, error) {
 	key := &MockKey{
-		PublicKey: make([]byte, ed25519.PublicKeySize),
+		Name:       name,
+		PublicKey:  make([]byte, ed25519.PublicKeySize),
+		PrivateKey: make([]byte, ed25519.PrivateKeySize),
 	}
 	// this is a mock key, so the entropy of the source is purely
 	// for testing
@@ -65,15 +93,34 @@ func mockKeyFromPrivateAccount(privateAccount acm.PrivateAccount) *MockKey {
 		panic(fmt.Errorf("mock key client only supports ed25519 private keys at present"))
 	}
 	key := &MockKey{
-		Address:   privateAccount.Address(),
-		PublicKey: privateAccount.PublicKey().RawBytes(),
+		Name:       privateAccount.Address().String(),
+		Address:    privateAccount.Address(),
+		PublicKey:  privateAccount.PublicKey().RawBytes(),
+		PrivateKey: privateAccount.PrivateKey().RawBytes(),
 	}
-	copy(key.PrivateKey[:], privateAccount.PrivateKey().RawBytes())
 	return key
 }
 
 func (mockKey *MockKey) Sign(message []byte) (acm.Signature, error) {
-	return acm.SignatureFromBytes(ed25519.Sign(&mockKey.PrivateKey, message)[:])
+	var privateKey [ed25519.PrivateKeySize]byte
+	copy(privateKey[:], mockKey.PrivateKey)
+	return acm.SignatureFromBytes(ed25519.Sign(&privateKey, message)[:])
+}
+
+func (mockKey *MockKey) PrivateKeyBase64() string {
+	return base64.StdEncoding.EncodeToString(mockKey.PrivateKey[:])
+}
+
+func (mockKey *MockKey) PrivateKeyHex() string {
+	return hex.EncodeUpperToString(mockKey.PrivateKey[:])
+}
+
+func (mockKey *MockKey) PublicKeyBase64() string {
+	return base64.StdEncoding.EncodeToString(mockKey.PublicKey)
+}
+
+func (mockKey *MockKey) PublicKeyHex() string {
+	return hex.EncodeUpperToString(mockKey.PublicKey)
 }
 
 //---------------------------------------------------------------------
@@ -96,26 +143,26 @@ func NewMockKeyClient(privateAccounts ...acm.PrivateAccount) *MockKeyClient {
 	return client
 }
 
-func (mock *MockKeyClient) NewKey() acm.Address {
+func (mkc *MockKeyClient) NewKey(name string) acm.Address {
 	// Only tests ED25519 curve and ripemd160.
-	key, err := newMockKey()
+	key, err := newMockKey(name)
 	if err != nil {
 		panic(fmt.Sprintf("Mocked key client failed on key generation: %s", err))
 	}
-	mock.knownKeys[key.Address] = key
+	mkc.knownKeys[key.Address] = key
 	return key.Address
 }
 
-func (mock *MockKeyClient) Sign(signAddress acm.Address, message []byte) (acm.Signature, error) {
-	key := mock.knownKeys[signAddress]
+func (mkc *MockKeyClient) Sign(signAddress acm.Address, message []byte) (acm.Signature, error) {
+	key := mkc.knownKeys[signAddress]
 	if key == nil {
 		return acm.Signature{}, fmt.Errorf("Unknown address (%s)", signAddress)
 	}
 	return key.Sign(message)
 }
 
-func (mock *MockKeyClient) PublicKey(address acm.Address) (acm.PublicKey, error) {
-	key := mock.knownKeys[address]
+func (mkc *MockKeyClient) PublicKey(address acm.Address) (acm.PublicKey, error) {
+	key := mkc.knownKeys[address]
 	if key == nil {
 		return acm.PublicKey{}, fmt.Errorf("Unknown address (%s)", address)
 	}
@@ -124,10 +171,27 @@ func (mock *MockKeyClient) PublicKey(address acm.Address) (acm.PublicKey, error)
 	return acm.PublicKeyFromGoCryptoPubKey(pubKeyEd25519.Wrap())
 }
 
-func (mock *MockKeyClient) Generate(keyName string, keyType KeyType) (acm.Address, error) {
-	return mock.NewKey(), nil
+func (mkc *MockKeyClient) Generate(keyName string, keyType KeyType) (acm.Address, error) {
+	return mkc.NewKey(keyName), nil
 }
 
-func (mock *MockKeyClient) HealthCheck() error {
+func (mkc *MockKeyClient) HealthCheck() error {
 	return nil
+}
+
+func (mkc *MockKeyClient) DumpKeys(templateString string) (string, error) {
+	tmpl, err := template.New("DumpKeys").Delims(LeftTemplateDelim, RightTemplateDelim).Parse(templateString)
+	if err != nil {
+		errors.Wrap(err, "could not dump keys to template")
+	}
+	buf := new(bytes.Buffer)
+	keys := make([]*MockKey, 0, len(mkc.knownKeys))
+	for _, k := range mkc.knownKeys {
+		keys = append(keys, k)
+	}
+	err = tmpl.Execute(buf, keys)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }

--- a/keys/mock/key_client_mock_test.go
+++ b/keys/mock/key_client_mock_test.go
@@ -1,0 +1,29 @@
+package mock
+
+import (
+	"testing"
+
+	"encoding/json"
+
+	"github.com/hyperledger/burrow/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockKeyClient_DumpKeys(t *testing.T) {
+	keyClient := NewMockKeyClient()
+	_, err := keyClient.Generate("foo", keys.KeyTypeEd25519Ripemd160)
+	require.NoError(t, err)
+	_, err = keyClient.Generate("foobar", keys.KeyTypeEd25519Ripemd160)
+	require.NoError(t, err)
+	dump, err := keyClient.DumpKeys(DefaultDumpKeysFormat)
+	require.NoError(t, err)
+
+	// Check JSON equal
+	var keys struct{ Keys []*MockKey }
+	err = json.Unmarshal([]byte(dump), &keys)
+	require.NoError(t, err)
+	bs, err := json.MarshalIndent(keys, "", "  ")
+	require.NoError(t, err)
+	assert.Equal(t, string(bs), dump)
+}


### PR DESCRIPTION
This PR:

- Allows ingestion of JSON or TOML without specifying by detecting the input format
- Allows you to provide base genesis specs to merge into a final spec
- Allows the generation and output of secret keys using `burrow congfigure`

so `burrow spec -p1 | burrow configure --genesis-spec=- --separate-genesis-doc genesis.json --generate-keys keys.json` now outputs separate genesis (from a previous PR) and this for `keys.json`:

```json
{
  "Keys": [
    {
      "Name": "Full_0",
      "Address": "7432F2067106C6879615DA6E8F9CA014C9392828",
      "PublicKey": "52MU2qwSabiAlyoN2bVBGEPOQyYLeyw5xJjdJwOGIPY=",
      "PrivateKey": "llI1W+K5QMz12HG/sYbvWcktFBmLncMh+YP0GLiutDDnYxTarBJpuICXKg3ZtUEYQ85DJgt7LDnEmN0nA4Yg9g=="
    },
    {
      "Name": "Participant_0",
      "Address": "C0A4FC8E7968F9717F8530BD6126C52D3C183357",
      "PublicKey": "X9ImxdjsiEGfZtmMeWAHpVDG/LFgosPAwcot0bEpPX8=",
      "PrivateKey": "bSH4OsspagMjTRTLr5ckVOSsC3OetO25IfvW9HeaVCtf0ibF2OyIQZ9m2Yx5YAelUMb8sWCiw8DByi3RsSk9fw=="
    }
  ]
}%
```

You can also provide a Go template for the keys output, the default would look like:

```shell
--keys-template '{\
  "Keys": [<< range $index, $key := . >><< if $index>>,<< end >>\
    {\
      "Name": "<< $key.Name >>",\
      "Address": "<< $key.Address >>",\
      "PublicKey": "<< $key.PublicKeyBase64 >>",\
      "PrivateKey": "<< $key.PrivateKeyBase64 >>"\
    }<< end >>\
  ]\
}
```