### PR TITLE
[docs] Improve seed mode quick start

### DIFF
--- a/docs/quickstart/deploy-contracts.md
+++ b/docs/quickstart/deploy-contracts.md
@@ -170,7 +170,7 @@ jobs:
 
 while our Solidity contract (`storage.sol`) looks like:
 
-```
+```solidity
 pragma solidity >=0.0.0;
 
 contract SimpleStorage {


### PR DESCRIPTION
Add precision on seed mode from @silasdavis.
Fix wrong config for validator #3. Configure a non-seed-mode as seed example.

Solidity highlight syntax in docs smart contract example.

Signed-off-by: phymbert <pierrick.hymbert@gmail.com>