### PR TITLE
Make debugging easier by printing event during deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 # [Hyperledger Burrow](https://github.com/hyperledger/burrow) Changelog
+## [Unreleased]
+### Security
+
+### Changed
+
+### Fixed
+
+### Added
+- [Deploy] burrow deploy now prints events generated during transactions
+
+### Removed
+
+### Deprecated
+
+
 ## [0.23.1] - 2018-11-14
 ### Fixed
 - [EVM] state/Cache no longer allows SetStorage on accounts that do not exist
@@ -321,6 +336,7 @@ This release marks the start of Eris-DB as the full permissioned blockchain node
   - [Blockchain] Fix getBlocks to respect block height cap.
 
 
+[Unreleased]: https://github.com/hyperledger/burrow/compare/v0.23.1...HEAD
 [0.23.1]: https://github.com/hyperledger/burrow/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/hyperledger/burrow/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/hyperledger/burrow/compare/v0.21.0...v0.22.0

--- a/cmd/burrow/commands/deploy.go
+++ b/cmd/burrow/commands/deploy.go
@@ -137,4 +137,5 @@ func (f *PlainFormatter) appendMessageData(b *bytes.Buffer, key string, value in
 		stringVal = fmt.Sprint(value)
 	}
 	b.WriteString(stringVal)
+	b.WriteString(" ")
 }

--- a/execution/evm/abi/abi.go
+++ b/execution/evm/abi/abi.go
@@ -1098,7 +1098,7 @@ func UnpackRevert(data []byte) (message *string, err error) {
 /*
  * Given a eventSpec, get all the fields (topic fields or not)
  */
-func UnpackEvent(eventSpec EventSpec, topics []burrow_binary.Word256, data []byte, args ...interface{}) error {
+func UnpackEvent(eventSpec *EventSpec, topics []burrow_binary.Word256, data []byte, args ...interface{}) error {
 	// First unpack the topic fields
 	topicIndex := 0
 	if !eventSpec.Anonymous {

--- a/integration/rpctransact/call_test.go
+++ b/integration/rpctransact/call_test.go
@@ -285,7 +285,7 @@ func TestLogEvents(t *testing.T) {
 	var direction string
 	var depth int64
 	evAbi := spec.Events["ChangeLevel"]
-	err = abi.UnpackEvent(evAbi, log.Topics, log.Data, &direction, &depth)
+	err = abi.UnpackEvent(&evAbi, log.Topics, log.Data, &direction, &depth)
 	require.NoError(t, err)
 	assert.Equal(t, evAbi.EventID.Bytes(), log.Topics[0].Bytes())
 	assert.Equal(t, int64(18), depth)
@@ -307,7 +307,7 @@ func TestEventEmitter(t *testing.T) {
 	data := abi.GetPackingTypes(evAbi.Inputs)
 	// Check signature
 	assert.Equal(t, evAbi.EventID.Bytes(), log.Topics[0].Bytes())
-	err = abi.UnpackEvent(evAbi, log.Topics, log.Data.Bytes(), data...)
+	err = abi.UnpackEvent(&evAbi, log.Topics, log.Data.Bytes(), data...)
 	require.NoError(t, err)
 
 	h := sha3.NewKeccak256()
@@ -346,7 +346,7 @@ func TestEventEmitterBytes32isString(t *testing.T) {
 			data[i] = new(string)
 		}
 	}
-	err = abi.UnpackEvent(evAbi, log.Topics, log.Data.Bytes(), data...)
+	err = abi.UnpackEvent(&evAbi, log.Topics, log.Data.Bytes(), data...)
 	require.NoError(t, err)
 
 	h := sha3.NewKeccak256()

--- a/project/history.go
+++ b/project/history.go
@@ -47,7 +47,21 @@ func FullVersion() string {
 // To cut a new release add a release to the front of this slice then run the
 // release tagging script: ./scripts/tag_release.sh
 var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "https://github.com/hyperledger/burrow").
-	MustDeclareReleases("0.23.1 - 2018-11-14",
+	MustDeclareReleases("",
+		`### Security
+
+### Changed
+
+### Fixed
+
+### Added
+- [Deploy] burrow deploy now prints events generated during transactions
+
+### Removed
+
+### Deprecated
+`,
+		"0.23.1 - 2018-11-14",
 		`### Fixed
 - [EVM] state/Cache no longer allows SetStorage on accounts that do not exist
 - [GRPC] GetAccount on unknown account no longer causes a panic


### PR DESCRIPTION
This debugging solidity much easier. For example, add the following to the contract:

 event Foo(string trace, address owner);

Now at any point you can do:
        emit Foo("owner", _owner);
        emit Foo("ecosystem", _ecosystem);

And borrow deploy -debug will say:
```shell
*****Executing Job*****
                    
Job Name                                    => testParticipantsManager
Type                                        => Call

                                           
Tried, not found                            abifile => /home/sean/git/blackstone/contracts/src/bin/ParticipantsManagerTest
Found ABI                                   abifile => /home/sean/git/blackstone/contracts/src/bin/ParticipantsManagerTest.bin
ABI Specification (Formulate)               => [{"constant":false,"inputs":[],"name":"testUserAccountSecurity","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"testOrganizationAuthorization","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"testOrganizationsManagement","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"testParticipantsManager","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"nonpayable","type":"function"}]
Packing Call via ABI                        function => testParticipantsManagerarguments => []
Calling                                     destination => E9C4EAC1CA456AB6C3E3A182191FCE3A62F0F040function => testParticipantsManagerdata => a0edd12c
CallTx                                      Sequence => Address => E9C4EAC1CA456AB6C3E3A182191FCE3A62F0F040Fee => 9999Gas => 1111111111Data => a0edd12cInput => B2736CA2E352761BB98B18CDDDF96E307709A007Amount => 9999
Using mempool signing                       
event LogSystemOwnerChanged                 previousOwner => EF7FBC22B794ADCA15C24B545A375AC973F72C94newOwner => EF7FBC22B794ADCA15C24B545A375AC973F72C94
event Foo                                   trace => ownerowner => 0000000000000000000000000000000000000000
event Foo                                   trace => ecosystemowner => C5CB681D4A97C3048D445F8A7F8888A60B18771F
event LogUserCreation                       id => 1446owner => 0000000000000000000000000000000000000000eventId => AN://user-accountsuser_account_address => D0EB5B19E1FEBF0A1648602762047D4AAAE64D16
event Foo                                   trace => ownerowner => 0000000000000000000000000000000000000000
event Foo                                   trace => ecosystemowner => C5CB681D4A97C3048D445F8A7F8888A60B18771F
event LogUserCreation                       eventId => AN://user-accountsuser_account_address => 1A568B75F0472E365724CA3E8E0430021A269948id => dummyIdowner => 0000000000000000000000000000000000000000
event Foo                                   trace => ownerowner => 0000000000000000000000000000000000000000
event Foo                                   trace => ecosystemowner => C5CB681D4A97C3048D445F8A7F8888A60B18771F
event Foo                                   trace => ownerowner => E9C4EAC1CA456AB6C3E3A182191FCE3A62F0F040
event Foo                                   owner => C5CB681D4A97C3048D445F8A7F8888A60B18771Ftrace => ecosystem
event LogUserCreation                       id => dummyId2owner => E9C4EAC1CA456AB6C3E3A182191FCE3A62F0F040eventId => AN://user-accountsuser_account_address => 5AB856A24F3136CB4E23A12BC64F79AFE1089734
[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7 115 117 99 99 101 115 115 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
Decoding Raw Result                         => 
Tried, not found                            abifile => /home/sean/git/blackstone/contracts/src/bin/ParticipantsManagerTest
Found ABI                                   abifile => /home/sean/git/blackstone/contracts/src/bin/ParticipantsManagerTest.bin
ABI Specification (Decode)                  => [{"constant":false,"inputs":[],"name":"testUserAccountSecurity","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"testOrganizationAuthorization","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"testOrganizationsManagement","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"testParticipantsManager","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"nonpayable","type":"function"}]
call variables:                             => [0xc4201c3da0]
Debugging: success                          
Return Value                                => success
Job Vars                                    => 0,success
Replacement Match Found                     match => $testParticipantsManager
Fixing Variables =>                         var => testParticipantsManagerres => success
```


Signed-off-by: Sean Young <sean.young@monax.io>