### PR TITLE
Add new yaml function to burrow configure templating

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -210,7 +210,7 @@
   branch = "master"
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus"]
-  revision = "77e8f2ddcfed59ece3a8151879efb2304b5cbbcf"
+  revision = "d6a9817c4afc94d51115e4a30d449056a3fbf547"
 
 [[projects]]
   branch = "master"
@@ -237,7 +237,7 @@
     "nfs",
     "xfs"
   ]
-  revision = "7d6f385de8bea29190f15ba9931442a0eaef9af7"
+  revision = "40f013a808ec4fa79def444a1a56de4d1727efcb"
 
 [[projects]]
   branch = "master"
@@ -440,7 +440,7 @@
     "internal/timeseries",
     "trace"
   ]
-  revision = "afe8f62b1d6bbd81f31868121a50b06d8188e1f9"
+  revision = "ed29d75add3d7c4bf7ca65aac0c6df3d1420216f"
 
 [[projects]]
   branch = "master"
@@ -450,7 +450,7 @@
     "unix",
     "windows"
   ]
-  revision = "a200a19cb90b19de298170992778b1fda7217bd6"
+  revision = "151529c776cdc58ddbe7963ba9af779f3577b419"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -477,7 +477,7 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "80063a038e333bbe006c878e4c5ce4c74d055498"
+  revision = "ff3583edef7de132f219f0efc00e097cabcc0ec0"
 
 [[projects]]
   name = "google.golang.org/grpc"
@@ -533,6 +533,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ab60dfe224ea60fe247e9585bba9cd57e37f1e03a1fca0eb368291e28cfb71df"
+  inputs-digest = "7b9b17cb4d553647a445b9cefe47cea819dac89f8787efc9ed2992ef585c9948"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger/burrow/genesis"
 	"github.com/pkg/errors"
 	"github.com/tmthrgd/go-hex"
+	"gopkg.in/yaml.v2"
 )
 
 type Validator struct {
@@ -44,6 +45,14 @@ var templateFuncs template.FuncMap = map[string]interface{}{
 	},
 	"hex": func(rv reflect.Value) string {
 		return encode(rv, hex.EncodeUpperToString)
+	},
+	"yaml": func(rv interface{}) string {
+		a, _ := yaml.Marshal(rv)
+		return string(a)
+	},
+	"json": func(rv interface{}) string {
+		b, _ := json.Marshal(rv)
+		return string(b)
 	},
 }
 

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -50,7 +50,7 @@ type Account struct {
 
 type Validator struct {
 	BasicAccount
-	NodeAddress *crypto.Address `json:",omitempty" toml:",omitempty"`
+	NodeAddress *crypto.Address `json:",omitempty" toml:",omitempty" yaml:",omitempty"`
 	Name        string
 	UnbondTo    []BasicAccount
 }

--- a/vendor/github.com/prometheus/procfs/xfrm.go
+++ b/vendor/github.com/prometheus/procfs/xfrm.go
@@ -113,7 +113,7 @@ func (fs FS) NewXfrmStat() (XfrmStat, error) {
 
 		if len(fields) != 2 {
 			return XfrmStat{}, fmt.Errorf(
-				"couldnt parse %s line %s", file.Name(), s.Text())
+				"couldn't parse %s line %s", file.Name(), s.Text())
 		}
 
 		name := fields[0]

--- a/vendor/golang.org/x/net/http2/flow.go
+++ b/vendor/golang.org/x/net/http2/flow.go
@@ -41,10 +41,10 @@ func (f *flow) take(n int32) {
 // add adds n bytes (positive or negative) to the flow control window.
 // It returns false if the sum would exceed 2^31-1.
 func (f *flow) add(n int32) bool {
-	remain := (1<<31 - 1) - f.n
-	if n > remain {
-		return false
+	sum := f.n + n
+	if (sum > n) == (f.n > 0) {
+		f.n = sum
+		return true
 	}
-	f.n += n
-	return true
+	return false
 }

--- a/vendor/golang.org/x/sys/unix/fcntl.go
+++ b/vendor/golang.org/x/sys/unix/fcntl.go
@@ -14,7 +14,11 @@ var fcntl64Syscall uintptr = SYS_FCNTL
 
 // FcntlInt performs a fcntl syscall on fd with the provided command and argument.
 func FcntlInt(fd uintptr, cmd, arg int) (int, error) {
-	valptr, _, err := Syscall(fcntl64Syscall, fd, uintptr(cmd), uintptr(arg))
+	valptr, _, errno := Syscall(fcntl64Syscall, fd, uintptr(cmd), uintptr(arg))
+	var err error
+	if errno != 0 {
+		err = errno
+	}
 	return int(valptr), err
 }
 

--- a/vendor/golang.org/x/sys/unix/syscall_solaris.go
+++ b/vendor/golang.org/x/sys/unix/syscall_solaris.go
@@ -314,7 +314,11 @@ func UtimesNanoAt(dirfd int, path string, ts []Timespec, flags int) error {
 
 // FcntlInt performs a fcntl syscall on fd with the provided command and argument.
 func FcntlInt(fd uintptr, cmd, arg int) (int, error) {
-	valptr, _, err := sysvicall6(uintptr(unsafe.Pointer(&procfcntl)), 3, uintptr(fd), uintptr(cmd), uintptr(arg), 0, 0, 0)
+	valptr, _, errno := sysvicall6(uintptr(unsafe.Pointer(&procfcntl)), 3, uintptr(fd), uintptr(cmd), uintptr(arg), 0, 0, 0)
+	var err error
+	if errno != 0 {
+		err = errno
+	}
 	return int(valptr), err
 }
 

--- a/vendor/golang.org/x/sys/windows/service.go
+++ b/vendor/golang.org/x/sys/windows/service.go
@@ -43,6 +43,11 @@ const (
 
 	SC_STATUS_PROCESS_INFO = 0
 
+	SC_ACTION_NONE        = 0
+	SC_ACTION_RESTART     = 1
+	SC_ACTION_REBOOT      = 2
+	SC_ACTION_RUN_COMMAND = 3
+
 	SERVICE_STOPPED          = 1
 	SERVICE_START_PENDING    = 2
 	SERVICE_STOP_PENDING     = 3
@@ -146,6 +151,19 @@ type ENUM_SERVICE_STATUS_PROCESS struct {
 	ServiceName          *uint16
 	DisplayName          *uint16
 	ServiceStatusProcess SERVICE_STATUS_PROCESS
+}
+
+type SERVICE_FAILURE_ACTIONS struct {
+	ResetPeriod  uint32
+	RebootMsg    *uint16
+	Command      *uint16
+	ActionsCount uint32
+	Actions      *SC_ACTION
+}
+
+type SC_ACTION struct {
+	Type  uint32
+	Delay uint32
 }
 
 //sys	CloseServiceHandle(handle Handle) (err error) = advapi32.CloseServiceHandle


### PR DESCRIPTION
Now the the genesis spec can be generated as yaml, or yaml as a string.

<< yaml .Config >>

This would would generate the genesis spec as yaml; alternatively, it
can be string escaped by using the json function:

<< json (yaml .Config) >>

Signed-off-by: Sean Young <sean.young@monax.io>