### PR TITLE
[docs] Updating docs with multiple validators config, initialize docs folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See the [install instructions](docs/INSTALL.md).
 1. [Send transactions](docs/quickstart/send-transactions.md)
 1. [Deploy contracts](docs/quickstart/deploy-contracts.md)
 1. [Multiple validators](docs/quickstart/multiple-validators.md)
+1. [Seed nodes](docs/quickstart/seed-nodes.md)
 
 ## Project documentation
 Burrow documentation is available in the [docs](docs/README.md) directory.

--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ Go version | Go1.10 or higher
 See the [install instructions](docs/INSTALL.md).
 
 ## Quick Start
-1. [Single full node](docs/quickstart/single-full-node.md)
-1. [Send transactions](docs/quickstart/send-transactions.md)
-1. [Deploy contracts](docs/quickstart/deploy-contracts.md)
-1. [Multiple validators](docs/quickstart/multiple-validators.md)
-1. [Seed nodes](docs/quickstart/seed-nodes.md)
+1. [Single full node](docs/quickstart/single-full-node.md) - start your first chain
+1. [Send transactions](docs/quickstart/send-transactions.md) - how to communicate with your Burrow chain
+1. [Deploy contracts](docs/quickstart/deploy-contracts.md) - interact with the Ethereum Virtual Machine
+1. [Multiple validators](docs/quickstart/multiple-validators.md) - advanced consensus setup
+1. [Seed nodes](docs/quickstart/seed-nodes.md) - add new node dynamically
+1. [Kubernetes](https://github.com/helm/charts/tree/master/stable/burrow) - bootstraps a burrow network on a Kubernetes cluster
 
 ## Project documentation
-Burrow documentation is available in the [docs](docs/README.md) directory.
+Burrow getting started documentation is available in the [docs](docs/README.md) directory and in [GoDocs](https://godoc.org/github.com/hyperledger/burrow).
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Hyperledger Burrow
 
-|[![GoDoc](https://godoc.org/github.com/burrow?status.png)](https://godoc.org/github.com/hyperledger/burrow) | Linux |
-|---|-------|
+[![version](https://img.shields.io/github/tag/hyperledger/burrow.svg)](https://github.com/hyperledger/burrow/releases/latest)
+[![GoDoc](https://godoc.org/github.com/burrow?status.png)](https://godoc.org/github.com/hyperledger/burrow)
+[![license](https://img.shields.io/github/license/hyperledger/burrow.svg)](LICENSE.md)
+[![LoC](https://tokei.rs/b1/github/hyperledger/burrow?category=lines)](https://github.com/hyperledger/burrow)
+
+Branch    | Linux
+----------|------
 | Master | [![Circle CI](https://circleci.com/gh/hyperledger/burrow/tree/master.svg?style=svg)](https://circleci.com/gh/hyperledger/burrow/tree/master) |
 | Develop | [![Circle CI (develop)](https://circleci.com/gh/hyperledger/burrow/tree/develop.svg?style=svg)](https://circleci.com/gh/hyperledger/burrow/tree/develop) |
 
@@ -20,349 +25,28 @@ Hyperledger Burrow is a permissioned blockchain node that executes smart contrac
 - **Application Binary Interface (ABI):** Transactions need to be formulated in a binary format that can be processed by the blockchain node. Current tooling provides functionality to compile, deploy and link solidity smart contracts and formulate transactions to call smart contracts on the chain.
 - **API Gateway:** Burrow exposes REST and JSON-RPC endpoints to interact with the blockchain network and the application state through broadcasting transactions, or querying the current state of the application. Websockets allow subscribing to events, which is particularly valuable as the consensus engine and smart contract application can give unambiguously finalised results to transactions within one blocktime of about one second.
 
-## Project documentation and Roadmap
+## Project Roadmap
 
 Project information generally updated on a quarterly basis can be found on the [Hyperledger Burrow Wiki](https://wiki.hyperledger.org/projects/burrow).
 
+## Minimum requirements
+
+Requirement|Notes
+---|---
+Go version | Go1.10 or higher
+
 ## Installation
 
-- [Install go](https://golang.org/doc/install) version 1.10 or above and have `$GOPATH` set
-
-```
-go get github.com/hyperledger/burrow
-cd github.com/hyperledger/burrow
-make build
-```
-
-This will build the `burrow` and `burrow-client` binaries and put them in the `bin/` directory. They can be executed from there or put wherever is convenient.
-
-You can also install `burrow` into `$GOPATH/bin` with `make install_burrow`,
-
-## Usage
-
-The end result will be a `burrow.toml` that will be read in from your current working directory when starting `burrow`.
-
-### Configuration
-
-#### Configure Burrow
-The quick-and-dirty one-liner looks like:
-
-```shell
-# Read spec on stdin
-burrow spec -p1 -f1 | burrow configure -s- > burrow.toml
-```
-
-which translates into:
-
-```shell
-# This is a place we can store config files and burrow's working directory '.burrow'
-mkdir chain_dir && cd chain_dir
-burrow spec --participant-accounts=1 --full-accounts=1 > genesis-spec.json
-burrow configure --genesis-spec=genesis-spec.json > burrow.toml
-```
-#### Run Burrow
-Once the `burrow.toml` has been created, we run:
-
-```
-# To select our validator address by index in the GenesisDoc
-burrow start --validator-index=0
-# Or to select based on address directly (substituting the example address below with your validator's):
-burrow start --validator-address=BE584820DC904A55449D7EB0C97607B40224B96E
-```
-
-and the logs will start streaming through.
-
-If you would like to reset your node, you can just delete its working directory with `rm -rf .burrow`. In the context of a
-multi-node chain it will resync with peers, otherwise it will restart from height 0.
-
-### Logging
-
-Logging is highly configurable through the `burrow.toml` `[logging]` section. Each log line is a list of key-value pairs that flows from the root sink through possible child sinks. Each sink can have an output, a transform, and sinks that it outputs to. Below is a more involved example than the one appearing in the default generated config of what you can configure:
-
-```toml
-# This is a top level config section within the main Burrow config
-[logging]
-  # All log lines are sent to the root sink from all sources
-  [logging.root_sink]
-    # We define two child sinks that each receive all log lines
-    [[logging.root_sink.sinks]]
-      # We send all output to stderr
-      [logging.root_sink.sinks.output]
-        output_type = "stderr"
-
-    [[logging.root_sink.sinks]]
-      # But for the second sink we define a transform that filters log lines from Tendermint's p2p module
-      [logging.root_sink.sinks.transform]
-        transform_type = "filter"
-        filter_mode = "exclude_when_all_match"
-
-        [[logging.root_sink.sinks.transform.predicates]]
-          key_regex = "module"
-          value_regex = "p2p"
-
-        [[logging.root_sink.sinks.transform.predicates]]
-          key_regex = "captured_logging_source"
-          value_regex = "tendermint_log15"
-
-      # The child sinks of this filter transform sink are syslog and file and will omit log lines originating from p2p
-      [[logging.root_sink.sinks.sinks]]
-        [logging.root_sink.sinks.sinks.output]
-          output_type = "syslog"
-          url = ""
-          tag = "Burrow-network"
-
-      [[logging.root_sink.sinks.sinks]]
-        [logging.root_sink.sinks.sinks.output]
-          output_type = "file"
-          path = "/var/log/burrow-network.log"
-```
-## Deploy Contracts
-
-Now that the burrow node is running, we can deploy contracts.
-
-For this step, we need two things: one or more solidity contracts, and an `deploy.yaml`.
-
-Let's take a simple example, found in [this directory](tests/jobs_fixtures/app06-deploy_basic_contract_and_different_solc_types_packed_unpacked/).
-
-The `deploy.yaml` should look like:
-
-```
-jobs:
-
-- name: deployStorageK
-  deploy:
-    contract: storage.sol
-
-- name: setStorageBaseBool
-  set:
-    val: "true"
-
-- name: setStorageBool
-  call:
-    destination: $deployStorageK
-    function: setBool
-    data: [$setStorageBaseBool]
-
-- name: queryStorageBool
-  query-contract:
-    destination: $deployStorageK
-    function: getBool
-
-- name: assertStorageBool
-  assert:
-    key: $queryStorageBool
-    relation: eq
-    val: $setStorageBaseBool
-
-# tests string bools: #71
-- name: setStorageBool2
-  call:
-    destination: $deployStorageK
-    function: setBool2
-    data: [true]
-
-- name: queryStorageBool2
-  query-contract:
-    destination: $deployStorageK
-    function: getBool2
-
-- name: assertStorageBool2
-  assert:
-    key: $queryStorageBool2
-    relation: eq
-    val: "true"
-
-- name: setStorageBaseInt
-  set:
-    val: 50000
-
-- name: setStorageInt
-  call:
-    destination: $deployStorageK
-    function: setInt
-    data: [$setStorageBaseInt]
-
-- name: queryStorageInt
-  query-contract:
-    destination: $deployStorageK
-    function: getInt
-
-- name: assertStorageInt
-  assert:
-    key: $queryStorageInt
-    relation: eq
-    val: $setStorageBaseInt
-
-- name: setStorageBaseUint
-  set:
-    val: 9999999
-
-- name: setStorageUint
-  call:
-    destination: $deployStorageK
-    function: setUint
-    data: [$setStorageBaseUint]
-
-- name: queryStorageUint
-  query-contract:
-    destination: $deployStorageK
-    function: getUint
-
-- name: assertStorageUint
-  assert:
-    key: $queryStorageUint
-    relation: eq
-    val: $setStorageBaseUint
-
-- name: setStorageBaseAddress
-  set:
-    val: "1040E6521541DAB4E7EE57F21226DD17CE9F0FB7"
-
-- name: setStorageAddress
-  call:
-    destination: $deployStorageK
-    function: setAddress
-    data: [$setStorageBaseAddress]
-
-- name: queryStorageAddress
-  query-contract:
-    destination: $deployStorageK
-    function: getAddress
-
-- name: assertStorageAddress
-  assert:
-    key: $queryStorageAddress
-    relation: eq
-    val: $setStorageBaseAddress
-
-- name: setStorageBaseBytes
-  set:
-    val: marmatoshi
-
-- name: setStorageBytes
-  call:
-    destination: $deployStorageK
-    function: setBytes
-    data: [$setStorageBaseBytes]
-
-- name: queryStorageBytes
-  query-contract:
-    destination: $deployStorageK
-    function: getBytes
-
-- name: assertStorageBytes
-  assert:
-    key: $queryStorageBytes
-    relation: eq
-    val: $setStorageBaseBytes
-
-- name: setStorageBaseString
-  set:
-    val: nakaburrow
-
-- name: setStorageString
-  call:
-    destination: $deployStorageK
-    function: setString
-    data: [$setStorageBaseString]
-
-- name: queryStorageString
-  query-contract:
-    destination: $deployStorageK
-    function: getString
-
-- name: assertStorageString
-  assert:
-    key: $queryStorageString
-    relation: eq
-    val: $setStorageBaseString
-```
-
-while our Solidity contract (`storage.sol`) looks like:
-
-```
-pragma solidity >=0.0.0;
-
-contract SimpleStorage {
-  bool storedBool;
-  bool storedBool2;
-  int storedInt;
-  uint storedUint;
-  address storedAddress;
-  bytes32 storedBytes;
-  string storedString;
-
-  function setBool(bool x) {
-    storedBool = x;
-  }
-
-  function getBool() constant returns (bool retBool) {
-    return storedBool;
-  }
-
-  function setBool2(bool x) {
-    storedBool2 = x;
-  }
-
-  function getBool2() constant returns (bool retBool) {
-    return storedBool2;
-  }
-
-  function setInt(int x) {
-    storedInt = x;
-  }
-
-  function getInt() constant returns (int retInt) {
-    return storedInt;
-  }
-
-  function setUint(uint x) {
-    storedUint = x;
-  }
-
-  function getUint() constant returns (uint retUint) {
-    return storedUint;
-  }
-
-  function setAddress(address x) {
-    storedAddress = x;
-  }
-
-  function getAddress() constant returns (address retAddress) {
-    return storedAddress;
-  }
-
-  function setBytes(bytes32 x) {
-    storedBytes = x;
-  }
-
-  function getBytes() constant returns (bytes32 retBytes) {
-    return storedBytes;
-  }
-
-  function setString(string x) {
-    storedString = x;
-  }
-
-  function getString() constant returns (string retString) {
-    return storedString;
-  }
-}
-```
-
-Both files (`deploy.yaml` & `storage.sol`) should be in the same directory with no other yaml or sol files.
-
-From inside that directory, we are ready to deploy.
-
-```
-burrow deploy --address=F71831847564B7008AD30DD56336D9C42787CF63
-```
-
-where you should replace the `--address` field with the `ValidatorAddress` at the top of your `burrow.toml`.
-
-That's it! You've succesfully deployed (and tested) a Soldity contract to a Burrow node.
-
-Note - that to redeploy the burrow chain later, you will need the same genesis-spec.json and burrow.toml files - so keep hold of them!
+See the [install instructions](docs/INSTALL.md).
+
+## Quick Start
+1. [Single full node](docs/quickstart/single-full-node.md)
+1. [Send transactions](docs/quickstart/send-transactions.md)
+1. [Deploy contracts](docs/quickstart/deploy-contracts.md)
+1. [Multiple validators](docs/quickstart/multiple-validators.md)
+
+## Project documentation
+Burrow documentation is available in the [docs](docs/README.md) directory.
 
 ## Contribute
 
@@ -375,7 +59,7 @@ You can find us on:
 
 ## Future work
 
-For some (slightly outdated) ideas on future work, see the [proposals document](./docs/PROPOSALS.md).
+For some (slightly outdated) ideas on future work, see the [proposals document](docs/PROPOSALS.md).
 
 ## License
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,13 @@
+## Installation
+
+- [Install go](https://golang.org/doc/install) version 1.10 or above and have `$GOPATH` set
+
+```
+go get github.com/hyperledger/burrow
+cd $GOPATH/github.com/hyperledger/burrow
+make build
+```
+
+This will build the `burrow` and `burrow-client` binaries and put them in the `bin/` directory. They can be executed from there or put wherever is convenient.
+
+You can also install `burrow` into `$GOPATH/bin` with `make install_burrow`,

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -1,0 +1,41 @@
+# Logging
+
+Logging is highly configurable through the `burrow.toml` `[logging]` section. Each log line is a list of key-value pairs that flows from the root sink through possible child sinks. Each sink can have an output, a transform, and sinks that it outputs to. Below is a more involved example than the one appearing in the default generated config of what you can configure:
+
+```toml
+# This is a top level config section within the main Burrow config
+[logging]
+  # All log lines are sent to the root sink from all sources
+  [logging.root_sink]
+    # We define two child sinks that each receive all log lines
+    [[logging.root_sink.sinks]]
+      # We send all output to stderr
+      [logging.root_sink.sinks.output]
+        output_type = "stderr"
+
+    [[logging.root_sink.sinks]]
+      # But for the second sink we define a transform that filters log lines from Tendermint's p2p module
+      [logging.root_sink.sinks.transform]
+        transform_type = "filter"
+        filter_mode = "exclude_when_all_match"
+
+        [[logging.root_sink.sinks.transform.predicates]]
+          key_regex = "module"
+          value_regex = "p2p"
+
+        [[logging.root_sink.sinks.transform.predicates]]
+          key_regex = "captured_logging_source"
+          value_regex = "tendermint_log15"
+
+      # The child sinks of this filter transform sink are syslog and file and will omit log lines originating from p2p
+      [[logging.root_sink.sinks.sinks]]
+        [logging.root_sink.sinks.sinks.output]
+          output_type = "syslog"
+          url = ""
+          tag = "Burrow-network"
+
+      [[logging.root_sink.sinks.sinks]]
+        [logging.root_sink.sinks.sinks.output]
+          output_type = "file"
+          path = "/var/log/burrow-network.log"
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,10 @@ Hyperledger Burrow is a permissioned Ethereum smart-contract blockchain node. It
 1. [Installation](INSTALL.md)
 1. [Logging](LOGGING.md)
 1. [Quickstart](quickstart)
+  * [Single full node](docs/quickstart/single-full-node.md) - start your first chain
+  * [Send transactions](docs/quickstart/send-transactions.md) - how to communicate with your Burrow chain
+  * [Deploy contracts](docs/quickstart/deploy-contracts.md) - interact with the Ethereum Virtual Machine
+  * [Multiple validators](docs/quickstart/multiple-validators.md) - advanced consensus setup
+  * [Seed nodes](docs/quickstart/seed-nodes.md) - add new node dynamically
+  * [Kubernetes](https://github.com/helm/charts/tree/master/stable/burrow) - bootstraps a burrow network on a Kubernetes cluster
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Hyperledger Burrow Documentation
+
+Hyperledger Burrow is a permissioned Ethereum smart-contract blockchain node. It executes Ethereum EVM smart contract code (usually written in [Solidity](https://solidity.readthedocs.io)) on a permissioned virtual machine. Burrow provides transaction finality and high transaction throughput on a proof-of-stake [Tendermint](https://tendermint.com) consensus engine.
+
+![burrow logo](images/burrow.png)
+
+1. [Installation](INSTALL.md)
+1. [Logging](LOGGING.md)
+1. [Quickstart](quickstart)

--- a/docs/quickstart/deploy-contracts.md
+++ b/docs/quickstart/deploy-contracts.md
@@ -1,0 +1,257 @@
+# Deploy Contracts
+
+Now that the [burrow node is running](single-full-node.md), we can deploy contracts.
+
+For this step, we need two things: one or more solidity contracts, and an `deploy.yaml`.
+
+Let's take a simple example, found in [this directory](../../tests/jobs_fixtures/app06-deploy_basic_contract_and_different_solc_types_packed_unpacked/).
+
+The `deploy.yaml` should look like:
+
+```yaml
+jobs:
+
+- name: deployStorageK
+  deploy:
+      contract: storage.sol
+
+- name: setStorageBaseBool
+  set:
+      val: "true"
+
+- name: setStorageBool
+  call:
+      destination: $deployStorageK
+      function: setBool
+      data:
+        - $setStorageBaseBool
+
+- name: queryStorageBool
+  query-contract:
+      destination: $deployStorageK
+      function: getBool
+
+- name: assertStorageBool
+  assert:
+      key: $queryStorageBool
+      relation: eq
+      val: $setStorageBaseBool
+
+# tests string bools: #71
+- name: setStorageBool2
+  call:
+      destination: $deployStorageK
+      function: setBool2
+      data:
+        - true
+
+- name: queryStorageBool2
+  query-contract:
+      destination: $deployStorageK
+      function: getBool2
+
+- name: assertStorageBool2
+  assert:
+      key: $queryStorageBool2
+      relation: eq
+      val: "true"
+
+- name: setStorageBaseInt
+  set:
+      val: 50000
+
+- name: setStorageInt
+  call:
+      destination: $deployStorageK
+      function: setInt
+      data:
+        - $setStorageBaseInt
+
+- name: queryStorageInt
+  query-contract:
+      destination: $deployStorageK
+      function: getInt
+
+- name: assertStorageInt
+  assert:
+      key: $queryStorageInt
+      relation: eq
+      val: $setStorageBaseInt
+
+- name: setStorageBaseUint
+  set:
+      val: 9999999
+
+- name: setStorageUint
+  call:
+      destination: $deployStorageK
+      function: setUint
+      data:
+        - $setStorageBaseUint
+
+- name: queryStorageUint
+  query-contract:
+      destination: $deployStorageK
+      function: getUint
+
+- name: assertStorageUint
+  assert:
+      key: $queryStorageUint
+      relation: eq
+      val: $setStorageBaseUint
+
+- name: setStorageBaseAddress
+  set:
+      val: "1040E6521541DAB4E7EE57F21226DD17CE9F0FB7"
+
+- name: setStorageAddress
+  call:
+      destination: $deployStorageK
+      function: setAddress
+      data:
+        - $setStorageBaseAddress
+
+- name: queryStorageAddress
+  query-contract:
+      destination: $deployStorageK
+      function: getAddress
+
+- name: assertStorageAddress
+  assert:
+      key: $queryStorageAddress
+      relation: eq
+      val: $setStorageBaseAddress
+
+- name: setStorageBaseBytes
+  set:
+      val: marmatoshi
+
+- name: setStorageBytes
+  call:
+      destination: $deployStorageK
+      function: setBytes
+      data:
+        - $setStorageBaseBytes
+
+- name: queryStorageBytes
+  query-contract:
+      destination: $deployStorageK
+      function: getBytes
+
+- name: assertStorageBytes
+  assert:
+      key: $queryStorageBytes
+      relation: eq
+      val: $setStorageBaseBytes
+
+- name: setStorageBaseString
+  set:
+      val: nakaburrow
+
+- name: setStorageString
+  call:
+      destination: $deployStorageK
+      function: setString
+      data:
+        - $setStorageBaseString
+
+- name: queryStorageString
+  query-contract:
+      destination: $deployStorageK
+      function: getString
+
+- name: assertStorageString
+  assert:
+      key: $queryStorageString
+      relation: eq
+      val: $setStorageBaseString
+
+```
+
+while our Solidity contract (`storage.sol`) looks like:
+
+```
+pragma solidity >=0.0.0;
+
+contract SimpleStorage {
+  bool storedBool;
+  bool storedBool2;
+  int storedInt;
+  uint storedUint;
+  address storedAddress;
+  bytes32 storedBytes;
+  string storedString;
+
+  function setBool(bool x) public {
+    storedBool = x;
+  }
+
+  function getBool() constant public returns (bool retBool) {
+    return storedBool;
+  }
+
+  function setBool2(bool x) public {
+    storedBool2 = x;
+  }
+
+  function getBool2() constant public returns (bool retBool) {
+    return storedBool2;
+  }
+
+  function setInt(int x) public {
+    storedInt = x;
+  }
+
+  function getInt() constant public returns (int retInt) {
+    return storedInt;
+  }
+
+  function setUint(uint x) public {
+    storedUint = x;
+  }
+
+  function getUint() constant public returns (uint retUint) {
+    return storedUint;
+  }
+
+  function setAddress(address x) public {
+    storedAddress = x;
+  }
+
+  function getAddress() constant public returns (address retAddress) {
+    return storedAddress;
+  }
+
+  function setBytes(bytes32 x) public {
+    storedBytes = x;
+  }
+
+  function getBytes() constant public returns (bytes32 retBytes) {
+    return storedBytes;
+  }
+
+  function setString(string x) public {
+    storedString = x;
+  }
+
+  function getString() constant public returns (string retString) {
+    return storedString;
+  }
+}
+```
+
+Both files (`deploy.yaml` & `storage.sol`) should be in the same directory with **no other yaml** or sol files.
+
+You have to install [solc binary](https://solidity.readthedocs.io/en/v0.4.21/installing-solidity.html) in order to compile Solidity code.
+
+From inside that directory, we are ready to deploy.
+
+```bash
+burrow deploy --address F71831847564B7008AD30DD56336D9C42787CF63
+```
+
+where you should replace the `--address` field with the `ValidatorAddress` at the top of your `burrow.toml`.
+
+That's it! You've successfully deployed (and tested) a Solidity contract to a Burrow node.
+
+Note - that to redeploy the burrow chain later, you will need the same genesis-spec.json and burrow.toml files - so keep hold of them!

--- a/docs/quickstart/multiple-validators.md
+++ b/docs/quickstart/multiple-validators.md
@@ -1,0 +1,127 @@
+# Multiple validators
+
+### Configure a chain with 2 full accounts and validators
+```bash
+ rm -rf .burrow* .keys*
+ burrow spec -f2 | burrow configure -s- > .burrow_init.toml
+```
+
+### Configure 2 validator nodes config files
+From the generated `.burrow_init.toml `file, create new files for each node, and change the content, example:
+
+#### Validator 1 node `.burrow_val0.toml` modified line from `.burrow_init.toml`
+
+```toml
+[Tendermint]
+  Seeds = ""
+  SeedMode = false
+  PersistentPeers = ""
+  ListenAddress = "tcp://0.0.0.0:20000"
+  Moniker = "val_node_0"
+  TendermintRoot = ".burrow_node0"
+
+[Execution]
+
+[Keys]
+  GRPCServiceEnabled = false
+  AllowBadFilePermissions = true
+  RemoteAddress = ""
+  KeysDirectory = ".keys"
+
+[RPC]
+  [RPC.Info]
+    Enabled = true
+    ListenAddress = "tcp://127.0.0.1:20001"
+  [RPC.Profiler]
+    Enabled = false
+  [RPC.GRPC]
+    Enabled = true
+    ListenAddress = "127.0.0.1:20002"
+  [RPC.Metrics]
+    Enabled = false
+```
+
+#### Validator 2 node `.burrow_val1.toml` modified line from `.burrow_init.toml`
+
+```toml
+[Tendermint]
+  Seeds = ""
+  SeedMode = false
+  PersistentPeers = "PUT_HERE_NODE_0_ID@LISTEN_EXTERNAL_ADDRESS"
+  ListenAddress = "tcp://0.0.0.0:30000"
+  Moniker = "val_node_1"
+  TendermintRoot = ".burrow_node1"
+
+[Execution]
+
+[Keys]
+  GRPCServiceEnabled = false
+  AllowBadFilePermissions = true
+  RemoteAddress = ""
+  KeysDirectory = ".keys"
+
+[RPC]
+  [RPC.Info]
+    Enabled = true
+    ListenAddress = "tcp://127.0.0.1:30001"
+  [RPC.Profiler]
+    Enabled = false
+  [RPC.GRPC]
+    Enabled = true
+    ListenAddress = "127.0.0.1:30002"
+  [RPC.Metrics]
+    Enabled = false
+```
+
+Node 0 will be defined as persistent peer of node 1.
+Persistent peers are people you want to be constantly connected with.
+
+### Start the network
+
+#### Start the first node
+```bash
+burrow start --validator-index=0 --config=.burrow_val0.toml
+```
+
+You will see `Blockpool has no peers` in console logs.
+The node has not enough validator power in order to have quorum (2/3) on the network, so it is blocked waiting for the second validator to join.
+
+#### Find the first node identifier and address
+
+Configure second node to persistently connect to the first node.
+
+```bash
+NODE_0_URL=`curl -s 127.0.0.1:20001/network | jq -r '.result.ThisNode | [.ID, .ListenAddress] | join("@") | ascii_downcase'`
+sed -i s%PUT_HERE_NODE_0_ID@LISTEN_EXTERNAL_ADDRESS%${NODE_0_URL}% .burrow_val1.toml
+```
+
+#### Start the second node
+
+```bash
+burrow start --validator-index=1 --config=.burrow_val1.toml
+```
+
+If the connection successed, you will see empty blocks automatically created `Sending vote message` and `Finalizing commit of block with 0 txs`, you can see consensus state:
+```bash
+curl -s 127.0.0.1:20001/consensus
+```
+
+#### Disable Tendermint strict address if required
+If you face `Cannot add non-routable address` message in logs, it means your listen address is not routable for tendermint.
+
+You can disable this check by modified default tendermint/config.go:46 and rebuild burrow:
+```go
+conf.P2P.AddrBookStrict = false
+```
+
+Or explicitly set an external routable address, for example on node 0, if you have a net interface on `172.217.19.227`:
+```toml
+[Tendermint]
+  ExternalAddress = "172.217.19.227:20000"
+```
+
+Update `PersistentPeers` property of node 1 with this new address.
+
+## Send transactions to the blockchain
+
+You can start to [send transactions](send-transactions.md).

--- a/docs/quickstart/seed-nodes.md
+++ b/docs/quickstart/seed-nodes.md
@@ -1,0 +1,189 @@
+# Network with seed nodes
+
+## What is a seed node
+
+According to [Tendermint documentation](https://tendermint.com/docs/tendermint-core/using-tendermint.html#seed):
+>A seed node is a node who relays the addresses of other peers which they know
+of. These nodes constantly crawl the network to try to get more peers. The
+addresses which the seed node relays get saved into a local address book. Once
+these are in the address book, you will connect to those addresses directly.
+Basically the seed nodes job is just to relay everyones addresses. You won't
+connect to seed nodes once you have received enough addresses, so typically you
+only need them on the first start. The seed node will immediately disconnect
+from you after sending you some addresses.
+
+## Configure network
+
+In this quick start, we will few create validator nodes which does not know each other from network point of view.
+A seed node will crawl the network and relay everyones addresses.
+
+### Configure chain
+
+```bash
+rm -rf .burrow* .keys*
+burrow spec --full-accounts=3 | burrow configure -s- > .burrow_init.toml
+```
+
+### Generate one additional key in another local store for seed node
+```bash
+burrow spec -f1 | burrow configure --keysdir=.keys_seed -s- > /dev/null
+```
+
+### Make 3 validator nodes and one seed node config files
+From the generated `.burrow_init.toml `file, create new files for each node, and change the content, example:
+
+#### Seed node `.burrow_seed.toml` modified line from `.burrow_init.toml`
+```toml
+[Tendermint]
+  SeedMode = true
+  ListenAddress = "tcp://0.0.0.0:10000"
+  Moniker = "seed_node_0"
+  TendermintRoot = ".burrow_seed_0"
+
+[Execution]
+
+[Keys]
+  GRPCServiceEnabled = false
+  AllowBadFilePermissions = true
+  RemoteAddress = ""
+  KeysDirectory = ".keys_seed"
+
+[RPC]
+  [RPC.Info]
+    Enabled = true
+    ListenAddress = "tcp://127.0.0.1:10001"
+  [RPC.Profiler]
+    Enabled = false
+  [RPC.GRPC]
+    Enabled = false
+  [RPC.Metrics]
+    Enabled = false
+```
+
+#### Validator 1 node `.burrow_val0.toml` modified line from `.burrow_init.toml`
+
+```toml
+[Tendermint]
+  Seeds = "PUT_HERE_SEED_NODE_ID@LISTEN_EXTERNAL_ADDRESS"
+  SeedMode = false
+  PersistentPeers = ""
+  ListenAddress = "tcp://0.0.0.0:20000"
+  Moniker = "val_node_0"
+  TendermintRoot = ".burrow_node0"
+
+[Execution]
+
+[Keys]
+  GRPCServiceEnabled = false
+  AllowBadFilePermissions = true
+  RemoteAddress = ""
+  KeysDirectory = ".keys"
+
+[RPC]
+  [RPC.Info]
+    Enabled = true
+    ListenAddress = "tcp://127.0.0.1:20001"
+  [RPC.Profiler]
+    Enabled = false
+  [RPC.GRPC]
+    Enabled = true
+    ListenAddress = "127.0.0.1:20002"
+  [RPC.Metrics]
+    Enabled = false
+```
+
+#### Validator 2 node `.burrow_val1.toml` modified line from `.burrow_init.toml`
+
+```toml
+[Tendermint]
+  Seeds = "PUT_HERE_SEED_NODE_ID@LISTEN_EXTERNAL_ADDRESS"
+  SeedMode = false
+  PersistentPeers = ""
+  ListenAddress = "tcp://0.0.0.0:30000"
+  Moniker = "val_node_1"
+  TendermintRoot = ".burrow_node1"
+
+[Execution]
+
+[Keys]
+  GRPCServiceEnabled = false
+  AllowBadFilePermissions = true
+  RemoteAddress = ""
+  KeysDirectory = ".keys"
+
+[RPC]
+  [RPC.Info]
+    Enabled = true
+    ListenAddress = "tcp://127.0.0.1:30001"
+  [RPC.Profiler]
+    Enabled = false
+  [RPC.GRPC]
+    Enabled = true
+    ListenAddress = "127.0.0.1:30002"
+  [RPC.Metrics]
+    Enabled = false
+```
+
+
+#### Validator 3 node `.burrow_val2.toml` modified line from `.burrow_init.toml`
+
+```toml
+[Tendermint]
+  Seeds = "PUT_HERE_SEED_NODE_ID@LISTEN_EXTERNAL_ADDRESS"
+  SeedMode = false
+  PersistentPeers = ""
+  ListenAddress = "tcp://0.0.0.0:40000"
+  Moniker = "val_node_1"
+  TendermintRoot = ".burrow_node2"
+
+[Execution]
+
+[Keys]
+  GRPCServiceEnabled = false
+  AllowBadFilePermissions = true
+  RemoteAddress = ""
+  KeysDirectory = ".keys"
+
+[RPC]
+  [RPC.Info]
+    Enabled = true
+    ListenAddress = "tcp://127.0.0.1:40001"
+  [RPC.Profiler]
+    Enabled = false
+  [RPC.GRPC]
+    Enabled = true
+    ListenAddress = "127.0.0.1:40002"
+  [RPC.Metrics]
+    Enabled = false
+```
+
+#### Start the seed node
+```bash
+burrow start --validator-address=`basename .keys_seed/data/* .json` --config=.burrow_seed.toml  > .burrow_seed.log 2>&1 &
+```
+
+#### Find seed node external address
+Tendermint requires strict and routable address (not loopback, local etc), you can find the listen address with this command:
+```bash
+SEED_URL=`curl -s 127.0.0.1:10001/network | jq -r '.result.ThisNode | [.ID, .ListenAddress] | join("@") | ascii_downcase'`
+echo $SEED_URL
+```
+
+#### Configure other node to connect to seed node
+Update other nodes with that seed address:
+```bash
+sed -i s%PUT_HERE_SEED_NODE_ID@LISTEN_EXTERNAL_ADDRESS%${SEED_URL}% .burrow_val0.toml
+sed -i s%PUT_HERE_SEED_NODE_ID@LISTEN_EXTERNAL_ADDRESS%${SEED_URL}% .burrow_val1.toml
+sed -i s%PUT_HERE_SEED_NODE_ID@LISTEN_EXTERNAL_ADDRESS%${SEED_URL}% .burrow_val2.toml
+```
+
+#### Start validator nodes
+```bash
+burrow start --validator-index=0 --config=.burrow_val0.toml  > .burrow_val0.log 2>&1 &
+burrow start --validator-index=1 --config=.burrow_val1.toml  > .burrow_val1.log 2>&1 &
+burrow start --validator-index=2 --config=.burrow_val2.toml  > .burrow_val2.log 2>&1 &
+```
+
+Nodes will connect to seed node and request addresses, then they will connect to each other and start submitting and voting on blocks.
+
+At the moment, there is an [issue](https://github.com/tendermint/tendermint/issues/2092) opened in Tendermint that can lead to no sync.

--- a/docs/quickstart/send-transactions.md
+++ b/docs/quickstart/send-transactions.md
@@ -1,0 +1,41 @@
+# Send transactions to a burrow network
+
+#### Create a deploy file _test.yaml_
+```yaml
+jobs:
+- name: sendTxTest1
+  send:
+      destination: PUT_HERE_ONE_ACCOUNT_OF_YOUR_GENESIS
+      amount: 42
+```
+
+#### Send it from a node
+
+```bash
+SIGNING_ADDRESS=HERE_ONE_VALIDATOR_ADDRESS_OF_THE_GENESIS
+burrow deploy --address $SIGNING_ADDRESS -f test.yaml
+```
+
+where you should replace the `--address` field with the `ValidatorAddress` at the top of your `burrow.toml`.
+
+if you have updated the default burrow GRPC port, parameter `-u` `--chain-url` is your burrow running node ip:GRPCport.
+
+It outputs:
+```
+*****Executing Job*****
+
+Job Name                                    => defaultAddr
+
+
+*****Executing Job*****
+
+Job Name                                    => sendTxTest1
+
+
+Transaction Hash                            => 41E0C13D1515F83E6FFDC5032C60682BE1F5B19A
+Writing [test.output.json] to current directory
+```
+
+You can find lot of different transactions example in [jobs fixtures directory](../../tests/jobs_fixtures)
+
+You may also start to [deploy contracts](deploy-contracts.md).

--- a/docs/quickstart/single-full-node.md
+++ b/docs/quickstart/single-full-node.md
@@ -1,0 +1,43 @@
+# Set up a single full account node
+
+## Usage
+
+The end result will be a `burrow.toml` that will be read in from your current working directory when starting `burrow`.
+
+## Configuration
+
+### Configure Burrow
+The quick-and-dirty one-liner looks like:
+
+```shell
+# Read spec on stdin
+burrow spec -p1 -f1 | burrow configure -s- > burrow.toml
+```
+
+which translates into:
+
+```shell
+# This is a place we can store config files and burrow's working directory '.burrow'
+mkdir chain_dir && cd chain_dir
+burrow spec --participant-accounts=1 --full-accounts=1 > genesis-spec.json
+burrow configure --genesis-spec=genesis-spec.json > burrow.toml
+```
+
+## Run Burrow
+Once the `burrow.toml` has been created, we run:
+
+```
+# To select our validator address by index in the GenesisDoc
+burrow start --validator-index=0
+# Or to select based on address directly (substituting the example address below with your validator's):
+burrow start --validator-address=BE584820DC904A55449D7EB0C97607B40224B96E
+```
+
+and the logs will start streaming through.
+
+If you would like to reset your node, you can just delete its working directory with `rm -rf .burrow`. In the context of a
+multi-node chain it will resync with peers, otherwise it will restart from height 0.
+
+## Send transactions to the blockchain
+
+You can start to [send transactions](send-transactions.md).


### PR DESCRIPTION
Hello, this PR to introduce documentation quick start and initiate documentation movement.

I took the liberty to move some part of the README.md to the docs folder (install, quick config and logging). Tell me if I have to revert.

I have also tried to add some goodies on the main page, maybe adding Line Of Code is not pertinent when dependencies are vendoring.

Move quick start steps in main README.md to docs folder.

Signed-off-by: phymbert <pierrick.hymbert@gmail.com>