### PR TITLE
Add last block checkpointing and versioned state loading

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -148,11 +148,18 @@ func NewTip(chainID string, genesisTime time.Time, genesisHash []byte) *Tip {
 func (bc *Blockchain) CommitBlock(blockTime time.Time, blockHash, appHash []byte) error {
 	bc.Lock()
 	defer bc.Unlock()
+	// Checkpoint on the _previous_ block. If we die, this is where we will resume since we know it must have been
+	// committed since we are committing the next block. If we fall over we can resume a safe committed state and
+	// Tendermint will catch us up
+	err := bc.save()
+	if err != nil {
+		return err
+	}
 	bc.lastBlockHeight += 1
 	bc.lastBlockTime = blockTime
 	bc.lastBlockHash = blockHash
 	bc.appHashAfterLastBlock = appHash
-	return bc.save()
+	return nil
 }
 
 func (bc *Blockchain) save() error {

--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -90,10 +90,11 @@ func DeriveGenesisDoc(burrowGenesisDoc *genesis.GenesisDoc) *tm_types.GenesisDoc
 		}
 	}
 	return &tm_types.GenesisDoc{
-		ChainID:     burrowGenesisDoc.ChainID(),
-		GenesisTime: burrowGenesisDoc.GenesisTime,
-		Validators:  validators,
-		AppHash:     burrowGenesisDoc.Hash(),
+		ChainID:         burrowGenesisDoc.ChainID(),
+		GenesisTime:     burrowGenesisDoc.GenesisTime,
+		Validators:      validators,
+		AppHash:         burrowGenesisDoc.Hash(),
+		ConsensusParams: tm_types.DefaultConsensusParams(),
 	}
 }
 

--- a/core/kernel.go
+++ b/core/kernel.go
@@ -84,7 +84,7 @@ func NewKernel(ctx context.Context, keyClient keys.KeyClient, privValidator tm_t
 	var state *execution.State
 	// These should be in sync unless we are at the genesis block
 	if blockchain.LastBlockHeight() > 0 {
-		state, err = execution.LoadState(stateDB)
+		state, err = execution.LoadState(stateDB, blockchain.AppHashAfterLastBlock())
 		if err != nil {
 			return nil, fmt.Errorf("could not load persisted execution state at hash 0x%X: %v",
 				blockchain.AppHashAfterLastBlock(), err)

--- a/core/kernel_test.go
+++ b/core/kernel_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger/burrow/logging"
 	"github.com/hyperledger/burrow/rpc"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	tmConfig "github.com/tendermint/tendermint/config"
 	tmTypes "github.com/tendermint/tendermint/types"
 )
@@ -42,18 +43,18 @@ func TestBootShutdownResume(t *testing.T) {
 	genesisDoc, _, privateValidators := genesis.NewDeterministicGenesis(123).GenesisDoc(1, true, 1000, 1, true, 1000)
 	privValidator := validator.NewPrivValidatorMemory(privateValidators[0], privateValidators[0])
 
-	i := int64(1)
+	i := int64(0)
 	// asserts we get a consecutive run of blocks
 	blockChecker := func(block *tmTypes.EventDataNewBlock) bool {
-		assert.Equal(t, i, block.Block.Height)
+		assert.Equal(t, i+1, block.Block.Height)
 		i++
 		// stop every third block
 		return i%3 != 0
 	}
 	// First run
-	assert.NoError(t, bootWaitBlocksShutdown(privValidator, genesisDoc, tmConf, logger, blockChecker))
+	require.NoError(t, bootWaitBlocksShutdown(privValidator, genesisDoc, tmConf, logger, blockChecker))
 	// Resume and check we pick up where we left off
-	assert.NoError(t, bootWaitBlocksShutdown(privValidator, genesisDoc, tmConf, logger, blockChecker))
+	require.NoError(t, bootWaitBlocksShutdown(privValidator, genesisDoc, tmConf, logger, blockChecker))
 	// Resuming with mismatched genesis should fail
 	genesisDoc.Salt = []byte("foo")
 	assert.Error(t, bootWaitBlocksShutdown(privValidator, genesisDoc, tmConf, logger, blockChecker))


### PR DESCRIPTION
This reintroduces some of the logic around saving a version number but with some tweaks:

- The multiple writes to db are not atomic, but instead of this we can use a checkpoint on the _last_ block to get the same safety
- When we start we load application and blockchain state from the last hash -> state version we were _certain_ had been fully committed

This needs a long-running statistically evaluated test where we randomly kill burrow so we cover various intervals in the commit process to prove that it is robust, but that will have to wait.