### PR TITLE
[consensus] Authorized only node sync / Peers filter support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,7 +85,7 @@ func (conf *BurrowConfig) Kernel(ctx context.Context) (*core.Kernel, error) {
 	}
 
 	return core.NewKernel(ctx, keyClient, privValidator, conf.GenesisDoc, conf.Tendermint.TendermintConfig(), conf.RPC,
-		conf.Keys, keyStore, exeOptions, logger)
+		conf.Keys, keyStore, exeOptions, conf.Tendermint.AuthorizedPeers, logger)
 }
 
 func (conf *BurrowConfig) JSONString() string {

--- a/config/config.go
+++ b/config/config.go
@@ -85,7 +85,7 @@ func (conf *BurrowConfig) Kernel(ctx context.Context) (*core.Kernel, error) {
 	}
 
 	return core.NewKernel(ctx, keyClient, privValidator, conf.GenesisDoc, conf.Tendermint.TendermintConfig(), conf.RPC,
-		conf.Keys, keyStore, exeOptions, conf.Tendermint.AuthorizedPeers, logger)
+		conf.Keys, keyStore, exeOptions, conf.Tendermint.DefaultAuthorizedPeersProvider(), logger)
 }
 
 func (conf *BurrowConfig) JSONString() string {

--- a/consensus/tendermint/abci/app.go
+++ b/consensus/tendermint/abci/app.go
@@ -24,12 +24,14 @@ type App struct {
 	// Node information to return in Info
 	nodeInfo string
 	// State
-	blockchain    *bcm.Blockchain
-	checker       execution.BatchExecutor
-	committer     execution.BatchCommitter
-	checkTx       func(txBytes []byte) abciTypes.ResponseCheckTx
-	deliverTx     func(txBytes []byte) abciTypes.ResponseCheckTx
-	mempoolLocker sync.Locker
+	blockchain             *bcm.Blockchain
+	checker                execution.BatchExecutor
+	committer              execution.BatchCommitter
+	checkTx                func(txBytes []byte) abciTypes.ResponseCheckTx
+	deliverTx              func(txBytes []byte) abciTypes.ResponseCheckTx
+	mempoolLocker          sync.Locker
+	authorizedPeersID      []string
+	authorizedPeersAddress []string
 	// We need to cache these from BeginBlock for when we need actually need it in Commit
 	block *abciTypes.RequestBeginBlock
 	// Function to use to fail gracefully from panic rather than letting Tendermint make us a zombie
@@ -41,15 +43,17 @@ type App struct {
 var _ abciTypes.Application = &App{}
 
 func NewApp(nodeInfo string, blockchain *bcm.Blockchain, checker execution.BatchExecutor, committer execution.BatchCommitter,
-	txDecoder txs.Decoder, panicFunc func(error), logger *logging.Logger) *App {
+	txDecoder txs.Decoder, authorizedPeers string, panicFunc func(error), logger *logging.Logger) *App {
 	return &App{
-		nodeInfo:   nodeInfo,
-		blockchain: blockchain,
-		checker:    checker,
-		committer:  committer,
-		checkTx:    txExecutor("CheckTx", checker, txDecoder, logger.WithScope("CheckTx")),
-		deliverTx:  txExecutor("DeliverTx", committer, txDecoder, logger.WithScope("DeliverTx")),
-		panicFunc:  panicFunc,
+		nodeInfo:               nodeInfo,
+		blockchain:             blockchain,
+		checker:                checker,
+		committer:              committer,
+		checkTx:                txExecutor("CheckTx", checker, txDecoder, logger.WithScope("CheckTx")),
+		deliverTx:              txExecutor("DeliverTx", committer, txDecoder, logger.WithScope("DeliverTx")),
+		authorizedPeersID:      makeAuthorizedPeersID(authorizedPeers),
+		authorizedPeersAddress: makeAuthorizedPeersAddress(authorizedPeers),
+		panicFunc:              panicFunc,
 		logger: logger.WithScope("abci.NewApp").With(structure.ComponentKey, "ABCI_App",
 			"node_info", nodeInfo),
 	}
@@ -78,8 +82,18 @@ func (app *App) SetOption(option abciTypes.RequestSetOption) (respSetOption abci
 }
 
 func (app *App) Query(reqQuery abciTypes.RequestQuery) (respQuery abciTypes.ResponseQuery) {
-	respQuery.Log = "Query not supported"
-	respQuery.Code = codes.UnsupportedRequestCode
+	defer func() {
+		if r := recover(); r != nil {
+			app.panicFunc(fmt.Errorf("panic occurred in abci.App/Query: %v\n%s", r, debug.Stack()))
+		}
+	}()
+	switch {
+	case isPeersFilterQuery(&reqQuery):
+		app.peersFilter(&reqQuery, &respQuery)
+	default:
+		respQuery.Log = "Query not supported"
+		respQuery.Code = codes.UnsupportedRequestCode
+	}
 	return
 }
 

--- a/consensus/tendermint/abci/app.go
+++ b/consensus/tendermint/abci/app.go
@@ -24,14 +24,13 @@ type App struct {
 	// Node information to return in Info
 	nodeInfo string
 	// State
-	blockchain             *bcm.Blockchain
-	checker                execution.BatchExecutor
-	committer              execution.BatchCommitter
-	checkTx                func(txBytes []byte) abciTypes.ResponseCheckTx
-	deliverTx              func(txBytes []byte) abciTypes.ResponseCheckTx
-	mempoolLocker          sync.Locker
-	authorizedPeersID      []string
-	authorizedPeersAddress []string
+	blockchain              *bcm.Blockchain
+	checker                 execution.BatchExecutor
+	committer               execution.BatchCommitter
+	checkTx                 func(txBytes []byte) abciTypes.ResponseCheckTx
+	deliverTx               func(txBytes []byte) abciTypes.ResponseCheckTx
+	mempoolLocker           sync.Locker
+	authorizedPeersProvider PeersFilterProvider
 	// We need to cache these from BeginBlock for when we need actually need it in Commit
 	block *abciTypes.RequestBeginBlock
 	// Function to use to fail gracefully from panic rather than letting Tendermint make us a zombie
@@ -40,20 +39,22 @@ type App struct {
 	logger *logging.Logger
 }
 
+// PeersFilterProvider provides current authorized nodes id and/or addresses
+type PeersFilterProvider func() (authorizedPeersID []string, authorizedPeersAddress []string)
+
 var _ abciTypes.Application = &App{}
 
 func NewApp(nodeInfo string, blockchain *bcm.Blockchain, checker execution.BatchExecutor, committer execution.BatchCommitter,
-	txDecoder txs.Decoder, authorizedPeers string, panicFunc func(error), logger *logging.Logger) *App {
+	txDecoder txs.Decoder, authorizedPeersProvider PeersFilterProvider, panicFunc func(error), logger *logging.Logger) *App {
 	return &App{
-		nodeInfo:               nodeInfo,
-		blockchain:             blockchain,
-		checker:                checker,
-		committer:              committer,
-		checkTx:                txExecutor("CheckTx", checker, txDecoder, logger.WithScope("CheckTx")),
-		deliverTx:              txExecutor("DeliverTx", committer, txDecoder, logger.WithScope("DeliverTx")),
-		authorizedPeersID:      makeAuthorizedPeersID(authorizedPeers),
-		authorizedPeersAddress: makeAuthorizedPeersAddress(authorizedPeers),
-		panicFunc:              panicFunc,
+		nodeInfo:                nodeInfo,
+		blockchain:              blockchain,
+		checker:                 checker,
+		committer:               committer,
+		checkTx:                 txExecutor("CheckTx", checker, txDecoder, logger.WithScope("CheckTx")),
+		deliverTx:               txExecutor("DeliverTx", committer, txDecoder, logger.WithScope("DeliverTx")),
+		authorizedPeersProvider: authorizedPeersProvider,
+		panicFunc:               panicFunc,
 		logger: logger.WithScope("abci.NewApp").With(structure.ComponentKey, "ABCI_App",
 			"node_info", nodeInfo),
 	}
@@ -87,12 +88,12 @@ func (app *App) Query(reqQuery abciTypes.RequestQuery) (respQuery abciTypes.Resp
 			app.panicFunc(fmt.Errorf("panic occurred in abci.App/Query: %v\n%s", r, debug.Stack()))
 		}
 	}()
+	respQuery.Log = "Query not supported"
+	respQuery.Code = codes.UnsupportedRequestCode
+
 	switch {
 	case isPeersFilterQuery(&reqQuery):
 		app.peersFilter(&reqQuery, &respQuery)
-	default:
-		respQuery.Log = "Query not supported"
-		respQuery.Code = codes.UnsupportedRequestCode
 	}
 	return
 }

--- a/consensus/tendermint/abci/peers_filter.go
+++ b/consensus/tendermint/abci/peers_filter.go
@@ -1,0 +1,76 @@
+package abci
+
+import (
+	"fmt"
+	"github.com/hyperledger/burrow/consensus/tendermint/codes"
+	abciTypes "github.com/tendermint/tendermint/abci/types"
+	"net/url"
+	"strings"
+)
+
+const (
+	peersFilterQueryPath = "/p2p/filter/"
+)
+
+func isPeersFilterQuery(query *abciTypes.RequestQuery) bool {
+	return strings.HasPrefix(query.Path, peersFilterQueryPath)
+}
+
+func (app *App) peersFilter(reqQuery *abciTypes.RequestQuery, respQuery *abciTypes.ResponseQuery) {
+	app.logger.TraceMsg("abci.App/Query peers filter query", "query_path", reqQuery.Path)
+	path := strings.Split(reqQuery.Path, "/")
+	if len(path) != 5 {
+		panic(fmt.Errorf("invalid peers filter query path %v", reqQuery.Path))
+	}
+
+	filterType := path[3]
+	peer := path[4]
+
+	var authorizedPeers *[]string
+	switch filterType {
+	case "id":
+		authorizedPeers = &app.authorizedPeersID
+	case "addr":
+		authorizedPeers = &app.authorizedPeersAddress
+	default:
+		panic(fmt.Errorf("invalid peers filter query type %v", reqQuery.Path))
+	}
+
+	peerAuthorized := len(*authorizedPeers) == 0
+	for _, authorizedPeer := range *authorizedPeers {
+		if authorizedPeer == peer {
+			peerAuthorized = true
+			break
+		}
+	}
+
+	if peerAuthorized {
+		app.logger.TraceMsg("Peer sync authorized", "peer", peer)
+		respQuery.Code = codes.PeerFilterAuthorizedCode
+	} else {
+		app.logger.InfoMsg("Peer sync forbidden", "peer", peer)
+		respQuery.Code = codes.PeerFilterForbiddenCode
+	}
+}
+
+func makeAuthorizedPeersAddress(authorizedPeers string) []string {
+	return makeAuthorizedPeers(authorizedPeers, true)
+}
+
+func makeAuthorizedPeersID(authorizedPeers string) []string {
+	return makeAuthorizedPeers(authorizedPeers, false)
+}
+
+func makeAuthorizedPeers(authorizedPeersString string, address bool) (authorizedPeers []string) {
+	authorizedPeersAddrOrID := strings.Split(authorizedPeersString, ",")
+	for _, authorizedPeerAddrOrID := range authorizedPeersAddrOrID {
+		_, err := url.Parse(authorizedPeerAddrOrID)
+		isNodeAddress := err != nil
+		if address && isNodeAddress {
+			authorizedPeers = append(authorizedPeers, authorizedPeerAddrOrID)
+		} else if !address && !isNodeAddress {
+			authorizedPeers = append(authorizedPeers, authorizedPeerAddrOrID)
+		}
+	}
+	return
+}

--- a/consensus/tendermint/abci/peers_filter_test.go
+++ b/consensus/tendermint/abci/peers_filter_test.go
@@ -2,31 +2,95 @@ package abci
 
 import (
 	"fmt"
+	"github.com/hyperledger/burrow/consensus/tendermint/codes"
+	"github.com/hyperledger/burrow/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/abci/types"
 	abciTypes "github.com/tendermint/tendermint/abci/types"
 	"testing"
 )
 
+const (
+	aNodeId      = "836AB8674A33416718E5A19557A25ED826B2BDD3"
+	aNodeAddress = "127.0.0.1:26656"
+)
+
+func TestApp_QueryAuthorizedPeers(t *testing.T) {
+	var panicked bool
+	app := &App{
+		logger: logging.NewNoopLogger(),
+		panicFunc: func(e error) {
+			panicked = true
+		},
+		// Given no authorized node defined
+		authorizedPeersProvider: func() ([]string, []string) {
+			return []string{}, []string{}
+		},
+	}
+
+	// When authorized node query is raised with any node id
+	resp := app.Query(*makeTestFilterQuery("id", aNodeId))
+
+	// Then we should authorized any node
+	assert.NotNil(t, resp)
+	assert.Equal(t, codes.PeerFilterAuthorizedCode, resp.Code)
+
+	// Given authorized nodes defined
+	app.authorizedPeersProvider = func() ([]string, []string) {
+		return []string{aNodeId}, []string{aNodeAddress}
+	}
+
+	// When authorized node query is raised for an authorized node by id
+	resp = app.Query(*makeTestFilterQuery("id", aNodeId))
+
+	// Then we should authorize it
+	assert.NotNil(t, resp)
+	assert.Equal(t, codes.PeerFilterAuthorizedCode, resp.Code)
+
+	// When authorized node query is raised for another node by id
+	resp = app.Query(*makeTestFilterQuery("id", "forbiddenId"))
+
+	// Then we should forbid this node to sync
+	assert.NotNil(t, resp)
+	assert.Equal(t, codes.PeerFilterForbiddenCode, resp.Code)
+
+	// When authorized node query is raised for an authorized node by address
+	resp = app.Query(*makeTestFilterQuery("addr", aNodeAddress))
+
+	// Then we should authorize it
+	assert.NotNil(t, resp)
+	assert.Equal(t, codes.PeerFilterAuthorizedCode, resp.Code)
+
+	// When authorized node query is raised for another node
+	resp = app.Query(*makeTestFilterQuery("addr", "forbiddenAddress"))
+
+	// Then we should forbid this node to sync
+	assert.NotNil(t, resp)
+	assert.Equal(t, codes.PeerFilterForbiddenCode, resp.Code)
+
+	// Given a provider which panics
+	assert.False(t, panicked)
+	app.authorizedPeersProvider = func() ([]string, []string) {
+		panic("ouch")
+	}
+
+	// When authorized node query is raised
+	resp = app.Query(*makeTestFilterQuery("addr", "hackMe"))
+
+	// The we should recover and mark the query as unsupported, so the node cannot sync
+	assert.True(t, panicked)
+	assert.NotNil(t, resp)
+	assert.Equal(t, codes.UnsupportedRequestCode, resp.Code)
+}
+
 func TestIsPeersFilterQuery(t *testing.T) {
-	assert.True(t, isPeersFilterQuery(makeTestFilterQuery("id", "836AB8674A33416718E5A19557A25ED826B2BDD3")))
-	assert.True(t, isPeersFilterQuery(makeTestFilterQuery("addr", "127.0.0.1:26656")))
+	assert.True(t, isPeersFilterQuery(makeTestFilterQuery("id", aNodeId)))
+	assert.True(t, isPeersFilterQuery(makeTestFilterQuery("addr", aNodeAddress)))
 	assert.False(t, isPeersFilterQuery(makeTestQuery("/another/query")))
 }
 
-func TestMakeAuthorizedPeersAddress(t *testing.T) {
-	assert.Empty(t, makeAuthorizedPeersAddress(""))
-	assert.Equal(t, []string{"127.0.0.1:26656"},
-		makeAuthorizedPeersAddress("127.0.0.1:26656,836AB8674A33416718E5A19557A25ED826B2BDD3"))
-}
-
-func TestMakeAuthorizedPeersID(t *testing.T) {
-	assert.Equal(t, []string{"836AB8674A33416718E5A19557A25ED826B2BDD3"},
-		makeAuthorizedPeersID("127.0.0.1:26656,836AB8674A33416718E5A19557A25ED826B2BDD3"))
-}
-
 func makeTestFilterQuery(filterType string, peer string) *abciTypes.RequestQuery {
-	return makeTestQuery(fmt.Sprintf("%v/%v/%v", peersFilterQueryPath, filterType, peer))
+	return makeTestQuery(fmt.Sprintf("%v%v/%v", peersFilterQueryPath, filterType, peer))
 }
 
 func makeTestQuery(path string) *types.RequestQuery {

--- a/consensus/tendermint/abci/peers_filter_test.go
+++ b/consensus/tendermint/abci/peers_filter_test.go
@@ -1,0 +1,36 @@
+package abci
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/abci/types"
+	abciTypes "github.com/tendermint/tendermint/abci/types"
+	"testing"
+)
+
+func TestIsPeersFilterQuery(t *testing.T) {
+	assert.True(t, isPeersFilterQuery(makeTestFilterQuery("id", "836AB8674A33416718E5A19557A25ED826B2BDD3")))
+	assert.True(t, isPeersFilterQuery(makeTestFilterQuery("addr", "127.0.0.1:26656")))
+	assert.False(t, isPeersFilterQuery(makeTestQuery("/another/query")))
+}
+
+func TestMakeAuthorizedPeersAddress(t *testing.T) {
+	assert.Empty(t, makeAuthorizedPeersAddress(""))
+	assert.Equal(t, []string{"127.0.0.1:26656"},
+		makeAuthorizedPeersAddress("127.0.0.1:26656,836AB8674A33416718E5A19557A25ED826B2BDD3"))
+}
+
+func TestMakeAuthorizedPeersID(t *testing.T) {
+	assert.Equal(t, []string{"836AB8674A33416718E5A19557A25ED826B2BDD3"},
+		makeAuthorizedPeersID("127.0.0.1:26656,836AB8674A33416718E5A19557A25ED826B2BDD3"))
+}
+
+func makeTestFilterQuery(filterType string, peer string) *abciTypes.RequestQuery {
+	return makeTestQuery(fmt.Sprintf("%v/%v/%v", peersFilterQueryPath, filterType, peer))
+}
+
+func makeTestQuery(path string) *types.RequestQuery {
+	return &abciTypes.RequestQuery{
+		Path: path,
+	}
+}

--- a/consensus/tendermint/codes/codes.go
+++ b/consensus/tendermint/codes/codes.go
@@ -6,10 +6,12 @@ import (
 
 const (
 	// Success
-	TxExecutionSuccessCode uint32 = abci_types.CodeTypeOK
+	TxExecutionSuccessCode   uint32 = abci_types.CodeTypeOK
+	PeerFilterAuthorizedCode uint32 = abci_types.CodeTypeOK
 
 	// Informational
-	UnsupportedRequestCode uint32 = 400
+	UnsupportedRequestCode  uint32 = 400
+	PeerFilterForbiddenCode uint32 = 403
 
 	// Internal errors
 	EncodingErrorCode    uint32 = 500

--- a/consensus/tendermint/config.go
+++ b/consensus/tendermint/config.go
@@ -1,7 +1,10 @@
 package tendermint
 
 import (
+	"github.com/hyperledger/burrow/consensus/tendermint/abci"
 	tm_config "github.com/tendermint/tendermint/config"
+	"net/url"
+	"strings"
 )
 
 // Burrow's view on Tendermint's config. Since we operate as a Tendermint harness not all configuration values
@@ -54,4 +57,23 @@ func (btc *BurrowTendermintConfig) TendermintConfig() *tm_config.Config {
 	// Disable Tendermint RPC
 	conf.RPC.ListenAddress = ""
 	return conf
+}
+
+func (btc *BurrowTendermintConfig) DefaultAuthorizedPeersProvider() abci.PeersFilterProvider {
+	var authorizedPeersID, authorizedPeersAddress []string
+
+	authorizedPeersAddrOrID := strings.Split(btc.AuthorizedPeers, ",")
+	for _, authorizedPeerAddrOrID := range authorizedPeersAddrOrID {
+		_, err := url.Parse(authorizedPeerAddrOrID)
+		isNodeAddress := err != nil
+		if isNodeAddress {
+			authorizedPeersAddress = append(authorizedPeersAddress, authorizedPeerAddrOrID)
+		} else {
+			authorizedPeersID = append(authorizedPeersID, authorizedPeerAddrOrID)
+		}
+	}
+
+	return func() ([]string, []string) {
+		return authorizedPeersID, authorizedPeersAddress
+	}
 }

--- a/consensus/tendermint/config.go
+++ b/consensus/tendermint/config.go
@@ -19,6 +19,8 @@ type BurrowTendermintConfig struct {
 	ExternalAddress string
 	Moniker         string
 	TendermintRoot  string
+	// Peers ID or address this node is authorize to sync with
+	AuthorizedPeers string
 }
 
 func DefaultBurrowTendermintConfig() *BurrowTendermintConfig {
@@ -47,6 +49,7 @@ func (btc *BurrowTendermintConfig) TendermintConfig() *tm_config.Config {
 		conf.Moniker = btc.Moniker
 		// Unfortunately this stops metrics from being used at all
 		conf.Instrumentation.Prometheus = false
+		conf.FilterPeers = btc.AuthorizedPeers != ""
 	}
 	// Disable Tendermint RPC
 	conf.RPC.ListenAddress = ""

--- a/consensus/tendermint/config_test.go
+++ b/consensus/tendermint/config_test.go
@@ -1,0 +1,14 @@
+package tendermint
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDefaultBurrowTendermintConfig(t *testing.T) {
+	btc := DefaultBurrowTendermintConfig()
+	btc.AuthorizedPeers = "127.0.0.1:26656,836AB8674A33416718E5A19557A25ED826B2BDD3"
+	authorizedPeersID, authorizedPeersAddress := btc.DefaultAuthorizedPeersProvider()()
+	assert.Equal(t, []string{"127.0.0.1:26656"}, authorizedPeersAddress)
+	assert.Equal(t, []string{"836AB8674A33416718E5A19557A25ED826B2BDD3"}, authorizedPeersID)
+}

--- a/core/kernel.go
+++ b/core/kernel.go
@@ -79,7 +79,7 @@ type Kernel struct {
 
 func NewKernel(ctx context.Context, keyClient keys.KeyClient, privValidator tmTypes.PrivValidator,
 	genesisDoc *genesis.GenesisDoc, tmConf *tmConfig.Config, rpcConfig *rpc.RPCConfig, keyConfig *keys.KeysConfig,
-	keyStore *keys.KeyStore, exeOptions []execution.ExecutionOption, authorizedPeers string, logger *logging.Logger) (*Kernel, error) {
+	keyStore *keys.KeyStore, exeOptions []execution.ExecutionOption, authorizedPeersProvider abci.PeersFilterProvider, logger *logging.Logger) (*Kernel, error) {
 
 	var err error
 	kern := &Kernel{
@@ -121,7 +121,7 @@ func NewKernel(ctx context.Context, keyClient keys.KeyClient, privValidator tmTy
 	committer := execution.NewBatchCommitter(kern.State, kern.Blockchain, kern.Emitter, kern.Logger, exeOptions...)
 
 	kern.nodeInfo = fmt.Sprintf("Burrow_%s_ValidatorID:%X", genesisDoc.ChainID(), privValidator.GetAddress())
-	app := abci.NewApp(kern.nodeInfo, kern.Blockchain, checker, committer, txCodec, authorizedPeers, kern.Panic, logger)
+	app := abci.NewApp(kern.nodeInfo, kern.Blockchain, checker, committer, txCodec, authorizedPeersProvider, kern.Panic, logger)
 	// We could use this to provide/register our own metrics (though this will register them with us). Unfortunately
 	// Tendermint currently ignores the metrics passed unless its own server is turned on.
 	metricsProvider := node.DefaultMetricsProvider(&tmConfig.InstrumentationConfig{

--- a/core/kernel.go
+++ b/core/kernel.go
@@ -79,7 +79,7 @@ type Kernel struct {
 
 func NewKernel(ctx context.Context, keyClient keys.KeyClient, privValidator tmTypes.PrivValidator,
 	genesisDoc *genesis.GenesisDoc, tmConf *tmConfig.Config, rpcConfig *rpc.RPCConfig, keyConfig *keys.KeysConfig,
-	keyStore *keys.KeyStore, exeOptions []execution.ExecutionOption, logger *logging.Logger) (*Kernel, error) {
+	keyStore *keys.KeyStore, exeOptions []execution.ExecutionOption, authorizedPeers string, logger *logging.Logger) (*Kernel, error) {
 
 	var err error
 	kern := &Kernel{
@@ -121,7 +121,7 @@ func NewKernel(ctx context.Context, keyClient keys.KeyClient, privValidator tmTy
 	committer := execution.NewBatchCommitter(kern.State, kern.Blockchain, kern.Emitter, kern.Logger, exeOptions...)
 
 	kern.nodeInfo = fmt.Sprintf("Burrow_%s_ValidatorID:%X", genesisDoc.ChainID(), privValidator.GetAddress())
-	app := abci.NewApp(kern.nodeInfo, kern.Blockchain, checker, committer, txCodec, kern.Panic, logger)
+	app := abci.NewApp(kern.nodeInfo, kern.Blockchain, checker, committer, txCodec, authorizedPeers, kern.Panic, logger)
 	// We could use this to provide/register our own metrics (though this will register them with us). Unfortunately
 	// Tendermint currently ignores the metrics passed unless its own server is turned on.
 	metricsProvider := node.DefaultMetricsProvider(&tmConfig.InstrumentationConfig{

--- a/integration/core/kernel_test.go
+++ b/integration/core/kernel_test.go
@@ -129,7 +129,7 @@ func bootWaitBlocksShutdown(t testing.TB, privValidator tmTypes.PrivValidator, t
 		testConfig.Tendermint.TendermintConfig(),
 		testConfig.RPC,
 		testConfig.Keys,
-		keyStore, nil, "", logger)
+		keyStore, nil, testConfig.Tendermint.DefaultAuthorizedPeersProvider(), logger)
 	if err != nil {
 		return err
 	}

--- a/integration/core/kernel_test.go
+++ b/integration/core/kernel_test.go
@@ -129,7 +129,7 @@ func bootWaitBlocksShutdown(t testing.TB, privValidator tmTypes.PrivValidator, t
 		testConfig.Tendermint.TendermintConfig(),
 		testConfig.RPC,
 		testConfig.Keys,
-		keyStore, nil, logger)
+		keyStore, nil, "", logger)
 	if err != nil {
 		return err
 	}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -84,6 +84,7 @@ func TestKernel(validatorAccount *acm.PrivateAccount, keysAccounts []*acm.Privat
 		testConfig.Keys,
 		nil,
 		[]execution.ExecutionOption{execution.VMOptions(evm.DebugOpcodes)},
+		"",
 		logger)
 	if err != nil {
 		panic(err)

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -84,7 +84,7 @@ func TestKernel(validatorAccount *acm.PrivateAccount, keysAccounts []*acm.Privat
 		testConfig.Keys,
 		nil,
 		[]execution.ExecutionOption{execution.VMOptions(evm.DebugOpcodes)},
-		"",
+		testConfig.Tendermint.DefaultAuthorizedPeersProvider(),
 		logger)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Ability to lock down a network syncing with unauthorized peers. Currently any node that can connect to the network will begin syncing and be able to pull the state. However, for a lot of use cases this is not desired and what is more desired is a network setup where validators only sync with validators/fullNodes that have been authorized.

Designed to support static configuration or dynamic peers ids/addresses provided at peer handkshaking time.

fix #669