### PR TITLE
Ensure tree version is synchronised with height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test_scratch/
 commit_hash.txt
 
 tests/keys/
+.output.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # [Hyperledger Burrow](https://github.com/hyperledger/burrow) Changelog
+## [0.23.3] - 2018-12-19
+### Fixed
+- [State] Since State hash is not unique (i.e if we make no writes) by storing the CommitID by AppHash we can overwrite an older CommitID with a newer one leading us to load the wrong tree version to overwrite in case of loading from a checkpoint.
+
+
 ## [0.23.2] - 2018-12-18
 Hotfix release for 0.23.1
 ### Fixed
@@ -328,6 +333,7 @@ This release marks the start of Eris-DB as the full permissioned blockchain node
   - [Blockchain] Fix getBlocks to respect block height cap.
 
 
+[0.23.3]: https://github.com/hyperledger/burrow/compare/v0.23.2...v0.23.3
 [0.23.2]: https://github.com/hyperledger/burrow/compare/v0.23.1...v0.23.2
 [0.23.1]: https://github.com/hyperledger/burrow/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/hyperledger/burrow/compare/v0.22.0...v0.23.0

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,5 +1,3 @@
-Hotfix release for 0.23.1
 ### Fixed
-- [State] Fixed issue with checkpointing whereby RWTree would load its readTree from one version lower than it should.
-
+- [State] Since State hash is not unique (i.e if we make no writes) by storing the CommitID by AppHash we can overwrite an older CommitID with a newer one leading us to load the wrong tree version to overwrite in case of loading from a checkpoint.
 

--- a/acm/state/dump_state.go
+++ b/acm/state/dump_state.go
@@ -1,0 +1,44 @@
+package state
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/hyperledger/burrow/acm"
+	"github.com/hyperledger/burrow/binary"
+	"github.com/hyperledger/burrow/crypto"
+)
+
+type DumpState struct {
+	bytes.Buffer
+}
+
+func (dw *DumpState) UpdateAccount(updatedAccount *acm.Account) error {
+	dw.WriteString("UpdateAccount\n")
+	bs, err := json.Marshal(updatedAccount)
+	if err != nil {
+		return err
+	}
+	dw.Write(bs)
+	dw.WriteByte('\n')
+	return nil
+}
+
+func (dw *DumpState) RemoveAccount(address crypto.Address) error {
+	dw.WriteString("RemoveAccount\n")
+	dw.WriteString(address.String())
+	dw.WriteByte('\n')
+	return nil
+}
+
+func (dw *DumpState) SetStorage(address crypto.Address, key, value binary.Word256) error {
+	dw.WriteString("SetStorage\n")
+	dw.WriteString(address.String())
+	dw.WriteByte('/')
+	dw.WriteString(hex.EncodeToString(key[:]))
+	dw.WriteByte('/')
+	dw.WriteString(hex.EncodeToString(value[:]))
+	dw.WriteByte('\n')
+	return nil
+}

--- a/bcm/blockchain.go
+++ b/bcm/blockchain.go
@@ -93,11 +93,11 @@ func LoadOrNewBlockchain(db dbm.DB, genesisDoc *genesis.GenesisDoc, logger *logg
 	}
 
 	logger.InfoMsg("No existing blockchain state found in database, making new blockchain")
-	return newBlockchain(db, genesisDoc), nil
+	return NewBlockchain(db, genesisDoc), nil
 }
 
 // Pointer to blockchain state initialised from genesis
-func newBlockchain(db dbm.DB, genesisDoc *genesis.GenesisDoc) *Blockchain {
+func NewBlockchain(db dbm.DB, genesisDoc *genesis.GenesisDoc) *Blockchain {
 	vs := validator.NewTrimSet()
 	for _, gv := range genesisDoc.Validators {
 		vs.ChangePower(gv.PublicKey, new(big.Int).SetUint64(gv.Amount))
@@ -138,6 +138,11 @@ func (bc *Blockchain) ValidatorWriter() validator.Writer {
 
 func (bc *Blockchain) CommitBlock(blockTime time.Time, blockHash,
 	appHash []byte) (totalPowerChange, totalFlow *big.Int, err error) {
+	return bc.CommitBlockAtHeight(blockTime, blockHash, appHash, bc.lastBlockHeight+1)
+}
+
+func (bc *Blockchain) CommitBlockAtHeight(blockTime time.Time, blockHash, appHash []byte,
+	height uint64) (totalPowerChange, totalFlow *big.Int, err error) {
 	bc.Lock()
 	defer bc.Unlock()
 	// Checkpoint on the _previous_ block. If we die, this is where we will resume since we know all intervening state
@@ -159,7 +164,7 @@ func (bc *Blockchain) CommitBlock(blockTime time.Time, blockHash,
 	if err != nil {
 		return
 	}
-	bc.lastBlockHeight += 1
+	bc.lastBlockHeight = height
 	bc.lastBlockTime = blockTime
 	bc.lastBlockHash = blockHash
 	bc.appHashAfterLastBlock = appHash
@@ -200,7 +205,8 @@ func DecodeBlockchain(encodedState []byte) (*Blockchain, error) {
 	if err != nil {
 		return nil, err
 	}
-	bc := newBlockchain(nil, &persistedState.GenesisDoc)
+	bc := NewBlockchain(nil, &persistedState.GenesisDoc)
+	//bc.lastBlockHeight = persistedState.LastBlockHeight
 	bc.lastBlockHeight = persistedState.LastBlockHeight
 	bc.appHashAfterLastBlock = persistedState.AppHashAfterLastBlock
 	bc.validatorCache = validator.UnpersistRing(persistedState.ValidatorCache)

--- a/bcm/blockchain_test.go
+++ b/bcm/blockchain_test.go
@@ -18,7 +18,7 @@ var big0 = big.NewInt(0)
 func TestBlockchain_Encode(t *testing.T) {
 	genesisDoc, _, validators := genesis.NewDeterministicGenesis(234).
 		GenesisDoc(5, true, 232, 3, true, 34)
-	bc := newBlockchain(db.NewMemDB(), genesisDoc)
+	bc := NewBlockchain(db.NewMemDB(), genesisDoc)
 	bs, err := bc.Encode()
 	require.NoError(t, err)
 	bcOut, err := DecodeBlockchain(bs)

--- a/consensus/tendermint/abci/app.go
+++ b/consensus/tendermint/abci/app.go
@@ -294,7 +294,6 @@ func (app *App) Commit() abciTypes.ResponseCommit {
 	if err != nil {
 		panic(errors.Wrap(err, "Could not commit transactions in block to execution state"))
 	}
-
 	err = app.checker.Reset()
 	if err != nil {
 		panic(errors.Wrap(err, "could not reset check cache during commit"))

--- a/execution/execution_test.go
+++ b/execution/execution_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/hyperledger/burrow/execution/evm"
 	. "github.com/hyperledger/burrow/execution/evm/asm"
 	"github.com/hyperledger/burrow/execution/evm/asm/bc"
-	"github.com/hyperledger/burrow/execution/evm/sha3"
 	"github.com/hyperledger/burrow/execution/exec"
 	"github.com/hyperledger/burrow/execution/names"
 	"github.com/hyperledger/burrow/genesis"
@@ -1005,11 +1004,13 @@ func TestNameTxs(t *testing.T) {
 	// fail to update it as non-owner
 	// Fast forward
 	for exe.blockchain.LastBlockHeight() < entry.Expires-1 {
-		commitNewBlock(st, exe.blockchain)
+		_, err = exe.Commit(nil, time.Now(), nil)
+		require.NoError(t, err)
 	}
 	tx, _ = payload.NewNameTx(st, testPrivAccounts[1].GetPublicKey(), name, data, amt, fee)
 	require.Error(t, exe.signExecuteCommit(tx, testPrivAccounts[1]))
-	commitNewBlock(st, exe.blockchain)
+	_, err = exe.Commit(nil, time.Now(), nil)
+	require.NoError(t, err)
 
 	// once expires, non-owner succeeds
 	startingBlock = exe.blockchain.LastBlockHeight()
@@ -1058,7 +1059,8 @@ func TestNameTxs(t *testing.T) {
 	validateEntry(t, entry, name, data, testPrivAccounts[0].GetAddress(), startingBlock+numDesiredBlocks)
 	// Fast forward
 	for exe.blockchain.LastBlockHeight() < entry.Expires {
-		commitNewBlock(st, exe.blockchain)
+		_, err = exe.Commit(nil, time.Now(), nil)
+		require.NoError(t, err)
 	}
 
 	amt = fee
@@ -1179,7 +1181,7 @@ func TestContractSend(t *testing.T) {
 
 	newAcc1 := getAccount(st, acc1.Address)
 	newAcc1.Code = callerCode
-	_, err := st.Update(func(up Updatable) error {
+	_, _, err := st.Update(func(up Updatable) error {
 		return up.UpdateAccount(newAcc1)
 	})
 	require.NoError(t, err)
@@ -1330,7 +1332,7 @@ func TestTxs(t *testing.T) {
 		stateCallTx := copyState(t, st)
 		newAcc1 := getAccount(stateCallTx, acc1.Address)
 		newAcc1.Code = []byte{0x60}
-		_, err := stateCallTx.Update(func(up Updatable) error {
+		_, _, err := stateCallTx.Update(func(up Updatable) error {
 			return up.UpdateAccount(newAcc1)
 		})
 		require.NoError(t, err)
@@ -1437,7 +1439,7 @@ func TestSelfDestruct(t *testing.T) {
 	contractCode = append(contractCode, acc2.Address.Bytes()...)
 	contractCode = append(contractCode, 0xff)
 	newAcc1.Code = contractCode
-	_, err := st.Update(func(up Updatable) error {
+	_, _, err := st.Update(func(up Updatable) error {
 		return up.UpdateAccount(newAcc1)
 	})
 	require.NoError(t, err)
@@ -1522,11 +1524,6 @@ func newBaseGenDoc(globalPerm, accountPerm permission.AccountPermissions) genesi
 	}
 }
 
-func commitNewBlock(state *State, blockchain *bcm.Blockchain) {
-	blockchain.CommitBlock(blockchain.LastBlockTime().Add(time.Second), sha3.Sha3(blockchain.LastBlockHash()),
-		state.Hash())
-}
-
 func makeGenesisState(numAccounts int, randBalance bool, minBalance uint64, numValidators int, randBonded bool,
 	minBonded int64) (*State, []*acm.PrivateAccount) {
 	testGenesisDoc, privAccounts, _ := deterministicGenesis.GenesisDoc(numAccounts, randBalance, minBalance,
@@ -1535,7 +1532,7 @@ func makeGenesisState(numAccounts int, randBalance bool, minBalance uint64, numV
 	if err != nil {
 		panic(fmt.Errorf("could not make genesis state: %v", err))
 	}
-	s0.writeState.commit()
+	//s0.writeState.commit()
 	return s0, privAccounts
 }
 
@@ -1563,6 +1560,7 @@ type testExecutor struct {
 
 func makeExecutor(state *State) *testExecutor {
 	blockchain := newBlockchain(testGenesisDoc)
+	blockchain.CommitBlockAtHeight(time.Now(), []byte("hashily"), state.Hash(), uint64(state.Version()))
 	return &testExecutor{
 		executor: newExecutor("makeExecutorCache", true, state, blockchain, event.NewNoOpPublisher(),
 			logger),
@@ -1590,9 +1588,9 @@ func (te *testExecutor) permString(t *testing.T, address crypto.Address) string 
 
 func (te *testExecutor) updateAccounts(t *testing.T, accounts ...*acm.Account) {
 	for _, acc := range accounts {
-		_, err := te.state.Update(func(ws Updatable) error {
-			return ws.UpdateAccount(acc)
-		})
+		err := te.stateCache.UpdateAccount(acc)
+		require.NoError(t, err)
+		_, err = te.Commit(nil, time.Now(), nil)
 		require.NoError(t, err)
 	}
 }
@@ -1629,8 +1627,6 @@ func execTxWaitAccountCall(t *testing.T, exe *testExecutor, txEnv *txs.Envelope,
 		return nil, err
 	}
 	_, err = exe.Commit([]byte("Blocky McHash"), time.Now(), nil)
-	require.NoError(t, err)
-	_, _, err = exe.blockchain.CommitBlock(time.Time{}, nil, nil)
 	require.NoError(t, err)
 
 	for _, ev := range txe.TaggedEvents().Filter(qry) {

--- a/execution/state.go
+++ b/execution/state.go
@@ -54,15 +54,18 @@ var (
 	storageKeyFormat  = storage.NewMustKeyFormat("s", crypto.AddressLength, binary.Word256Length)
 	nameKeyFormat     = storage.NewMustKeyFormat("n", storage.VariadicSegmentLength)
 	proposalKeyFormat = storage.NewMustKeyFormat("p", sha256.Size)
+
 	// Keys that reference references
 	blockRefKeyFormat = storage.NewMustKeyFormat("b", uint64Length)
 	txRefKeyFormat    = storage.NewMustKeyFormat("t", uint64Length, uint64Length)
-	// Reference keys
+
+	// Reference keys (that do not contribute to state hash)
 	// TODO: implement content-addressing of code and optionally blocks (to allow reference to block to be stored in state tree)
 	//codeKeyFormat   = storage.NewMustKeyFormat("c", sha256.Size)
 	//blockKeyFormat  = storage.NewMustKeyFormat("b", sha256.Size)
-	txKeyFormat     = storage.NewMustKeyFormat("b", tmhash.Size)
-	commitKeyFormat = storage.NewMustKeyFormat("x", tmhash.Size)
+	txKeyFormat = storage.NewMustKeyFormat("b", tmhash.Size)
+	// Binding between apphash and version stto
+	commitKeyFormat = storage.NewMustKeyFormat("v", uint64Length)
 )
 
 // Implements account and blockchain state
@@ -82,22 +85,21 @@ type writeState struct {
 }
 
 type CommitID struct {
-	Hash binary.HexBytes
-	// Height and Version will normally be the same - but it's not clear we should assume this
-	Height  uint64
+	Hash    binary.HexBytes
 	Version int64
 }
 
 func (cid CommitID) String() string {
-	return fmt.Sprintf("Commit{Hash: %v, Height: %v, TreeVersion: %v}", cid.Hash, cid.Height, cid.Version)
+	return fmt.Sprintf("Commit{Hash: %v, Version: %v}", cid.Hash, cid.Version)
 }
 
 // Writers to state are responsible for calling State.Lock() before calling
 type State struct {
+	// Last seen height from GetBlock
+	height uint64
 	// Values not reassigned
-	sync.RWMutex
+	sync.Mutex
 	writeState *writeState
-	height     uint64
 	db         dbm.DB
 	cacheDB    *storage.CacheDB
 	tree       *storage.RWTree
@@ -162,23 +164,15 @@ func MakeGenesisState(db dbm.DB, genesisDoc *genesis.GenesisDoc) (*State, error)
 		return nil, err
 	}
 
-	// We need to save at least once so that readTree points at a non-working-state tree
-	_, err = s.writeState.commit()
-	if err != nil {
-		return nil, err
-	}
 	return s, nil
-
 }
 
 // Tries to load the execution state from DB, returns nil with no error if no state found
-func LoadState(db dbm.DB, hash []byte) (*State, error) {
+func LoadState(db dbm.DB, version int64) (*State, error) {
 	s := NewState(db)
-	// Get the version associated with this state hash
-	commitID := new(CommitID)
-	err := s.codec.UnmarshalBinary(s.refs.Get(commitKeyFormat.Key(hash)), commitID)
+	commitID, err := s.CommitID(version)
 	if err != nil {
-		return nil, fmt.Errorf("could not decode CommitID: %v", err)
+		return nil, err
 	}
 	if commitID.Version <= 0 {
 		return nil, fmt.Errorf("trying to load state from non-positive version: CommitID: %v", commitID)
@@ -190,23 +184,37 @@ func LoadState(db dbm.DB, hash []byte) (*State, error) {
 	return s, nil
 }
 
+func (s *State) Version() int64 {
+	return s.tree.Version()
+}
+
+func (s *State) CommitID(version int64) (*CommitID, error) {
+	// Get the version associated with this state hash
+	commitID := new(CommitID)
+	err := s.codec.UnmarshalBinary(s.refs.Get(commitKeyFormat.Key(version)), commitID)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode CommitID: %v", err)
+	}
+	return commitID, nil
+}
+
 // Perform updates to state whilst holding the write lock, allows a commit to hold the write lock across multiple
 // operations while preventing interlaced reads and writes
-func (s *State) Update(updater func(up Updatable) error) ([]byte, error) {
+func (s *State) Update(updater func(up Updatable) error) ([]byte, int64, error) {
 	s.Lock()
 	defer s.Unlock()
 	err := updater(s.writeState)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	return s.writeState.commit()
 }
 
-func (ws *writeState) commit() ([]byte, error) {
+func (ws *writeState) commit() ([]byte, int64, error) {
 	// save state at a new version may still be orphaned before we save the version against the hash
-	hash, treeVersion, err := ws.state.tree.Save()
+	hash, version, err := ws.state.tree.Save()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if len(hash) == 0 {
 		// Normalise the hash of an empty to tree to the correct hash size
@@ -215,19 +223,18 @@ func (ws *writeState) commit() ([]byte, error) {
 	// Provide a reference to load this version in the future from the state hash
 	commitID := CommitID{
 		Hash:    hash,
-		Height:  ws.state.height,
-		Version: treeVersion,
+		Version: version,
 	}
 	bs, err := ws.state.codec.MarshalBinary(commitID)
 	if err != nil {
-		return nil, fmt.Errorf("could not encode CommitID %v: %v", commitID, err)
+		return nil, 0, fmt.Errorf("could not encode CommitID %v: %v", commitID, err)
 	}
-	ws.state.refs.Set(commitKeyFormat.Key(hash), bs)
+	ws.state.refs.Set(commitKeyFormat.Key(version), bs)
 	// Commit the state in cacheDB atomically for this block (synchronous)
 	batch := ws.state.db.NewBatch()
 	ws.state.cacheDB.Commit(batch)
 	batch.WriteSync()
-	return hash, err
+	return hash, version, err
 }
 
 // Returns nil if account does not exist with given address.
@@ -376,8 +383,6 @@ func (s *State) GetBlocks(startHeight, endHeight uint64, consumer func(*exec.Blo
 }
 
 func (s *State) Hash() []byte {
-	s.RLock()
-	defer s.RUnlock()
 	return s.tree.Hash()
 }
 
@@ -475,7 +480,7 @@ func (s *State) Copy(db dbm.DB) (*State, error) {
 		stateCopy.tree.Set(key, value)
 		return false
 	})
-	_, err := stateCopy.writeState.commit()
+	_, _, err := stateCopy.writeState.commit()
 	if err != nil {
 		return nil, err
 	}

--- a/execution/state_test.go
+++ b/execution/state_test.go
@@ -37,7 +37,7 @@ func TestState_UpdateAccount(t *testing.T) {
 	s := NewState(db.NewMemDB())
 	account := acm.NewAccountFromSecret("Foo")
 	account.Permissions.Base.Perms = permission.SetGlobal | permission.HasRole
-	_, err := s.Update(func(ws Updatable) error {
+	_, _, err := s.Update(func(ws Updatable) error {
 		return ws.UpdateAccount(account)
 	})
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestWriteState_AddBlock(t *testing.T) {
 	height := uint64(100)
 	txs := uint64(5)
 	events := uint64(10)
-	_, err := s.Update(func(ws Updatable) error {
+	_, _, err := s.Update(func(ws Updatable) error {
 		return ws.AddBlock(mkBlock(height, txs, events))
 	})
 	require.NoError(t, err)
@@ -69,7 +69,7 @@ func TestWriteState_AddBlock(t *testing.T) {
 		})
 	require.NoError(t, err)
 	// non-increasing events
-	_, err = s.Update(func(ws Updatable) error {
+	_, _, err = s.Update(func(ws Updatable) error {
 		return nil
 	})
 	require.NoError(t, err)

--- a/execution/transactor_test.go
+++ b/execution/transactor_test.go
@@ -16,7 +16,6 @@ package execution
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/hyperledger/burrow/acm"
@@ -57,7 +56,6 @@ func TestTransactor_BroadcastTxSync(t *testing.T) {
 		func(tx tmTypes.Tx, cb func(*abciTypes.Response)) error {
 			txe := exec.NewTxExecution(txEnv)
 			txe.Height = height
-			fmt.Printf("Sending transaction with hash %v\n", txEnv.Tx.Hash())
 			err := evc.Publish(context.Background(), txe, txe.Tagged())
 			if err != nil {
 				return err

--- a/forensics/replay.go
+++ b/forensics/replay.go
@@ -1,0 +1,109 @@
+package forensics
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/hyperledger/burrow/bcm"
+	"github.com/hyperledger/burrow/binary"
+	"github.com/hyperledger/burrow/core"
+	"github.com/hyperledger/burrow/event"
+	"github.com/hyperledger/burrow/execution"
+	"github.com/hyperledger/burrow/execution/exec"
+	"github.com/hyperledger/burrow/genesis"
+	"github.com/hyperledger/burrow/logging"
+	"github.com/hyperledger/burrow/storage"
+	"github.com/hyperledger/burrow/txs"
+	dbm "github.com/tendermint/tendermint/libs/db"
+	"github.com/tendermint/tendermint/types"
+)
+
+type Replay struct {
+	explorer   *BlockExplorer
+	burrowDB   *storage.CacheDB
+	blockchain *bcm.Blockchain
+	logger     *logging.Logger
+}
+
+type ReplayCapture struct {
+	AppHashBefore binary.HexBytes
+	AppHashAfter  binary.HexBytes
+	TxExecutions  []*exec.TxExecution
+}
+
+func NewReplay(dbDir string, genesisDoc *genesis.GenesisDoc, logger *logging.Logger) *Replay {
+	// Avoid writing through to underlying DB
+	burrowDB := storage.NewCacheDB(core.NewBurrowDB(dbDir))
+	return &Replay{
+		explorer:   NewBlockExplorer(dbm.LevelDBBackend, dbDir),
+		burrowDB:   burrowDB,
+		blockchain: bcm.NewBlockchain(burrowDB, genesisDoc),
+		logger:     logger,
+	}
+}
+
+func (re *Replay) State(height uint64) (*execution.State, error) {
+	// Load block for replay
+	block, err := re.explorer.Block(int64(height))
+	if err != nil {
+		return nil, err
+	}
+	// block.AppHash is hash after txs from previous block have been applied - it's the state we want to load on top
+	// of which we will reapply this block txs
+	return execution.LoadState(re.burrowDB, block.Height)
+}
+
+func (re *Replay) Block(height uint64) (*ReplayCapture, error) {
+	recap := new(ReplayCapture)
+	// Load and commit previous block
+	block, err := re.explorer.Block(int64(height - 1))
+	if err != nil {
+		return nil, err
+	}
+	_, _, err = re.blockchain.CommitBlockAtHeight(block.Time, block.Hash(), block.Header.AppHash, uint64(block.Height))
+	if err != nil {
+		return nil, err
+	}
+	// Load block for replay
+	block, err = re.explorer.Block(int64(height))
+	if err != nil {
+		return nil, err
+	}
+	// block.AppHash is hash after txs from previous block have been applied - it's the state we want to load on top
+	// of which we will reapply this block txs
+	st, err := re.State(height)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(st.Hash(), block.AppHash) {
+		return nil, fmt.Errorf("state hash (%X) retrieved for block AppHash (%X) do not match",
+			st.Hash(), block.AppHash)
+	}
+	recap.AppHashBefore = binary.HexBytes(block.AppHash)
+
+	// Get our commit machinery
+	committer := execution.NewBatchCommitter(st, re.blockchain, event.NewNoOpPublisher(), re.logger)
+
+	var txe *exec.TxExecution
+	var execErr error
+	_, err = block.Transactions(func(txEnv *txs.Envelope) (stop bool) {
+		txe, execErr = committer.Execute(txEnv)
+		if execErr != nil {
+			return true
+		}
+		recap.TxExecutions = append(recap.TxExecutions, txe)
+		return false
+	})
+	if err != nil {
+		return nil, err
+	}
+	if execErr != nil {
+		return nil, execErr
+	}
+	abciHeader := types.TM2PB.Header(&block.Header)
+	recap.AppHashAfter, err = committer.Commit(block.Hash(), block.Time, &abciHeader)
+	if err != nil {
+		return nil, err
+	}
+	return recap, nil
+}

--- a/forensics/replay_test.go
+++ b/forensics/replay_test.go
@@ -1,0 +1,86 @@
+// +build forensics
+
+package forensics
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/hyperledger/burrow/config/source"
+	"github.com/hyperledger/burrow/execution"
+	"github.com/hyperledger/burrow/genesis"
+	"github.com/hyperledger/burrow/logging"
+	"github.com/stretchr/testify/require"
+)
+
+// This serves as a testbed for looking at non-deterministic burrow instances capture from the wild
+// Put the path to 'good' and 'bad' burrow directories here (containing the config files and .burrow dir)
+const goodDir = "/home/silas/burrows/catch-up-non-determinism/demo-silas-validator-good"
+const badDir = "/home/silas/burrows/catch-up-non-determinism/demo-silas-validator-bad"
+const criticalBlock uint64 = 35693
+
+func TestReplay_Good(t *testing.T) {
+	replayBlock(t, goodDir, criticalBlock)
+}
+
+func TestReplay_Bad(t *testing.T) {
+	replayBlock(t, badDir, criticalBlock)
+}
+
+func TestCriticalBlock(t *testing.T) {
+	badState := getState(t, badDir, criticalBlock)
+	goodState := getState(t, goodDir, criticalBlock)
+	require.Equal(t, goodState.Hash(), badState.Hash())
+	fmt.Printf("good: %X, bad: %X\n", goodState.Hash(), badState.Hash())
+	_, err := badState.Update(func(up execution.Updatable) error {
+		return nil
+	})
+	require.NoError(t, err)
+	_, err = goodState.Update(func(up execution.Updatable) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	fmt.Printf("good: %X, bad: %X\n", goodState.Hash(), badState.Hash())
+	_, err = badState.Update(func(up execution.Updatable) error {
+		return nil
+	})
+	require.NoError(t, err)
+	_, err = goodState.Update(func(up execution.Updatable) error {
+		return nil
+	})
+	require.NoError(t, err)
+	fmt.Printf("good: %X, bad: %X\n", goodState.Hash(), badState.Hash())
+
+	_, err = badState.Update(func(up execution.Updatable) error {
+		return nil
+	})
+	require.NoError(t, err)
+	_, err = goodState.Update(func(up execution.Updatable) error {
+		return nil
+	})
+	require.NoError(t, err)
+	fmt.Printf("good: %X, bad: %X\n", goodState.Hash(), badState.Hash())
+}
+
+func replayBlock(t *testing.T, burrowDir string, height uint64) {
+	replay := newReplay(t, burrowDir)
+	recap, err := replay.Block(height)
+	require.NoError(t, err)
+	recap.TxExecutions = nil
+	fmt.Println(recap)
+}
+
+func getState(t *testing.T, burrowDir string, height uint64) *execution.State {
+	st, err := newReplay(t, burrowDir).State(height)
+	require.NoError(t, err)
+	return st
+}
+
+func newReplay(t *testing.T, burrowDir string) *Replay {
+	genesisDoc := new(genesis.GenesisDoc)
+	err := source.FromFile(path.Join(burrowDir, "genesis.json"), genesisDoc)
+	require.NoError(t, err)
+	return NewReplay(path.Join(burrowDir, ".burrow", "data"), genesisDoc, logging.NewNoopLogger())
+}

--- a/project/history.go
+++ b/project/history.go
@@ -47,7 +47,11 @@ func FullVersion() string {
 // To cut a new release add a release to the front of this slice then run the
 // release tagging script: ./scripts/tag_release.sh
 var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "https://github.com/hyperledger/burrow").
-	MustDeclareReleases("0.23.2 - 2018-12-18",
+	MustDeclareReleases("0.23.3 - 2018-12-19",
+		`### Fixed
+- [State] Since State hash is not unique (i.e if we make no writes) by storing the CommitID by AppHash we can overwrite an older CommitID with a newer one leading us to load the wrong tree version to overwrite in case of loading from a checkpoint.
+`,
+		"0.23.2 - 2018-12-18",
 		`Hotfix release for 0.23.1
 ### Fixed
 - [State] Fixed issue with checkpointing whereby RWTree would load its readTree from one version lower than it should.

--- a/storage/kvcache.go
+++ b/storage/kvcache.go
@@ -60,12 +60,13 @@ func (kvc *KVCache) ReverseIterator(start, end []byte) KVIterator {
 }
 
 func (kvc *KVCache) newIterator(start, end []byte) *KVCacheIterator {
-	return &KVCacheIterator{
+	kvi := &KVCacheIterator{
 		start: start,
 		end:   end,
 		keys:  kvc.SortedKeysInDomain(start, end),
 		cache: kvc.cache,
 	}
+	return kvi
 }
 
 // Writes contents of cache to backend without flushing the cache

--- a/util/debug.go
+++ b/util/debug.go
@@ -1,0 +1,14 @@
+package util
+
+import "fmt"
+
+// If we ever want to ship some specific debug we could make this a string var and set it through -ldflags "-X ..."
+const debug = true
+
+// Using this in place of Printf statements makes it easier to find any errant debug statements and the switch means
+// we can turn them off at minimal runtime cost.
+func Debugf(format string, args ...interface{}) {
+	if debug {
+		fmt.Printf(format+"\n", args...)
+	}
+}


### PR DESCRIPTION
Since the version of the IAVL tree is written into the node structure with every write and contribute to hash we much ensure that it is consistent between reloads.

Currently if no writes are made between successive commits we have:

```
AppHash_A -> CommitID {Version: 100 } written at Height 99
AppHash_A -> CommitID {Version: 101} written at Height 100
```
But suppose we attempt to restore starting from height 99. Now we end up starting with version 101 - which we are _meant_ to be overwriting. This will lead to AppHash mismatch on the next write.

To make things less confusing this also synchronises height and tree version (and checks this each commit).

With IAVL 0.12.0 we can make the checkpointing/rollback work as really intended with `LoadVersionForOverwriting`