### PR TITLE
Prevent SetStorage on non-existent accounts

### DIFF
--- a/project/history.go
+++ b/project/history.go
@@ -47,7 +47,23 @@ func FullVersion() string {
 // To cut a new release add a release to the front of this slice then run the
 // release tagging script: ./scripts/tag_release.sh
 var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "https://github.com/hyperledger/burrow").
-	MustDeclareReleases("0.23.0 - 2018-11-09",
+	MustDeclareReleases("",
+		`### Security
+
+### Changed
+
+### Fixed
+- [EVM] state/Cache no longer allows SetStorage on accounts that do not exist
+
+### Added
+- [Execution] panics from executors are captured and pushed to error sink of TxExecution
+
+### Removed
+
+### Deprecated
+
+`,
+		"0.23.0 - 2018-11-09",
 		`### Changed
 - [ABI] provides fast event lookup of EventID
 - [Events] BlockExecution now included full Tendermint block header as protobuf object rather than JSON string


### PR DESCRIPTION
This prevents some subsequent errors observed in http://github.com/agreements-network/blackstone that arise from breaking the invariant of only writing storage after accounts have been created.

It also breaks some of our integration tests...