### PR TITLE
bring our log fields in line with tendermints on ABCI-App component

### DIFF
--- a/consensus/tendermint/abci/app.go
+++ b/consensus/tendermint/abci/app.go
@@ -173,10 +173,10 @@ func (app *App) Commit() abci_types.ResponseCommit {
 	app.logger.InfoMsg("Committing block",
 		"tag", "Commit",
 		structure.ScopeKey, "Commit()",
-		"block_height", app.block.Header.Height,
-		"block_hash", app.block.Hash,
-		"block_time", app.block.Header.Time,
-		"num_txs", app.block.Header.NumTxs,
+		"height", app.block.Header.Height,
+		"hash", app.block.Hash,
+		"txs", app.block.Header.NumTxs,
+		"block_time", app.block.Header.Time, // [CSK] this sends a fairly non-sensical number; should be human readable
 		"last_block_time", tip.LastBlockTime(),
 		"last_block_hash", tip.LastBlockHash())
 


### PR DESCRIPTION
currently our structured logging fields differ frustratingly slightly from tendermints. this adjusts the predomoninant logging output on our end to use the same fields as they do to avoid the overlap in the screenshot below.

![screenshot-logs cluster monax io-2018 06 04-18-35-41](https://user-images.githubusercontent.com/590037/40932532-8f38a948-6826-11e8-96c2-ce3014634282.png)
