### PR TITLE
Test fixture for problems with forward proxy pattern

### DIFF
--- a/tests/jobs_fixtures/app51-user-account-forward-proxy-pattern/DefaultUserAccount.sol
+++ b/tests/jobs_fixtures/app51-user-account-forward-proxy-pattern/DefaultUserAccount.sol
@@ -1,0 +1,40 @@
+pragma solidity ^0.4.23;
+
+/**
+ * @title DefaultUserAccount
+ * @dev The default implementation of a UserAccount
+ */
+contract DefaultUserAccount {
+
+    /**
+     * @dev Forwards a call to the specified target using the given bytes message.
+     * @param _target the address to call
+     * @param _payload the function payload consisting of the 4-bytes function hash and the abi-encoded function parameters which is typically created by
+     * calling abi.encodeWithSelector(bytes4, args...) or abi.encodeWithSignature(signatureString, args...) 
+     * @return success - whether the forwarding call returned normally
+     * @return returnData - the bytes returned from calling the target function, if successful (NOTE: this is currently not supported, yet, and the returnData will always be empty)
+     * REVERTS if:
+     * - the target address is empty (0x0)
+     */
+    function forwardCall(address _target, bytes _payload)
+        external
+        returns (bool success, bytes returnData)
+    {
+        require(_target != address(0), "Empty target not allowed");
+        bytes memory data = _payload;
+        assembly {
+            success := call(gas, _target, 0, add(data, 0x20), mload(data), 0, 0)
+        }
+        if (success) {
+            uint returnSize;
+            assembly {
+                returnSize := returndatasize
+            }
+            returnData = new bytes(returnSize); // allocates a new byte array with the right size
+            assembly {
+                returndatacopy(add(returnData, 0x20), 0, returnSize) // copies the returned bytes from the function call into the return variable
+            }
+        }
+    }
+
+}

--- a/tests/jobs_fixtures/app51-user-account-forward-proxy-pattern/UserAccountTest.sol
+++ b/tests/jobs_fixtures/app51-user-account-forward-proxy-pattern/UserAccountTest.sol
@@ -1,0 +1,106 @@
+pragma solidity ^0.4.23;
+
+import "./DefaultUserAccount.sol";
+
+contract UserAccountTest {
+
+	string constant SUCCESS = "success";
+	string longString = "longString";
+
+	string testServiceFunctionSig = "serviceInvocation(address,uint256,bytes32)";
+
+	/**
+	 * @dev Tests the DefaultUserAccount call forwarding logic
+	 */
+	function testCallForwarding() external returns (string) {
+
+		uint testState = 42;
+		bytes32 testKey = "myKey";
+		TestService testService = new TestService();
+		bool success;
+
+		DefaultUserAccount account = new DefaultUserAccount();
+
+		// The bytes payload encoding the function signature and parameters for the forwarding call
+		bytes memory payload = abi.encodeWithSignature(testServiceFunctionSig, address(this), testState, testKey);
+
+		// test failures
+		// *IMPORTANT*: the use of the abi.encode function for this call is extremely important since sending the parameters individually via call(bytes4, args...)
+		// has known problems encoding the dynamic-size parameters correctly, see https://github.com/ethereum/solidity/issues/2884
+		if (address(account).call(bytes4(keccak256("forwardCall(address,bytes)")), abi.encode(address(0), payload))) 
+			return "Forwarding a call to an empty address should revert";
+		(success, ) = account.forwardCall(address(testService), abi.encodeWithSignature("fakeFunction(bytes32)", testState));
+		if (success)
+			return "Forwarding a call to a non-existent function should return false";
+
+		// test successful invocation
+		bytes memory returnData;
+		(success, returnData) = account.forwardCall(address(testService), payload);
+		if (!success) return "Forwarding a call from an authorized address with correct payload should return true";
+		if (testService.currentEntity() != address(this)) return "The testService should show this address as the current entity";
+		if (testService.currentState() != testState) return "The testService should have the testState set";
+		if (testService.currentKey() != testKey) return "The testService should have the testKey set";
+		if (testService.lastCaller() != address(account)) return "The testService should show the DefaultUserAccount as the last caller";
+		if (returnData.length != 32) return "ReturnData should be of size 32";
+		// TODO ability to decode return data via abi requires 0.5.0.
+		// (bytes32 returnMessage) = abi.decode(returnData,(bytes32));
+		if (toBytes32(returnData) != testService.getSuccessMessage()) return "The function return data should match the service success message";
+
+		// test different input/return data
+		payload = abi.encodeWithSignature("isStringLonger5(string)", longString);
+		(success, returnData) = account.forwardCall(address(testService), payload);
+		if (!success) return "isStringLonger5 invocation should succeed";
+		if (returnData[31] != 1) return "isStringLonger5 should return true for longString"; // boolean is left-padded, so the value is at the end of the bytes
+
+		// NOTE: this fails with REVERT NO REASON in the forwardCall!
+		payload = abi.encodeWithSignature("getString()");
+		(success, returnData) = account.forwardCall(address(testService), payload);
+		// if (!success) return "getString invocation should succeed";
+		// if (toBytes32(returnData) != "Hello World") return "getString should return Hello World";
+
+		return SUCCESS;
+	}
+
+    function toBytes32(bytes b) public pure returns (bytes32 result) {
+	    assembly {
+    	    result := mload(add(b, 32))
+    	}
+    }
+
+}
+
+/**
+ * @dev Contract providing typical service functions to use as target for call forwarding.
+ */
+contract TestService {
+
+	address public currentEntity;
+	uint public currentState;
+	bytes32 public currentKey;
+	address public lastCaller;
+	string public storedString = "Hello World";
+
+	function serviceInvocation(address _entity, uint _newState, bytes32 _key) public returns (bytes32) {
+
+		currentEntity = _entity;
+		currentState = _newState;
+		currentKey = _key;
+		lastCaller = msg.sender;
+		return "congrats";
+	}
+
+	function getString() public view returns (string) {
+		return storedString;
+	}
+
+	function isStringLonger5(string _string) public pure returns (bool) {
+		if (bytes(_string).length > 5)
+			return true;
+		else
+			return false;
+	} 
+
+	function getSuccessMessage() public pure returns (bytes32) {
+		return "congrats";	
+	}
+}

--- a/tests/jobs_fixtures/app51-user-account-forward-proxy-pattern/deploy.yaml
+++ b/tests/jobs_fixtures/app51-user-account-forward-proxy-pattern/deploy.yaml
@@ -1,0 +1,25 @@
+jobs:
+
+- name: BuildUserAccountTest
+  build:
+    contract: UserAccountTest.sol
+
+##########
+# UserAccount Tests
+
+- name: UserAccountTest
+  deploy:
+    contract: UserAccountTest.bin
+    instance: UserAccountTest
+
+- name: testCallForwarding
+  call:
+    destination: $UserAccountTest
+    bin: UserAccountTest
+    function: testCallForwarding
+
+- name: assertCallForwarding
+  assert:
+    key: $testCallForwarding
+    relation: eq
+    val: success

--- a/tests/jobs_fixtures/app51-user-account-forward-proxy-pattern/readme.md
+++ b/tests/jobs_fixtures/app51-user-account-forward-proxy-pattern/readme.md
@@ -1,0 +1,2 @@
+# Error 5: Memory out of bounds  
+This fixture deploys and tests a proxy forwarding pattern implemented using assembly in the DefaultUserAccount contract. The included test performs mulitple forwardCall invocations and fails with a "Memory out of bounds" for functions that return a string.


### PR DESCRIPTION
The implementation of a forward proxy pattern leads to `Error 5: Memory out of bounds` for functions returning a string (most likely this is a problem for all functions returning dynamic types).
This PR adds a test fixture to reproduce the problem.

Signed-off-by: Jan Hendrik Scheufen <j.h.scheufen@gmail.com>