### PR TITLE
Adding create2 opcode placeholder

### DIFF
--- a/execution/evm/asm/opcodes.go
+++ b/execution/evm/asm/opcodes.go
@@ -188,6 +188,7 @@ const (
 
 	// 0x70 range - other
 	STATICCALL   = 0xfa
+	CREATE2      = 0xfb
 	REVERT       = 0xfd
 	INVALID      = 0xfe
 	SELFDESTRUCT = 0xff
@@ -347,6 +348,7 @@ var opCodeNames = map[OpCode]string{
 	DELEGATECALL: "DELEGATECALL",
 	STATICCALL:   "STATICCALL",
 	// 0x70 range - other
+	CREATE2:      "CREATE2",
 	REVERT:       "REVERT",
 	INVALID:      "INVALID",
 	SELFDESTRUCT: "SELFDESTRUCT",

--- a/execution/evm/vm.go
+++ b/execution/evm/vm.go
@@ -1153,7 +1153,7 @@ func (vm *VM) call(caller acm.Account, callee acm.MutableAccount, code, input []
 		case STOP: // 0x00
 			return nil, nil
 
-		case STATICCALL:
+		case STATICCALL, CREATE2:
 			return nil, fmt.Errorf("%s not yet implemented", op.Name())
 		default:
 			vm.Debugf("(pc) %-3v Unknown opcode %X\n", pc, op)

--- a/rpc/tm/integration/websocket_helpers.go
+++ b/rpc/tm/integration/websocket_helpers.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	timeoutSeconds       = 4
+	timeoutSeconds       = 8
 	expectBlockInSeconds = 2
 )
 


### PR DESCRIPTION
These changes provide a placeholder for the create2 opcode. This PR is meant to satisfy issue found here:

fixes https://github.com/hyperledger/burrow/issues/769