### PR TITLE
Provide more efficient non-string parsing based query for TxExecution

### DIFF
--- a/event/convention.go
+++ b/event/convention.go
@@ -1,6 +1,8 @@
 package event
 
 import (
+	"fmt"
+
 	"github.com/hyperledger/burrow/event/query"
 )
 
@@ -15,8 +17,22 @@ const (
 	AddressKey     = "Address"
 )
 
+type EventID string
+
+func (eid EventID) Matches(tags query.Tagged) bool {
+	value, ok := tags.Get(EventIDKey)
+	if !ok {
+		return false
+	}
+	return string(eid) == value
+}
+
+func (eid EventID) String() string {
+	return fmt.Sprintf("%s = %s", EventIDKey, string(eid))
+}
+
 // Get a query that matches events with a specific eventID
-func QueryForEventID(eventID string) *query.Builder {
+func QueryForEventID(eventID string) query.Queryable {
 	// Since we're accepting external output here there is a chance it won't parse...
-	return query.NewBuilder().AndEquals(EventIDKey, eventID)
+	return query.AsQueryable(EventID(eventID))
 }

--- a/execution/exec/tx_execution.go
+++ b/execution/exec/tx_execution.go
@@ -225,5 +225,5 @@ func (txe *TxExecution) TaggedEvents() TaggedEvents {
 }
 
 func QueryForTxExecution(txHash []byte) query.Queryable {
-	return query.NewBuilder().AndEquals(event.EventIDKey, EventStringTxExecution(txHash))
+	return event.QueryForEventID(EventStringTxExecution(txHash))
 }

--- a/execution/execution_test.go
+++ b/execution/execution_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hyperledger/burrow/event/query"
+
 	"github.com/hyperledger/burrow/crypto/sha3"
 	"github.com/hyperledger/burrow/execution/evm/abi"
 	"golang.org/x/crypto/ripemd160"
@@ -1623,7 +1625,8 @@ func (te *testExecutor) signExecuteCommit(tx payload.Payload, signers ...acm.Add
 func execTxWaitAccountCall(t *testing.T, exe *testExecutor, txEnv *txs.Envelope,
 	address crypto.Address) (*exec.CallEvent, error) {
 
-	qry, err := event.QueryForEventID(exec.EventStringAccountCall(address)).
+	qry, err := query.NewBuilder().
+		AndEquals(event.EventIDKey, exec.EventStringAccountCall(address)).
 		AndEquals(event.TxHashKey, txEnv.Tx.Hash()).Query()
 	if err != nil {
 		return nil, err

--- a/execution/transactor.go
+++ b/execution/transactor.go
@@ -87,13 +87,13 @@ func (trans *Transactor) BroadcastTxSync(ctx context.Context, txEnv *txs.Envelop
 		// We do not want to hold the lock with a defer so we must
 		return nil, err
 	}
+	defer trans.Subscribable.UnsubscribeAll(context.Background(), subID)
 	// Push Tx to mempool
 	checkTxReceipt, err := trans.CheckTxSync(txEnv)
 	unlock()
 	if err != nil {
 		return nil, err
 	}
-	defer trans.Subscribable.UnsubscribeAll(context.Background(), subID)
 	// Wait for all responses
 	timer := time.NewTimer(BlockingTimeout)
 	defer timer.Stop()


### PR DESCRIPTION
This probably helps mitigate #973 - though it's not clear where the leak is what is happening now is manifestly inefficient.