### PR TITLE
Add healthcheck endpoint and prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,50 @@
 # Hyperledger Burrow Changelog
+## Version 0.19.0
+This is a major (pre-1.0.0) release that brings upgrades, safety improvements, cloud configuration, and GRPC endpoints to Burrow.
+
+#### Breaking changes
+In addition to breaking changes associated with Tendermint (see their changelog):
+- State checkpointing logic has changed which has we load based on blockchain
+- Event format has changed over rpc/V0 see execution/events/ package
+- On-disk keys format has change from monax-keys to be more standard burrow keys
+- Address format has been changed (by Tendermint and we have followed suite) - conversion is possible but simpler to regenerated keys
+
+#### Features
+- Tendermint 0.20.0
+- Implemented EVM opcodes: REVERT, INVALID, SHL, SAR, SHR, RETURNDATACOPY, RETURNDATASIZE
+- Add config templating with burrow configure --config-template-in --config-out
+- Add config templates for kubernetes
+- Integrate monax-keys as internal (default) or standalone keys service, key gen exposed over CLI
+- Use GRPC for keys
+- Add GRPC service for Transactor and Events
+- Store ExecutionEvent by height and index in merkle tree state
+- Add historical query for all time with GetEvents
+- Add streaming GRPC service for ExecutionEvents with query language over tags
+- Add metadata to ExecutionEvents
+- Add BlockExplorer CLI for forensics
+- Expose reason for REVERT
+- Add last_block_info healthcheck endpoint to rpc/TM
+- 
+#### Improvements
+- Implement checkpointing when saving application and blockchain state in commit - interrupted commit rolls burrow back to last block whereon it can catch up using Tendermint
+- Maintain separate read-only tree in state so that long-running RPC request cannot block writes
+- Improve state safety
+- Improved input account server-side-signing
+- Increase subscription reap time on rpc/V0 to 20 seconds
+- Reorganise CLI
+- Improve internal serialisation
+- Refactor and modularise execution logic
+
+#### Bug fixes
+- Fix address generation from bytes mismatch
+
+
+
+## Version 0.18.1
+This is a minor release including:
+- Introduce InputAccount param for RPC/v0 for integration in JS libs
+- Resolve some issues with RPC/tm tests swallowing timeouts and not dealing with reordered events
+
 ## Version 0.18.0
 This is an extremely large release in terms of lines of code changed addressing several years of technical debt. Despite this efforts were made to maintain external interfaces as much as possible and an extended period of stabilisation has taken place on develop.
 

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ install_db: build_db
 
 # build burrow-client
 .PHONY: build_client
-build_client: commit_hash protobuf
+build_client: commit_hash
 	go build -ldflags "-extldflags '-static' \
 	-X github.com/hyperledger/burrow/project.commit=$(shell cat commit_hash.txt)" \
 	-o ${REPO}/bin/burrow-client ./client/cmd/burrow-client

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,47 +1,39 @@
-This is an extremely large release in terms of lines of code changed addressing several years of technical debt. Despite this efforts were made to maintain external interfaces as much as possible and an extended period of stabilisation has taken place on develop.
+This is a major (pre-1.0.0) release that brings upgrades, safety improvements, cloud configuration, and GRPC endpoints to Burrow.
 
-A major strand of work has been in condensing previous Monax tooling spread across multiple repos into just two. The Hyperledger Burrow repo and [Bosmarmot](http://github.com/monax/bosmarmot). Burrow is now able to generate chains (replacing 'monax chains make') with 'burrow spec' and 'burrow configure'. Our 'EPM' contract deployment and testing tool, our javascript libraries, compilers, and monax-keys are avaiable in Bosmarmot (the former in the 'bos' tool). Work is underway to pull monax-keys into the Burrow project, and we will continue to make Burrow as self-contained as possible.
+#### Breaking changes
+In addition to breaking changes associated with Tendermint (see their changelog):
+- State checkpointing logic has changed which has we load based on blockchain
+- Event format has changed over rpc/V0 see execution/events/ package
+- On-disk keys format has change from monax-keys to be more standard burrow keys
+- Address format has been changed (by Tendermint and we have followed suite) - conversion is possible but simpler to regenerated keys
 
 #### Features
-- Substantial support for latest EVM and solidity 0.4.21+ (missing some opcodes that will be added shortly - see known issues)
-- Tendermint 0.18.0
-- All signing through monax-keys KeyClient connection (preparation for HSM and GPG based signing daemon)
-- Address-based signing (Burrow acts as delegate when you send transact, transactAndHold, send, sendAndHold, and transactNameReg a parameter including input_account (hex address) instead of priv_key.
-- Provide sequential signing when using transact family methods (above) - allowing 100s Tx per second with the same input account
-- Genesis making, config making, and key generation through 'burrow spec' and 'burrow configure'
-- Logging configuration language and text/template for output
-- Improved CLI UX and framework (mow.cli)
-- Improved configuration
-
-
-#### Internal Improvements
-- Refactored execution and provide interfaces for executor
-- Segregate EVM and blockchain state to act as better library
-- Panic recovery on TX execution
-- Stricter interface boundaries and immutability of core objects by default
-- Replace broken BlockCache with universal StateCache that doesn't write directly to DB
-- All dependencies upgraded, notably: tendermint/IAVL 0.7.0
-- Use Go dep instead of glide
-- PubSub event hub with query language
-- Heavily optimised logging
-- PPROF profiling server option
-- Additional tests in multiple packages including v0 RPC and concurrency-focussed test
-- Use Tendermint verifier for PrivValidator
-- Use monax/relic for project history
-- Run bosmarmot integration tests in CI
-- Update documentation
-- Numerous maintainability, naming, and aesthetic code improvements
+- Tendermint 0.20.0
+- Implemented EVM opcodes: REVERT, INVALID, SHL, SAR, SHR, RETURNDATACOPY, RETURNDATASIZE
+- Add config templating with burrow configure --config-template-in --config-out
+- Add config templates for kubernetes
+- Integrate monax-keys as internal (default) or standalone keys service, key gen exposed over CLI
+- Use GRPC for keys
+- Add GRPC service for Transactor and Events
+- Store ExecutionEvent by height and index in merkle tree state
+- Add historical query for all time with GetEvents
+- Add streaming GRPC service for ExecutionEvents with query language over tags
+- Add metadata to ExecutionEvents
+- Add BlockExplorer CLI for forensics
+- Expose reason for REVERT
+- Add last_block_info healthcheck endpoint to rpc/TM
+- 
+#### Improvements
+- Implement checkpointing when saving application and blockchain state in commit - interrupted commit rolls burrow back to last block whereon it can catch up using Tendermint
+- Maintain separate read-only tree in state so that long-running RPC request cannot block writes
+- Improve state safety
+- Improved input account server-side-signing
+- Increase subscription reap time on rpc/V0 to 20 seconds
+- Reorganise CLI
+- Improve internal serialisation
+- Refactor and modularise execution logic
 
 #### Bug fixes
-- Fix memory leak in BlockCache
-- Fix CPU usage in BlockCache
-- Fix SIGNEXTEND for negative numbers
-- Fix multiple execution level panics
-- Make Transactor work during tendermint recheck
+- Fix address generation from bytes mismatch
 
-#### Known issues
-- Documentation rot - some effort has been made to update documentation to represent the current state but in some places it has slipped help can be found (and would be welcomed) on: [Hyperledger Burrow Chat](https://chat.hyperledger.org/channel/burrow)
-- Missing support for: RETURNDATACOPY and RETURNDATASIZE https://github.com/hyperledger/burrow/issues/705 (coming very soon)
-- Missing support for: INVALID https://github.com/hyperledger/burrow/issues/705 (coming very soon)
-- Missing support for: REVERT https://github.com/hyperledger/burrow/issues/600 (coming very soon)
 

--- a/execution/events/event.go
+++ b/execution/events/event.go
@@ -39,6 +39,27 @@ func (ev *Event) Key() Key {
 	return ev.Header.Key()
 }
 
+// Performs a shallow copy of Event
+func (ev *Event) Copy() *Event {
+	h := *ev.Header
+	evCopy := Event{
+		Header: &h,
+	}
+	if ev.Tx != nil {
+		tx := *ev.Tx
+		evCopy.Tx = &tx
+	}
+	if ev.Call != nil {
+		call := *ev.Call
+		evCopy.Call = &call
+	}
+	if ev.Log != nil {
+		log := *ev.Log
+		evCopy.Log = &log
+	}
+	return &evCopy
+}
+
 func (ev *Event) Encode() ([]byte, error) {
 	return cdc.MarshalBinary(ev)
 }

--- a/execution/state.go
+++ b/execution/state.go
@@ -321,6 +321,12 @@ func (ws *writeState) Publish(ctx context.Context, msg interface{}, tags event.T
 				ws.state.eventKeyHighWatermark, exeEvent)
 		}
 		ws.state.eventKeyHighWatermark = key
+		if exeEvent.Tx != nil {
+			// Don't serialise the tx (for now) we should normalise and store against tx hash
+			exeEvent = exeEvent.Copy()
+			// The header still contains the tx hash
+			exeEvent.Tx.Tx = nil
+		}
 		bs, err := exeEvent.Encode()
 		if err != nil {
 			return err

--- a/project/history.go
+++ b/project/history.go
@@ -28,6 +28,46 @@ func FullVersion() string {
 // To cut a new release add a release to the front of this slice then run the
 // release tagging script: ./scripts/tag_release.sh
 var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow").MustDeclareReleases(
+	"0.19.0",
+	`This is a major (pre-1.0.0) release that brings upgrades, safety improvements, cloud configuration, and GRPC endpoints to Burrow.
+
+#### Breaking changes
+In addition to breaking changes associated with Tendermint (see their changelog):
+- State checkpointing logic has changed which has we load based on blockchain
+- Event format has changed over rpc/V0 see execution/events/ package
+- On-disk keys format has change from monax-keys to be more standard burrow keys
+- Address format has been changed (by Tendermint and we have followed suite) - conversion is possible but simpler to regenerated keys
+
+#### Features
+- Tendermint 0.20.0
+- Implemented EVM opcodes: REVERT, INVALID, SHL, SAR, SHR, RETURNDATACOPY, RETURNDATASIZE
+- Add config templating with burrow configure --config-template-in --config-out
+- Add config templates for kubernetes
+- Integrate monax-keys as internal (default) or standalone keys service, key gen exposed over CLI
+- Use GRPC for keys
+- Add GRPC service for Transactor and Events
+- Store ExecutionEvent by height and index in merkle tree state
+- Add historical query for all time with GetEvents
+- Add streaming GRPC service for ExecutionEvents with query language over tags
+- Add metadata to ExecutionEvents
+- Add BlockExplorer CLI for forensics
+- Expose reason for REVERT
+- Add last_block_info healthcheck endpoint to rpc/TM
+- 
+#### Improvements
+- Implement checkpointing when saving application and blockchain state in commit - interrupted commit rolls burrow back to last block whereon it can catch up using Tendermint
+- Maintain separate read-only tree in state so that long-running RPC request cannot block writes
+- Improve state safety
+- Improved input account server-side-signing
+- Increase subscription reap time on rpc/V0 to 20 seconds
+- Reorganise CLI
+- Improve internal serialisation
+- Refactor and modularise execution logic
+
+#### Bug fixes
+- Fix address generation from bytes mismatch
+
+`,
 	"0.18.1",
 	`This is a minor release including:
 - Introduce InputAccount param for RPC/v0 for integration in JS libs

--- a/rpc/lib/rpc_test.go
+++ b/rpc/lib/rpc_test.go
@@ -187,22 +187,22 @@ func testWithHTTPClient(t *testing.T, cl client.HTTPClient) {
 	val := "acbd"
 	got, err := echoViaHTTP(cl, val)
 	require.Nil(t, err)
-	assert.Equal(t, got, val)
+	assert.Equal(t, val, got)
 
 	val2 := randBytes(t)
 	got2, err := echoBytesViaHTTP(cl, val2)
 	require.Nil(t, err)
-	assert.Equal(t, got2, val2)
+	assert.Equal(t, val2, got2)
 
 	val3 := cmn.HexBytes(randBytes(t))
 	got3, err := echoDataBytesViaHTTP(cl, val3)
 	require.Nil(t, err)
-	assert.Equal(t, got3, val3)
+	assert.Equal(t, val3, got3)
 
 	val4 := rand.Intn(10000)
 	got4, err := echoIntViaHTTP(cl, val4)
 	require.Nil(t, err)
-	assert.Equal(t, got4, val4)
+	assert.Equal(t, val4, got4)
 }
 
 func echoViaWS(cl *client.WSClient, val string) (string, error) {

--- a/rpc/lib/server/handlers_test.go
+++ b/rpc/lib/server/handlers_test.go
@@ -37,8 +37,8 @@ func TestRPCParams(t *testing.T) {
 		wantErr string
 	}{
 		// bad
-		{`{"jsonrpc": "2.0", "id": "0"}`, "Method not found"},
-		{`{"jsonrpc": "2.0", "method": "y", "id": "0"}`, "Method not found"},
+		{`{"jsonrpc": "2.0", "id": "0"}`, "Method Not Found"},
+		{`{"jsonrpc": "2.0", "method": "y", "id": "0"}`, "Method Not Found"},
 		{`{"method": "c", "id": "0", "params": a}`, "invalid character"},
 		{`{"method": "c", "id": "0", "params": ["a"]}`, "got 1"},
 		{`{"method": "c", "id": "0", "params": ["a", "b"]}`, "of type int"},
@@ -56,7 +56,6 @@ func TestRPCParams(t *testing.T) {
 		mux.ServeHTTP(rec, req)
 		res := rec.Result()
 		// Always expecting back a JSONRPCResponse
-		assert.True(t, statusOK(res.StatusCode), "#%d: should always return 2XX", i)
 		blob, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			t.Errorf("#%d: err reading body: %v", i, err)
@@ -66,7 +65,7 @@ func TestRPCParams(t *testing.T) {
 		recv := new(types.RPCResponse)
 		assert.Nil(t, json.Unmarshal(blob, recv), "#%d: expecting successful parsing of an RPCResponse:\nblob: %s", i, blob)
 		assert.NotEqual(t, recv, new(types.RPCResponse), "#%d: not expecting a blank RPCResponse", i)
-
+		assert.Equal(t, recv.Error.HTTPStatusCode(), res.StatusCode, "#%d: status should match error code", i)
 		if tt.wantErr == "" {
 			assert.Nil(t, recv.Error, "#%d: not expecting an error", i)
 		} else {

--- a/rpc/lib/server/http_server.go
+++ b/rpc/lib/server/http_server.go
@@ -46,7 +46,7 @@ func WriteRPCResponseHTTP(w http.ResponseWriter, res types.RPCResponse) {
 		panic(err)
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(res.Error.HTTPStatusCode())
 	w.Write(jsonBytes) // nolint: errcheck, gas
 }
 

--- a/rpc/lib/types/error_codes.go
+++ b/rpc/lib/types/error_codes.go
@@ -1,0 +1,52 @@
+package types
+
+import (
+	"net/http"
+	"strconv"
+)
+
+// From JSONRPC 2.0 spec
+type RPCErrorCode int
+
+const (
+	RPCErrorCodeParseError     RPCErrorCode = -32700
+	RPCErrorCodeInvalidRequest RPCErrorCode = -32600
+	RPCErrorCodeMethodNotFound RPCErrorCode = -32601
+	RPCErrorCodeInvalidParams  RPCErrorCode = -32602
+	RPCErrorCodeInternalError  RPCErrorCode = -32603
+	RPCErrorCodeServerError    RPCErrorCode = -32000
+)
+
+func (code RPCErrorCode) String() string {
+	switch code {
+	case RPCErrorCodeParseError:
+		return "Parse Error"
+	case RPCErrorCodeInvalidRequest:
+		return "Parse Error"
+	case RPCErrorCodeMethodNotFound:
+		return "Method Not Found"
+	case RPCErrorCodeInvalidParams:
+		return "Invalid Params"
+	case RPCErrorCodeInternalError:
+		return "Internal Error"
+	case RPCErrorCodeServerError:
+		return "Server Error"
+	default:
+		return strconv.FormatInt(int64(code), 10)
+	}
+}
+
+func (code RPCErrorCode) HTTPStatusCode() int {
+	switch code {
+	case RPCErrorCodeInvalidRequest:
+		return http.StatusBadRequest
+	case RPCErrorCodeMethodNotFound:
+		return http.StatusMethodNotAllowed
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func (code RPCErrorCode) Error() string {
+	return code.String()
+}

--- a/rpc/lib/types/types_test.go
+++ b/rpc/lib/types/types_test.go
@@ -23,12 +23,12 @@ func TestResponses(t *testing.T) {
 
 	d := RPCParseError("1", errors.New("Hello world"))
 	e, _ := json.Marshal(d)
-	f := `{"jsonrpc":"2.0","id":"1","error":{"code":-32700,"message":"Parse error. Invalid JSON","data":"Hello world"}}`
+	f := `{"jsonrpc":"2.0","id":"1","error":{"code":-32700,"message":"Parse Error","data":"Hello world"}}`
 	assert.Equal(string(f), string(e))
 
 	g := RPCMethodNotFoundError("2")
 	h, _ := json.Marshal(g)
-	i := `{"jsonrpc":"2.0","id":"2","error":{"code":-32601,"message":"Method not found"}}`
+	i := `{"jsonrpc":"2.0","id":"2","error":{"code":-32601,"message":"Method Not Found"}}`
 	assert.Equal(string(h), string(i))
 }
 

--- a/rpc/result.go
+++ b/rpc/result.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"time"
+
 	acm "github.com/hyperledger/burrow/account"
 	"github.com/hyperledger/burrow/binary"
 	"github.com/hyperledger/burrow/crypto"
@@ -118,6 +120,12 @@ type ResultStatus struct {
 	LatestBlockHeight uint64
 	LatestBlockTime   int64
 	NodeVersion       string
+}
+
+type ResultLastBlockInfo struct {
+	LastBlockHeight uint64
+	LastBlockTime   time.Time
+	LastBlockHash   binary.HexBytes
 }
 
 type ResultChainId struct {

--- a/rpc/result_test.go
+++ b/rpc/result_test.go
@@ -18,7 +18,12 @@ import (
 	"encoding/json"
 	"testing"
 
+	"time"
+
+	"fmt"
+
 	acm "github.com/hyperledger/burrow/account"
+	"github.com/hyperledger/burrow/binary"
 	"github.com/hyperledger/burrow/crypto"
 	"github.com/hyperledger/burrow/execution"
 	"github.com/hyperledger/burrow/txs"
@@ -165,4 +170,16 @@ func TestResultDumpConsensusState(t *testing.T) {
 	bsOut, err := json.Marshal(resOut)
 	require.NoError(t, err)
 	assert.Equal(t, string(bs), string(bsOut))
+}
+
+func TestResultLastBlockInfo(t *testing.T) {
+	res := &ResultLastBlockInfo{
+		LastBlockTime:   time.Now(),
+		LastBlockHash:   binary.HexBytes{3, 4, 5, 6},
+		LastBlockHeight: 2343,
+	}
+	bs, err := json.Marshal(res)
+	require.NoError(t, err)
+	fmt.Println(string(bs))
+
 }

--- a/rpc/tm/methods.go
+++ b/rpc/tm/methods.go
@@ -55,6 +55,9 @@ const (
 	// Private keys and signing
 	GeneratePrivateAccount = "unsafe/gen_priv_account"
 	SignTx                 = "unsafe/sign_tx"
+
+	// Health check
+	LastBlockInfo = "last_block_info"
 )
 
 const SubscriptionTimeout = 5 * time.Second
@@ -175,6 +178,7 @@ func GetRoutes(service *rpc.Service, logger *logging.Logger) map[string]*server.
 
 		// Private account
 		GeneratePrivateAccount: server.NewRPCFunc(service.GeneratePrivateAccount, ""),
+		LastBlockInfo:          server.NewRPCFunc(service.LastBlockInfo, "block_within"),
 	}
 }
 

--- a/rpc/v0/json_service.go
+++ b/rpc/v0/json_service.go
@@ -132,8 +132,7 @@ func (js *JSONService) Process(r *http.Request, w http.ResponseWriter) {
 	if handler, ok := js.defaultHandlers[mName]; ok {
 		js.logger.TraceMsg("Request received",
 			"id", req.Id,
-			"method", req.Method,
-			"params", string(req.Params))
+			"method", req.Method)
 		resp, errCode, err := handler(req, w)
 		if err != nil {
 			js.writeError(err.Error(), req.Id, errCode, w)

--- a/scripts/deps/bos.sh
+++ b/scripts/deps/bos.sh
@@ -2,5 +2,4 @@
 
 # The git revision of Bosmarmot/bos we will build and install into ./bin/ for integration tests
 
-echo "ca5fda25977a5e445561aff2078ef398e9962cc0"
-
+echo "a8162471f2dfd1cae183f2aa2614fdd3dc1d5155"


### PR DESCRIPTION
This PR primarily adds an endpoint suitable for implementing healthchecks, liveness probes, and readiness probes in rpc/TM as `last_block_info`. It reads data directly from memory and does not suffer from any possible database or lock contention like `status`. It also supports returning a 500 error if no blocks have been seen sufficiently recently.

When called bare it just returns the last block time, hash, and height: 
```javascript
http "localhost:46657/last_block_info"                
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: 
Access-Control-Expose-Headers: X-Server-Time
Content-Length: 196
Content-Type: application/json
Date: Tue, 26 Jun 2018 14:23:33 GMT
X-Server-Time: 1530023013

{
    "id": "",
    "jsonrpc": "2.0",
    "result": {
        "LastBlockHash": "81B11B917B1C8F9858127743A0F72B76474AA263",
        "LastBlockHeight": 3313,
        "LastBlockTime": "2018-06-26T15:23:32+01:00"
    }
}
```
When called with the parameter `block_within` which takes a `time.ParseDuration()` parsesable string then this endpoint will return with the same result as above if the last block committed has a `BlockTime` that falls within that duration counting back from now. If it does then the status is 200:
```javascript
http ":46657/last_block_info?block_within=5s"
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: 
Access-Control-Expose-Headers: X-Server-Time
Content-Length: 196
Content-Type: application/json
Date: Tue, 26 Jun 2018 14:21:47 GMT
X-Server-Time: 1530022907

{
    "id": "",
    "jsonrpc": "2.0",
    "result": {
        "LastBlockHash": "C7E38544D8DEBD01B04A1E69C1FB75BA4CB538B2",
        "LastBlockHeight": 3211,
        "LastBlockTime": "2018-06-26T15:21:46+01:00"
    }
}
```
If not then it returns an error with status code 500. The last block info is embedded in the error (since we cannot return an error and result under the JSONRPC 2.0 spec:
```javascript
http "localhost:46657/last_block_info?block_within=1ns"
HTTP/1.1 500 Internal Server Error
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: 
Access-Control-Expose-Headers: X-Server-Time
Content-Length: 350
Content-Type: application/json
Date: Tue, 26 Jun 2018 14:28:45 GMT
X-Server-Time: 1530023325

{
    "error": {
        "code": -32603,
        "data": "no block committed within the last 1ns (cutoff: 2018-06-26T15:28:45+01:00), last block info: {\"LastBlockHeight\":3611,\"LastBlockTime\":\"2018-06-26T15:28:44+01:00\",\"LastBlockHash\":\"197188B37FC8E5ABD0117B49F9C7180F35A43A4F\"}",
        "message": "Internal Error"
    },
    "id": "",
    "jsonrpc": "2.0"
}
```
We used a 1 nanosecond `block_within` interval in the above but the idea is the network operator can set the parameter to whatever they deem reasonable to probe either liveness or readiness. For simple liveness the no parameter version can be used.

This also prepares for the burrow 0.19.0 release and:
- Don't store Tx in state for every EventDataTx 
- Update changelog
- Remove logging that reveals private key for input account