### PR TITLE
Fix restore bug

### DIFF
--- a/rpc/rpcdump/dump_server.go
+++ b/rpc/rpcdump/dump_server.go
@@ -86,7 +86,7 @@ func (ds *dumpServer) GetDump(param *GetDumpParam, stream Dump_GetDumpServer) er
 		return err
 	}
 
-	err = ds.state.GetBlocks(0, height, func(be *exec.BlockExecution) error {
+	return ds.state.GetBlocks(0, height, func(be *exec.BlockExecution) error {
 		if be.TxExecutions == nil {
 			return nil
 		}
@@ -103,6 +103,4 @@ func (ds *dumpServer) GetDump(param *GetDumpParam, stream Dump_GetDumpServer) er
 		}
 		return nil
 	})
-
-	return nil
 }


### PR DESCRIPTION
When loading a dump during restore, the events are restored without their
transactions. The TxHash field is all 0s; however we added a txHash
reference, which also has the b prefix. Then when iterating over the blocks,
we find the TxHash reference which is then decoded as a block, which fails.

Signed-off-by: Sean Young <sean.young@monax.io>