### PR TITLE
Detect JSON from config file

### DIFF
--- a/config/source/source.go
+++ b/config/source/source.go
@@ -13,7 +13,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/cep21/xdgbasedir"
 	"github.com/imdario/mergo"
-	"regexp"
 )
 
 // If passed this identifier try to read config from STDIN
@@ -39,8 +38,6 @@ const (
 	TOML    Format = "TOML"
 	Unknown Format = ""
 )
-
-var jsonRegex = regexp.MustCompile(`\s*{`)
 
 type configSource struct {
 	from  string
@@ -211,7 +208,8 @@ func FromString(configString string, conf interface{}) error {
 }
 
 func DetectFormat(configString string) Format {
-	if jsonRegex.MatchString(configString) {
+	trimmed := strings.TrimSpace(configString)
+	if len(trimmed) > 0 && trimmed[0] == '{' {
 		return JSON
 	}
 	return TOML

--- a/keys/mock/key_client_mock.go
+++ b/keys/mock/key_client_mock.go
@@ -25,11 +25,11 @@ import (
 
 	acm "github.com/hyperledger/burrow/account"
 	. "github.com/hyperledger/burrow/keys"
+	"github.com/pkg/errors"
 	"github.com/tendermint/ed25519"
 	crypto "github.com/tendermint/go-crypto"
 	"github.com/tmthrgd/go-hex"
 	"golang.org/x/crypto/ripemd160"
-	"github.com/pkg/errors"
 )
 
 //---------------------------------------------------------------------


### PR DESCRIPTION
NOTE: Genesis file contains some JSON data (ex. crypto.PublicKey)
This patch is for detecting JSON format from TOML
