### PR TITLE
Update relic and add dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# Hyperledger Burrow Changelog
-## Version 0.20.1
+# [Hyperledger Burrow](https://github.com/hyperledger/burrow) Changelog
+## [Unreleased]
 Release our mempool signing lock once transactions have been CheckTx'd' to massively increase throughput, also support mempool signing for BroadcastTxAsync.
 
-## Version 0.20.0
+## [0.20.0] - 2018-07-24
 This is a major (pre-1.0.0) release that introduces the ability to change the validator set through GovTx, transaction execution history, and fuller GRPC endpoint.
 
 #### Breaking changes
@@ -26,7 +26,7 @@ This is a major (pre-1.0.0) release that introduces the ability to change the va
 
 
 
-## Version 0.19.0
+## [0.19.0] - 2018-06-26
 This is a major (pre-1.0.0) release that brings upgrades, safety improvements, cloud configuration, and GRPC endpoints to Burrow.
 
 #### Breaking changes
@@ -67,12 +67,12 @@ In addition to breaking changes associated with Tendermint (see their changelog)
 
 
 
-## Version 0.18.1
+## [0.18.1]
 This is a minor release including:
 - Introduce InputAccount param for RPC/v0 for integration in JS libs
 - Resolve some issues with RPC/tm tests swallowing timeouts and not dealing with reordered events
 
-## Version 0.18.0
+## [0.18.0] - 2018-05-09
 This is an extremely large release in terms of lines of code changed addressing several years of technical debt. Despite this efforts were made to maintain external interfaces as much as possible and an extended period of stabilisation has taken place on develop.
 
 A major strand of work has been in condensing previous Monax tooling spread across multiple repos into just two. The Hyperledger Burrow repo and [Bosmarmot](http://github.com/monax/bosmarmot). Burrow is now able to generate chains (replacing 'monax chains make') with 'burrow spec' and 'burrow configure'. Our 'EPM' contract deployment and testing tool, our javascript libraries, compilers, and monax-keys are avaiable in Bosmarmot (the former in the 'bos' tool). Work is underway to pull monax-keys into the Burrow project, and we will continue to make Burrow as self-contained as possible.
@@ -121,10 +121,10 @@ A major strand of work has been in condensing previous Monax tooling spread acro
 - Missing support for: REVERT https://github.com/hyperledger/burrow/issues/600 (coming very soon)
 
 
-## Version 0.17.1
+## [0.17.1]
 Minor tweaks to docker build file
 
-## Version 0.17.0
+## [0.17.0] - 2017-09-04
 This is a service release with some significant ethereum/solidity compatibility improvements and new logging features. It includes:
 
 - [Upgrade to use Tendermint v0.9.2](https://github.com/hyperledger/burrow/pull/595)
@@ -139,7 +139,7 @@ Known issues:
 
 - SELFDESTRUCT opcode causes a panic when an account is removed. A [fix](https://github.com/hyperledger/burrow/pull/605) was produced but was [reverted](https://github.com/hyperledger/burrow/pull/636) pending investigation of a possible regression.
 
-## Version 0.16.3
+## [0.16.3] - 2017-04-25
 This release adds an stop-gap fix to the Transact method so that it never
 transfers value with the CallTx is generates.
 
@@ -149,15 +149,15 @@ from transferring value to non-payable functions with newer versions of solidity
 By doing this we can resolve some issues with users of the v0 RPC without making
 a breaking API change.
 
-## Version 0.16.2
+## [0.16.2] - 2017-04-20
 This release finalises our accession to the Hyperledger project and updates our root package namespace to github.com/hyperledger/burrow.
 
 It also includes a bug fix for rpc/V0 so that BroadcastTx can accept any transaction type and various pieces of internal clean-up.
 
-## Version 0.16.1
+## [0.16.1] - 2017-04-04
 This release was an internal rename to 'Burrow' with some minor other attendant clean up.
 
-## Version 0.16.0
+## [0.16.0] - 2017-03-01
 This is a consolidation release that fixes various bugs and improves elements
 of the architecture across the Monax Platform to support a quicker release
 cadence.
@@ -187,16 +187,16 @@ cadence.
 - [pull-379](https://github.com/hyperledger/burrow/pull/379) more descriptive error message for eris-client
 
 
-## Version 0.15.0
+## [0.15.0]
 This release was elided to synchronise release versions with tooling
 
-## Version 0.14.0
+## [0.14.0]
 This release was elided to synchronise release versions with tooling
 
-## Version 0.13.0
+## [0.13.0]
 This release was elided to synchronise release versions with tooling
 
-## Version 0.12.0
+## [0.12.0]
 This release marks the start of Eris-DB as the full permissioned blockchain node
  of the Eris platform with the Tendermint permissioned consensus engine.
  This involved significant refactoring of almost all parts of the code,
@@ -234,3 +234,18 @@ This release marks the start of Eris-DB as the full permissioned blockchain node
   - [Blockchain] Fix getBlocks to respect block height cap.
 
 
+[Unreleased]: https://github.com/hyperledger/burrow/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/hyperledger/burrow/compare/v0.19.0...v0.20.0
+[0.19.0]: https://github.com/hyperledger/burrow/compare/v0.18.1...v0.19.0
+[0.18.1]: https://github.com/hyperledger/burrow/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/hyperledger/burrow/compare/v0.17.1...v0.18.0
+[0.17.1]: https://github.com/hyperledger/burrow/compare/v0.17.0...v0.17.1
+[0.17.0]: https://github.com/hyperledger/burrow/compare/v0.16.3...v0.17.0
+[0.16.3]: https://github.com/hyperledger/burrow/compare/v0.16.2...v0.16.3
+[0.16.2]: https://github.com/hyperledger/burrow/compare/v0.16.1...v0.16.2
+[0.16.1]: https://github.com/hyperledger/burrow/compare/v0.16.0...v0.16.1
+[0.16.0]: https://github.com/hyperledger/burrow/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/hyperledger/burrow/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/hyperledger/burrow/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/hyperledger/burrow/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/hyperledger/burrow/commits/v0.12.0

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  digest = "1:e0499b93857a1b91efbdc0c21e26f1130685de98035008f3b01eeeb0713798cb"
+  digest = "1:167b6f65a6656de568092189ae791253939f076df60231fdd64588ac703892a1"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
   pruneopts = "NUT"
@@ -35,7 +35,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ad87504ef74b1c36880f9287126dbc8dc4146d86acf902dd776ac6064cc75396"
+  digest = "1:5150d33e061d3af9440f2fdad3f82456cb142b3200ce77e0bc2ffef90eef0b0c"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
   pruneopts = "NUT"
@@ -105,7 +105,7 @@
   version = "v1.4.7"
 
 [[projects]]
-  digest = "1:2c03593aec9fa7d6969dc7295c636b46369ec2dd45dcf4acfb298281d62528ff"
+  digest = "1:4956b2f82cd1045ccded4db070821b3b6b8fbc8628d4d63de90128ea56efcdfb"
   name = "github.com/go-kit/kit"
   packages = [
     "log",
@@ -129,7 +129,7 @@
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:a82caecb6d771d89e452ddf2721e3e37cb247d72202ed983cbcbab4152d9324b"
+  digest = "1:4c59c7d491a28441d9f8b1c78d861021b13562e7e6cb3a8f258cc6703b244a31"
   name = "github.com/go-ozzo/ozzo-validation"
   packages = [
     ".",
@@ -148,7 +148,7 @@
   version = "v1.7.0"
 
 [[projects]]
-  digest = "1:212285efb97b9ec2e20550d81f0446cb7897e57cbdfd7301b1363ab113d8be45"
+  digest = "1:35621fe20f140f05a0c4ef662c26c0ab4ee50bca78aa30fe87d33120bd28165e"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
@@ -163,7 +163,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:713cc7628304d027a7e9edcb52da888a8912d6405250a8d9c8eff6f41dd54398"
+  digest = "1:03e14cff610a8a58b774e36bd337fa979482be86aab01be81fb8bbd6d0f07fc8"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -194,7 +194,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:02e4365951e1bc55bd6505938ea88e12b5a9d5dfedcb1ae35d5a3833e502833e"
+  digest = "1:11c6c696067d3127ecf332b10f89394d386d9083f82baf71f40f2da31841a009"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -228,7 +228,7 @@
   version = "v0.3.5"
 
 [[projects]]
-  digest = "1:fa8175fc1639f717d9462d6c507d92b174662db600997f1b4a92aae0571c23de"
+  digest = "1:c7ef3ee638cc1e5d39c2b1d9874183ecc62e4822c9524360bc8fbdc3139ab4c3"
   name = "github.com/jawher/mow.cli"
   packages = [
     ".",
@@ -285,12 +285,12 @@
   revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
-  digest = "1:0392287f4fcbbd32a8352f82044dd0b644284d8a979897810abfa246a080adec"
+  digest = "1:9a3c7cb3b6be10c156b8ac4f69bcf0bdf483b6e601005505e254958eeb599281"
   name = "github.com/monax/relic"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "f24b36b5f6f7f5c6034c89a6a47de1bfbbf7787e"
-  version = "v1.1.0"
+  revision = "b713bcb44ab7888328eb63f609abd21e111ff9d5"
+  version = "v2.0.0"
 
 [[projects]]
   digest = "1:51ea800cff51752ff68e12e04106f5887b4daec6f9356721238c28019f0b42db"
@@ -317,7 +317,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:76463f8d9f141bb3673ccece5fb0d1d0f9588395e94d01253667db733f865b18"
+  digest = "1:a16a1797cf7077c68a7a312ab68f1349b5ba2ca926a383d4b17c272b6ee97e15"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
@@ -328,7 +328,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0f37e09b3e92aaeda5991581311f8dbf38944b36a3edec61cc2d1991f527554a"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = "NUT"
@@ -336,7 +336,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3bbebf77a04cda10bd07834d1686141608aca01c1aeb400d504d8aa026793b5a"
+  digest = "1:768b555b86742de2f28beb37f1dedce9a75f91f871d75b5717c96399c1a78c08"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -348,7 +348,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:37e418257b05a9e9fabbf836df2d8f3613313e80a909da6b9597b759ebca61cd"
+  digest = "1:6621142cd60b7150ab66f38ff36303ca55843dc5a635c1f9a28f95ecddab72b4"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -376,7 +376,7 @@
   version = "v1.0.6"
 
 [[projects]]
-  digest = "1:a36d61943d51cd4a1d7ecaf6993190527535a57382114ebf6549956b3e4cb612"
+  digest = "1:330e9062b308ac597e28485699c02223bd052437a6eed32a173c9227dcb9d95a"
   name = "github.com/spf13/afero"
   packages = [
     ".",
@@ -427,7 +427,7 @@
   revision = "6617b501e485b77e61b98cd533aefff9e258b5a7"
 
 [[projects]]
-  digest = "1:a7cb71e7cef4a320ae6d91424df8f991ed4161aede6dea7ba8d8f3af1b589a6c"
+  digest = "1:0331452965d8695c0a5633e0f509012987681a654f388f2ad0c3b2d7f7004b1c"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -439,7 +439,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:922191411ad8f61bcd8018ac127589bb489712c1d1a0ab2497aca4b16de417d2"
+  digest = "1:b3cfb8d82b1601a846417c3f31c03a7961862cb2c98dcf0959c473843e6d9a2b"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -460,7 +460,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:203b409c21115233a576f99e8f13d8e07ad82b25500491f7e1cca12588fb3232"
+  digest = "1:087aaa7920e5d0bf79586feb57ce01c35c830396ab4392798112e8aae8c47722"
   name = "github.com/tendermint/ed25519"
   packages = [
     ".",
@@ -487,7 +487,7 @@
   version = "v0.9.2"
 
 [[projects]]
-  digest = "1:46ac5207f9074a8ca246a3fce7aa576f5c5f43a30c8f3ef833e247777fdb8a4f"
+  digest = "1:655269eb91b18f28ee2a596256a088dc140d38ab2e27d6e97dd999eafa548665"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
@@ -554,7 +554,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:acfa60b5755859faec71ac0f34d2ffd16113334fa6350aad536b4207e5b5193f"
+  digest = "1:3de75e179686c695b0647b887083e7a5967dcac33bd8b86c4edb9d094625fc7f"
   name = "golang.org/x/crypto"
   packages = [
     "curve25519",
@@ -576,7 +576,7 @@
   revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
 
 [[projects]]
-  digest = "1:15dbe437d38eb2103f6b55348758958a6f85a400ecc16fcb53b3f271d38cd8ea"
+  digest = "1:2822b75330f8a787dca2f7d861788811676b2c50cea125851bbe32e9fd31624c"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -593,7 +593,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:48419582c83b5715e244977ca617a3ff596dc6808368e3c1dcaf1b3ad2218e53"
+  digest = "1:d129afdf4044fab1e03a8912d0c2cb3241ac65781ad524764713afe79bbb5be8"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
@@ -604,7 +604,7 @@
   revision = "ac767d655b305d4e9612f5f6e33120b9176c4ad4"
 
 [[projects]]
-  digest = "1:a0f29009397dc27c9dc8440f0945d49e5cbb9b72d0b0fc745474d9bfdea2d9f8"
+  digest = "1:e7071ed636b5422cc51c0e3a6cebc229d6c9fffc528814b519a980641422d619"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -635,7 +635,7 @@
   revision = "02b4e95473316948020af0b7a4f0f22c73929b0e"
 
 [[projects]]
-  digest = "1:f778941d5c2e46da5e0f5d553d3e80bf70eb40d2e80bb4c649b625b9133f3d5f"
+  digest = "1:d0e5846da58e4e20d1bbd7502b24f31d37e3ac1e02a9042d95bd93c2d0c139dd"
   name = "google.golang.org/grpc"
   packages = [
     ".",

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,1 +1,22 @@
-Release our mempool signing lock once transactions have been CheckTx'd' to massively increase throughput, also support mempool signing for BroadcastTxAsync.
+This is a major (pre-1.0.0) release that introduces the ability to change the validator set through GovTx, transaction execution history, and fuller GRPC endpoint.
+
+#### Breaking changes
+- Address format has been changed (by Tendermint and we have followed suite) - conversion is possible but simpler to regenerated keys
+- JSON-RPC interface has been removed
+- burrow-client has been removed
+- rpc/TM methods for events and broadcast have been removed
+
+#### Features
+- Tendermint 0.24.4
+- GovTx GRPC service. The validator set can be now be changed.
+- Enhanced GRPC services: NameReg, Transaction index, blocks service
+- Events GRPC service
+- Transaction Service can set value transferred
+
+#### Improvements
+- The output of "burrow keys export" can be templated
+
+#### Bug fixes
+- Fixed panic on nil bounds for blocks service
+
+

--- a/project/history.go
+++ b/project/history.go
@@ -27,11 +27,12 @@ func FullVersion() string {
 //
 // To cut a new release add a release to the front of this slice then run the
 // release tagging script: ./scripts/tag_release.sh
-var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow").MustDeclareReleases(
-	"0.20.1",
-	`Release our mempool signing lock once transactions have been CheckTx'd' to massively increase throughput, also support mempool signing for BroadcastTxAsync.`,
-	"0.20.0",
-	`This is a major (pre-1.0.0) release that introduces the ability to change the validator set through GovTx, transaction execution history, and fuller GRPC endpoint.
+var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "https://github.com/hyperledger/burrow").
+	MustDeclareReleases(
+		"",
+		`Release our mempool signing lock once transactions have been CheckTx'd' to massively increase throughput, also support mempool signing for BroadcastTxAsync.`,
+		"0.20.0 - 2018-07-24",
+		`This is a major (pre-1.0.0) release that introduces the ability to change the validator set through GovTx, transaction execution history, and fuller GRPC endpoint.
 
 #### Breaking changes
 - Address format has been changed (by Tendermint and we have followed suite) - conversion is possible but simpler to regenerated keys
@@ -53,8 +54,8 @@ var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow").Must
 - Fixed panic on nil bounds for blocks service
 
 `,
-	"0.19.0",
-	`This is a major (pre-1.0.0) release that brings upgrades, safety improvements, cloud configuration, and GRPC endpoints to Burrow.
+		"0.19.0 - 2018-06-26",
+		`This is a major (pre-1.0.0) release that brings upgrades, safety improvements, cloud configuration, and GRPC endpoints to Burrow.
 
 #### Breaking changes
 In addition to breaking changes associated with Tendermint (see their changelog):
@@ -93,12 +94,12 @@ In addition to breaking changes associated with Tendermint (see their changelog)
 - Fix address generation from bytes mismatch
 
 `,
-	"0.18.1",
-	`This is a minor release including:
+		"0.18.1",
+		`This is a minor release including:
 - Introduce InputAccount param for RPC/v0 for integration in JS libs
 - Resolve some issues with RPC/tm tests swallowing timeouts and not dealing with reordered events`,
-	"0.18.0",
-	`This is an extremely large release in terms of lines of code changed addressing several years of technical debt. Despite this efforts were made to maintain external interfaces as much as possible and an extended period of stabilisation has taken place on develop.
+		"0.18.0 - 2018-05-09",
+		`This is an extremely large release in terms of lines of code changed addressing several years of technical debt. Despite this efforts were made to maintain external interfaces as much as possible and an extended period of stabilisation has taken place on develop.
 
 A major strand of work has been in condensing previous Monax tooling spread across multiple repos into just two. The Hyperledger Burrow repo and [Bosmarmot](http://github.com/monax/bosmarmot). Burrow is now able to generate chains (replacing 'monax chains make') with 'burrow spec' and 'burrow configure'. Our 'EPM' contract deployment and testing tool, our javascript libraries, compilers, and monax-keys are avaiable in Bosmarmot (the former in the 'bos' tool). Work is underway to pull monax-keys into the Burrow project, and we will continue to make Burrow as self-contained as possible.
 
@@ -146,11 +147,11 @@ A major strand of work has been in condensing previous Monax tooling spread acro
 - Missing support for: REVERT https://github.com/hyperledger/burrow/issues/600 (coming very soon)
 `,
 
-	"0.17.1",
-	`Minor tweaks to docker build file`,
+		"0.17.1",
+		`Minor tweaks to docker build file`,
 
-	"0.17.0",
-	`This is a service release with some significant ethereum/solidity compatibility improvements and new logging features. It includes:
+		"0.17.0 - 2017-09-04",
+		`This is a service release with some significant ethereum/solidity compatibility improvements and new logging features. It includes:
 
 - [Upgrade to use Tendermint v0.9.2](https://github.com/hyperledger/burrow/pull/595)
 - [Implemented dynamic memory](https://github.com/hyperledger/burrow/pull/607) assumed by the EVM bytecode produce by solidity, fixing various issues.
@@ -164,8 +165,8 @@ Known issues:
 
 - SELFDESTRUCT opcode causes a panic when an account is removed. A [fix](https://github.com/hyperledger/burrow/pull/605) was produced but was [reverted](https://github.com/hyperledger/burrow/pull/636) pending investigation of a possible regression.`,
 
-	"0.16.3",
-	`This release adds an stop-gap fix to the Transact method so that it never
+		"0.16.3 - 2017-04-25",
+		`This release adds an stop-gap fix to the Transact method so that it never
 transfers value with the CallTx is generates.
 
 We hard-code amount = fee so that no value is transferred
@@ -174,16 +175,16 @@ from transferring value to non-payable functions with newer versions of solidity
 By doing this we can resolve some issues with users of the v0 RPC without making
 a breaking API change.`,
 
-	"0.16.2",
-	`This release finalises our accession to the Hyperledger project and updates our root package namespace to github.com/hyperledger/burrow.
+		"0.16.2 - 2017-04-20",
+		`This release finalises our accession to the Hyperledger project and updates our root package namespace to github.com/hyperledger/burrow.
 
 It also includes a bug fix for rpc/V0 so that BroadcastTx can accept any transaction type and various pieces of internal clean-up.`,
 
-	"0.16.1",
-	`This release was an internal rename to 'Burrow' with some minor other attendant clean up.`,
+		"0.16.1 - 2017-04-04",
+		`This release was an internal rename to 'Burrow' with some minor other attendant clean up.`,
 
-	"0.16.0",
-	`This is a consolidation release that fixes various bugs and improves elements
+		"0.16.0 - 2017-03-01",
+		`This is a consolidation release that fixes various bugs and improves elements
 of the architecture across the Monax Platform to support a quicker release
 cadence.
 
@@ -212,17 +213,17 @@ cadence.
 - [pull-379](https://github.com/hyperledger/burrow/pull/379) more descriptive error message for eris-client
 `,
 
-	"0.15.0",
-	"This release was elided to synchronise release versions with tooling",
+		"0.15.0",
+		"This release was elided to synchronise release versions with tooling",
 
-	"0.14.0",
-	"This release was elided to synchronise release versions with tooling",
+		"0.14.0",
+		"This release was elided to synchronise release versions with tooling",
 
-	"0.13.0",
-	"This release was elided to synchronise release versions with tooling",
+		"0.13.0",
+		"This release was elided to synchronise release versions with tooling",
 
-	"0.12.0",
-	`This release marks the start of Eris-DB as the full permissioned blockchain node
+		"0.12.0",
+		`This release marks the start of Eris-DB as the full permissioned blockchain node
  of the Eris platform with the Tendermint permissioned consensus engine.
  This involved significant refactoring of almost all parts of the code,
  but provides a solid foundation to build the next generation of advanced
@@ -258,4 +259,4 @@ cadence.
   - [RPC/v0] Fix blocking event subscription in transactAndHold (preventing return in Javascript libraries)
   - [Blockchain] Fix getBlocks to respect block height cap.
 `,
-)
+	)

--- a/vendor/github.com/monax/relic/conversion.go
+++ b/vendor/github.com/monax/relic/conversion.go
@@ -1,0 +1,48 @@
+package relic
+
+import (
+	"fmt"
+	"time"
+)
+
+var DefaultDateLayout = "2006-01-02"
+
+func AsString(stringLike interface{}) (string, error) {
+	switch s := stringLike.(type) {
+	case string:
+		return s, nil
+	case fmt.Stringer:
+		return s.String(), nil
+	default:
+		return "", fmt.Errorf("unsupported type for string: %t, must string or fmt.Stringer", s)
+	}
+}
+
+func AsDate(dateLike interface{}) (time.Time, error) {
+	switch d := dateLike.(type) {
+	case time.Time:
+		return d, nil
+	default:
+		s, err := AsString(d)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return time.Parse(DefaultDateLayout, s)
+	}
+}
+func AsVersion(versionLike interface{}) (Version, error) {
+	switch v := versionLike.(type) {
+	case Version:
+		return v, nil
+	default:
+		s, err := AsString(v)
+		if err != nil {
+			return Version{}, err
+		}
+		if s == "" {
+			// for unreleased notes
+			return Version{}, nil
+		}
+		return ParseDatedVersion(s)
+	}
+}


### PR DESCRIPTION
I updated relic to follow some recommendations from https://keepachangelog.com/en/1.0.0/: https://github.com/monax/relic/compare/v1.1.0...v2.0.0

This updates to that version adding some dates and github compare links between our versions. Going forward we can try and follow the keepachangelog style with the same headers of:

- Changed
- Deprecated
- Added
- Removed
- Fixed

This will help those running validators to keep up to date