### PR TITLE
Flush events after hashing to fix timing issue in test

### DIFF
--- a/execution/execution.go
+++ b/execution/execution.go
@@ -147,7 +147,7 @@ func (exe *executor) Commit() (hash []byte, err error) {
 		return nil, err
 	}
 	// flush events to listeners
-	exe.eventCache.Flush()
+	defer exe.eventCache.Flush()
 	return exe.state.Hash(), nil
 }
 


### PR DESCRIPTION
I've seen this on CI, and I think this may resolve it. An artefact of the way this `WSCallNoWait` works mean there is a race.