### PR TITLE
local key client does not return curve type

### DIFF
--- a/keys/server.go
+++ b/keys/server.go
@@ -121,7 +121,7 @@ func (k *KeyStore) Sign(ctx context.Context, in *pbkeys.SignRequest) (*pbkeys.Si
 
 	sig, err := key.Sign(in.GetMessage())
 
-	return &pbkeys.SignResponse{Signature: sig}, nil
+	return &pbkeys.SignResponse{Signature: sig, Curvetype: key.CurveType.String()}, nil
 }
 
 func (k *KeyStore) Verify(ctx context.Context, in *pbkeys.VerifyRequest) (*pbkeys.Empty, error) {


### PR DESCRIPTION
This breaks voting:

{"caller":"state.go:836","component":"Tendermint","err":"invalid curve type","height":1,"log_channel":"Info","message":"enterPropose: Error signing proposal","module":"consensus","round":0,"run_id":"ae20372c-68ab-11e8-827b-6da5986ff0ad","scope":"tendermint.NewNode","time":"2018-06-05T10:32:03.568661284Z"}

Signed-off-by: Sean Young <sean.young@monax.io>