### PR TITLE
Use sed for indentation to not interpret shell characters

### DIFF
--- a/event/emitter_test.go
+++ b/event/emitter_test.go
@@ -33,3 +33,39 @@ func TestEmitter(t *testing.T) {
 		t.Errorf("timed out before receiving message matching subscription query")
 	}
 }
+
+func TestOrdering(t *testing.T) {
+	em := NewEmitter(logging.NewNoopLogger())
+	ctx := context.Background()
+	out := make(chan interface{})
+
+	err := em.Subscribe(ctx, "TestOrdering1", NewQueryBuilder().AndEquals("foo", "bar"), out)
+	require.NoError(t, err)
+
+	err = em.Subscribe(ctx, "TestOrdering2", NewQueryBuilder().AndEquals("foo", "baz"), out)
+	require.NoError(t, err)
+
+	barTag := map[string]interface{}{"foo": "bar"}
+	bazTag := map[string]interface{}{"foo": "baz"}
+
+	msgs := [][]interface{}{
+		{"baz1", bazTag},
+		{"bar1", barTag},
+		{"bar2", barTag},
+		{"bar3", barTag},
+		{"baz2", bazTag},
+		{"baz3", bazTag},
+		{"bar4", barTag},
+	}
+
+	go func() {
+		for _, msg := range msgs {
+			em.Publish(ctx, msg[0], msg[1].(map[string]interface{}))
+		}
+		em.Publish(ctx, "stop", bazTag)
+	}()
+
+	for _, msg := range msgs {
+		assert.Equal(t, msg[0], <-out)
+	}
+}

--- a/rpc/tm/methods.go
+++ b/rpc/tm/methods.go
@@ -101,8 +101,10 @@ func GetRoutes(service *rpc.Service, logger *logging.Logger) map[string]*gorpc.R
 			if err != nil {
 				return nil, err
 			}
+
 			ctx, cancel := context.WithTimeout(context.Background(), SubscriptionTimeoutSeconds*time.Second)
 			defer cancel()
+
 			err = service.Subscribe(ctx, subscriptionID, eventID, func(resultEvent *rpc.ResultEvent) bool {
 				keepAlive := wsCtx.TryWriteRPCResponse(rpctypes.NewRPCSuccessResponse(
 					EventResponseID(wsCtx.Request.ID, eventID), resultEvent))

--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -20,7 +20,7 @@ notes=$(go run ./project/cmd/notes/main.go)
 echo "This command will tag the current commit $(git rev-parse --short HEAD) as version $version"
 echo "defined programmatically in project/releases.go with release notes:"
 echo
-echo "$notes" | xargs -L1 echo "> "
+echo "$notes" | sed 's/^/> /'
 echo
 echo "It will then push the version tag to origin."
 echo


### PR DESCRIPTION
This now also contains a fix to what must have been a long-standing in principle test flake.