### PR TITLE
Fix test issues, and reorganise CLI UX. Read validator address on startup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,9 @@ build_race:	check build_race_db build_race_client
 # build burrow
 .PHONY: build_db
 build_db: commit_hash
-	go build -ldflags "-extldflags '-static' -X github.com/hyperledger/burrow/project.commit=$(shell cat commit_hash.txt)"\
-	 -o ${REPO}/bin/burrow ./cmd/burrow
+	go build -ldflags "-extldflags '-static' \
+	-X github.com/hyperledger/burrow/project.commit=$(shell cat commit_hash.txt)" \
+	-o ${REPO}/bin/burrow ./cmd/burrow
 
 .PHONY: install_db
 install_db: build_db
@@ -115,8 +116,9 @@ install_db: build_db
 # build burrow-client
 .PHONY: build_client
 build_client: commit_hash
-	go build -ldflags "-extldflags '-static' -X github.com/hyperledger/burrow/project.commit=$(shell cat commit_hash.txt)"\
-	 -o ${REPO}/bin/burrow-client ./client/cmd/burrow-client
+	go build -ldflags "-extldflags '-static' \
+	-X github.com/hyperledger/burrow/project.commit=$(shell cat commit_hash.txt)" \
+	-o ${REPO}/bin/burrow-client ./client/cmd/burrow-client
 
 # build burrow with checks for race conditions
 .PHONY: build_race_db

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ Hyperledger Burrow is a permissioned blockchain node that executes smart contrac
 - **Application Binary Interface (ABI):** transactions need to be formulated in a binary format that can be processed by the blockchain node. Current tooling provides functionality to compile, deploy and link solidity smart contracts and formulate transactions to call smart contracts on the chain.
 - **API Gateway:** Burrow exposes REST and JSON-RPC endpoints to interact with the blockchain network and the application state through broadcasting transactions, or querying the current state of the application. Websockets allow to subscribe to events, which is particularly valuable as the consensus engine and smart contract application can give unambiguously finalised results to transactions within one blocktime of about one second.
 
-## Installation
+## Project documentation and Roadmap
 
+Project information generally updated on a quarterly basis can be found on the [Hyperledger Burrow Wiki](https://wiki.hyperledger.org/projects/burrow).
+
+## Installation
 
 - [Install go](https://golang.org/doc/install) and have `$GOPATH` set
 - Ensure you have `gmp` installed (`sudo apt-get install libgmp3-dev || brew install gmp`)
@@ -32,34 +35,53 @@ make build
 
 This will build the `burrow` and `burrow-client` binaries and put them in the `bin/` directory. They can be executed from there or put wherever is convenient.
 
+You can also install `burrow` into `$GOPATH/bin` with `make install_db`,
+
 ## Usage
 
 The end result will be a `burrow.toml` that will be read in from your current working directory when starting `burrow`.
 
 ### Configuration
 
-Note: here we'll need `monax-keys` to start the keys server (TODO, where?)
+#### Install monax-keys
+Monax-keys is our key-signing daemon. In a future release this will be merged with Burrow and will support a GPG backend
+in addition to the development mode that monax-keys currently supplies.
 
+We need to run monax-keys so that `burrow configure` can generate keys for us in the following step.
+```shell
+# Install monax-keys
+go get -u github.com/monax/bosmarmot/keys/cmd/monax-keys
+# run monax-keys server in background
+monax-keys server &
+```
+
+#### Configure Burrow
 The quick-and-dirty one-liner looks like:
 
-```
-burrow spec -p1 -f1 | burrow configure -s- -v0
+```shell
+# Read spec on stdin
+burrow spec -p1 -f1 | burrow configure -s- > burrow.toml
 ```
 
 which translates into:
 
-```
+```shell
+# This is a place we can store config files and burrow's working directory '.burrow'
+mkdir chain_dir && cd chain_dir
 burrow spec --participant-accounts=1 --full-accounts=1 > genesis-spec.json
 burrow configure --genesis-spec=genesis-spec.json --validator-index=0 > burrow.toml
 ```
-
+#### Run Burrow
 Once the `burrow.toml` has been created, we run:
 
 ```
-burrow
+burrow serve
 ```
 
 and the logs will start streaming through.
+
+If you would like to reset your node you can just delete its working directory with `rm -rf .burrow`. In the context of a
+multi-node chain it will resync with peers, otherwise it will restart from height 0.
 
 ### Logging
 

--- a/client/rpc/client_test.go
+++ b/client/rpc/client_test.go
@@ -55,7 +55,7 @@ func testSend(t *testing.T,
 	nodeClient *mockclient.MockNodeClient, keyClient *mockkeys.MockKeyClient) {
 
 	// generate an ED25519 key and ripemd160 address
-	addressString := keyClient.NewKey().String()
+	addressString := keyClient.NewKey("").String()
 	// Public key can be queried from mockKeyClient.PublicKey(address)
 	// but here we let the transaction factory retrieve the public key
 	// which will then also overwrite the address we provide the function.
@@ -63,7 +63,7 @@ func testSend(t *testing.T,
 	// to address in generated transation.
 	publicKeyString := ""
 	// generate an additional address to send amount to
-	toAddressString := keyClient.NewKey().String()
+	toAddressString := keyClient.NewKey("").String()
 	// set an amount to transfer
 	amountString := "1000"
 	// unset sequence so that we retrieve sequence from account
@@ -80,7 +80,7 @@ func testCall(t *testing.T,
 	nodeClient *mockclient.MockNodeClient, keyClient *mockkeys.MockKeyClient) {
 
 	// generate an ED25519 key and ripemd160 address
-	addressString := keyClient.NewKey().String()
+	addressString := keyClient.NewKey("").String()
 	// Public key can be queried from mockKeyClient.PublicKey(address)
 	// but here we let the transaction factory retrieve the public key
 	// which will then also overwrite the address we provide the function.
@@ -88,7 +88,7 @@ func testCall(t *testing.T,
 	// to address in generated transation.
 	publicKeyString := ""
 	// generate an additional address to send amount to
-	toAddressString := keyClient.NewKey().String()
+	toAddressString := keyClient.NewKey("").String()
 	// set an amount to transfer
 	amountString := "1000"
 	// unset sequence so that we retrieve sequence from account
@@ -113,7 +113,7 @@ func testName(t *testing.T,
 	nodeClient *mockclient.MockNodeClient, keyClient *mockkeys.MockKeyClient) {
 
 	// generate an ED25519 key and ripemd160 address
-	addressString := keyClient.NewKey().String()
+	addressString := keyClient.NewKey("").String()
 	// Public key can be queried from mockKeyClient.PublicKey(address)
 	// but here we let the transaction factory retrieve the public key
 	// which will then also overwrite the address we provide the function.
@@ -144,7 +144,7 @@ func testPermissions(t *testing.T,
 	nodeClient *mockclient.MockNodeClient, keyClient *mockkeys.MockKeyClient) {
 
 	// generate an ED25519 key and ripemd160 address
-	addressString := keyClient.NewKey().String()
+	addressString := keyClient.NewKey("").String()
 	// Public key can be queried from mockKeyClient.PublicKey(address)
 	// but here we let the transaction factory retrieve the public key
 	// which will then also overwrite the address we provide the function.
@@ -152,7 +152,7 @@ func testPermissions(t *testing.T,
 	// to address in generated transation.
 	publicKeyString := ""
 	// generate an additional address to set permissions for
-	permAddressString := keyClient.NewKey().String()
+	permAddressString := keyClient.NewKey("").String()
 	// unset sequence so that we retrieve sequence from account
 	sequenceString := ""
 

--- a/cmd/burrow/main_test.go
+++ b/cmd/burrow/main_test.go
@@ -1,0 +1,12 @@
+package main
+
+import "testing"
+
+func TestBurrow(t *testing.T) {
+	app := burrow()
+	// Basic smoke test for cli config
+	app.Run([]string{"--version"})
+	app.Run([]string{"spec"})
+	app.Run([]string{"configure"})
+	app.Run([]string{"serve"})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -23,13 +23,16 @@ const DefaultBurrowConfigJSONEnvironmentVariable = "BURROW_CONFIG_JSON"
 const DefaultGenesisDocJSONFileName = "genesis.json"
 
 type BurrowConfig struct {
-	ValidatorAddress *acm.Address                       `json:",omitempty" toml:",omitempty"`
-	GenesisDoc       *genesis.GenesisDoc                `json:",omitempty" toml:",omitempty"`
-	Tendermint       *tendermint.BurrowTendermintConfig `json:",omitempty" toml:",omitempty"`
-	Execution        *execution.ExecutionConfig         `json:",omitempty" toml:",omitempty"`
-	Keys             *keys.KeysConfig                   `json:",omitempty" toml:",omitempty"`
-	RPC              *rpc.RPCConfig                     `json:",omitempty" toml:",omitempty"`
-	Logging          *logging_config.LoggingConfig      `json:",omitempty" toml:",omitempty"`
+	// Set on startup
+	ValidatorAddress    *acm.Address `json:",omitempty" toml:",omitempty"`
+	ValidatorPassphrase *string      `json:",omitempty" toml:",omitempty"`
+	// From config file
+	GenesisDoc *genesis.GenesisDoc                `json:",omitempty" toml:",omitempty"`
+	Tendermint *tendermint.BurrowTendermintConfig `json:",omitempty" toml:",omitempty"`
+	Execution  *execution.ExecutionConfig         `json:",omitempty" toml:",omitempty"`
+	Keys       *keys.KeysConfig                   `json:",omitempty" toml:",omitempty"`
+	RPC        *rpc.RPCConfig                     `json:",omitempty" toml:",omitempty"`
+	Logging    *logging_config.LoggingConfig      `json:",omitempty" toml:",omitempty"`
 }
 
 func DefaultBurrowConfig() *BurrowConfig {
@@ -46,7 +49,7 @@ func (conf *BurrowConfig) Kernel(ctx context.Context) (*core.Kernel, error) {
 		return nil, fmt.Errorf("no GenesisDoc defined in config, cannot make Kernel")
 	}
 	if conf.ValidatorAddress == nil {
-		return nil, fmt.Errorf("no validator address in config, cannot make Kernel")
+		return nil, fmt.Errorf("no validator address provided, cannot make Kernel")
 	}
 	logger, err := lifecycle.NewLoggerFromLoggingConfig(conf.Logging)
 	if err != nil {

--- a/keys/mock/key_client_mock.go
+++ b/keys/mock/key_client_mock.go
@@ -25,11 +25,11 @@ import (
 
 	acm "github.com/hyperledger/burrow/account"
 	. "github.com/hyperledger/burrow/keys"
+	"github.com/pkg/errors"
 	"github.com/tendermint/ed25519"
 	crypto "github.com/tendermint/go-crypto"
 	"github.com/tmthrgd/go-hex"
 	"golang.org/x/crypto/ripemd160"
-	"github.com/pkg/errors"
 )
 
 //---------------------------------------------------------------------
@@ -83,6 +83,9 @@ func newMockKey(name string) (*MockKey, error) {
 	key.Address, err = acm.AddressFromBytes(hasher.Sum(nil))
 	if err != nil {
 		return nil, err
+	}
+	if key.Name == "" {
+		key.Name = key.Address.String()
 	}
 	return key, nil
 }

--- a/scripts/deps/bos.sh
+++ b/scripts/deps/bos.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # The git revision of Bosmarmot/bos we will build and install into ./bin/ for integration tests
-echo "b6f5208284f54006b22955b8fcd5c86df1675c7f"
+echo "520a381e112f108e0ce71f4e6bc1bb8e3fde236f"


### PR DESCRIPTION
This PR:

- Fixes broken test that slipped through broken CircleCI notification on a previous PR
- Updates docs to point at roadmap and get keys and burrow running
- (Re)introduces `burrow serve` replacing `burrow` since current usage was not ideal and broke some uses of `Spec`
- Adds a smoke test for the mow.cli app
- Moves setting the `ValidatorAddress` from `burrow configure` to `burrow serve`, i.e. boot time. This allows us to use identical configuration for each validator in a pool in many cases and just specify the validator address. We can also set this via an environment variable