### PR TITLE
Fix forest non-determinism and remove CacheDB

### DIFF
--- a/execution/state/accounts.go
+++ b/execution/state/accounts.go
@@ -126,20 +126,21 @@ func (ws *writeState) SetStorage(address crypto.Address, key, value binary.Word2
 }
 
 func (s *ReadState) IterateStorage(address crypto.Address, consumer func(key, value binary.Word256) error) error {
-	keyFormat := keys.Storage.Fix(address)
+	keyFormat := keys.Storage
 	tree, err := s.Forest.Reader(keyFormat.Prefix())
 	if err != nil {
 		return err
 	}
-	return tree.Iterate(nil, nil, true, func(key []byte, value []byte) error {
-		if len(key) != binary.Word256Length {
-			return fmt.Errorf("key '%X' stored for account %s is not a %v-byte word",
-				key, address, binary.Word256Length)
-		}
-		if len(value) != binary.Word256Length {
-			return fmt.Errorf("value '%X' stored for account %s is not a %v-byte word",
-				key, address, binary.Word256Length)
-		}
-		return consumer(binary.LeftPadWord256(key), binary.LeftPadWord256(value))
-	})
+	return tree.Iterate(nil, nil, true,
+		func(key []byte, value []byte) error {
+			if len(key) != binary.Word256Length {
+				return fmt.Errorf("key '%X' stored for account %s is not a %v-byte word",
+					key, address, binary.Word256Length)
+			}
+			if len(value) != binary.Word256Length {
+				return fmt.Errorf("value '%X' stored for account %s is not a %v-byte word",
+					key, address, binary.Word256Length)
+			}
+			return consumer(binary.LeftPadWord256(key), binary.LeftPadWord256(value))
+		})
 }

--- a/storage/immutable_forest.go
+++ b/storage/immutable_forest.go
@@ -120,6 +120,7 @@ func (imf *ImmutableForest) newTree(prefix []byte) *RWTree {
 
 func (imf *ImmutableForest) Dump() string {
 	dump := treeprint.New()
+	AddTreePrintTree("Commits", dump, imf.commitsTree)
 	imf.Iterate(nil, nil, true, func(prefix []byte, tree KVCallbackIterableReader) error {
 		AddTreePrintTree(string(prefix), dump, tree)
 		return nil

--- a/storage/key_format_store.go
+++ b/storage/key_format_store.go
@@ -28,8 +28,8 @@ func EnsureKeyFormatStore(ks interface{}) error {
 			kf := fv.Interface().(MustKeyFormat)
 			prefix := kf.Prefix().String()
 			if kfDuplicate, ok := keyFormats[prefix]; ok {
-				return fmt.Errorf("duplicate prefix '%s' between key format %v and %v",
-					stringOrHex(prefix), kfDuplicate, kf)
+				return fmt.Errorf("duplicate prefix %q between key format %v and %v",
+					prefix, kfDuplicate, kf)
 			}
 			keyFormats[prefix] = kf
 		}

--- a/storage/kvcache.go
+++ b/storage/kvcache.go
@@ -60,10 +60,15 @@ func (kvc *KVCache) ReverseIterator(start, end []byte) KVIterator {
 }
 
 func (kvc *KVCache) newIterator(start, end []byte) *KVCacheIterator {
+	//keys := make([][]byte, 0, len(kvc.cache))
+	//for k := range kvc.cache {
+	//	keys = append(keys, []byte(k))
+	//}
+	keys := kvc.SortedKeysInDomain(start, end)
 	kvi := &KVCacheIterator{
 		start: start,
 		end:   end,
-		keys:  kvc.SortedKeysInDomain(start, end),
+		keys:  keys,
 		cache: kvc.cache,
 	}
 	return kvi

--- a/storage/kvstore.go
+++ b/storage/kvstore.go
@@ -27,6 +27,8 @@ type KVIterable interface {
 
 // Provides the native iteration for IAVLTree
 type KVCallbackIterable interface {
+	// Start must be lexicographically less than end. End is exclusive unless it is nil in which case it is inclusive.
+	// ascending == false reverses order.
 	Iterate(start, end []byte, ascending bool, fn func(key []byte, value []byte) error) error
 }
 

--- a/storage/mutable_forest_test.go
+++ b/storage/mutable_forest_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -29,7 +28,7 @@ func TestMutableForest_Genesis(t *testing.T) {
 		dump = tree.(*RWTree).Dump()
 		return nil
 	})
-	assert.Contains(t, dump, "bar -> nog")
+	assert.Contains(t, dump, "\"bar\" -> \"nog\"")
 	reader, err := rwf.Reader(prefix)
 	require.NoError(t, err)
 	require.Equal(t, val1, reader.Get(key1))
@@ -48,12 +47,13 @@ func TestMutableForest_Save(t *testing.T) {
 
 	hash1, version1, err := forest.Save()
 	require.NoError(t, err)
-
 	assertDump(t, forest, `
-        .
-        └── fooos
-            └── bar -> nog
-        `)
+        	            	.
+        	            	├── "Commits"
+        	            	│   └── "fooos" -> "\n ym.\xb8fw\xdcIK\xe8QQ\xb6\x8a\x1fT\x15\xff\x80\xd5\xd91\xf6YKf\x12wx\x16l\xf5\x10\x01"
+        	            	└── "fooos"
+        	            	    └── "bar" -> "nog"
+        	            	`)
 
 	prefix2 := bz("prefixo")
 	key2 := bz("hogs")
@@ -68,12 +68,15 @@ func TestMutableForest_Save(t *testing.T) {
 	require.Equal(t, version1+1, version2, "versions should increment")
 
 	assertDump(t, forest, `
-        .
-        ├── fooos
-        │   └── bar -> nog
-        └── prefixo
-            └── hogs -> they are dogs
-        `)
+        	            	.
+        	            	├── "Commits"
+        	            	│   ├── "fooos" -> "\n ym.\xb8fw\xdcIK\xe8QQ\xb6\x8a\x1fT\x15\xff\x80\xd5\xd91\xf6YKf\x12wx\x16l\xf5\x10\x01"
+        	            	│   └── "prefixo" -> "\n E\xb2\xa4{аA\xddf\xcc\x02ȭ\xfa\xd1\xceZ\xa0nP\xe0\xd3\\X\x9c\x16M\xc1\x88t\x15\x8c\x10\x01"
+        	            	├── "fooos"
+        	            	│   └── "bar" -> "nog"
+        	            	└── "prefixo"
+        	            	    └── "hogs" -> "they are dogs"
+        	            	`)
 }
 
 func TestMutableForest_Load(t *testing.T) {
@@ -124,23 +127,27 @@ func TestSorted(t *testing.T) {
 	setForest(t, forest, "age", "Cora", "1")
 	_, _, err = forest.Save()
 	require.NoError(t, err)
+
 	assertDump(t, forest, `
-        .
-        ├── age
-        │   ├── Cora -> 1
-        │   └── Lindsay -> 34
-        ├── balances
-        │   ├── Caitlin -> 2344
-        │   ├── Cora -> 654456
-        │   ├── Edward -> 34
-        │   └── Lindsay -> 654
-        └── names
-            ├── Caitlin -> female
-            ├── Cora -> female
-            ├── Edward -> male
-            └── Lindsay -> unisex
-        `)
-	fmt.Println(forest.Dump())
+        	            	.
+        	            	├── "Commits"
+        	            	│   ├── "age" -> "\n \x1dwd_\xbaRB\xf5\xa6\xf0\n\xab\x9aWY\xf7\t\x16t웿\xb6\x89O\n\xcf&\xf7\xe6\xcd\n\x10\x01"
+        	            	│   ├── "balances" -> "\n \x9f\xab\xd3s\x18{\xbc\xe8\x98\xdai\xf5\x9f\x16\xden\xac(\xc9ԷU\x99\x17\xda'\xfa3-\x98\xd4\xc9\x10\x02"
+        	            	│   └── "names" -> "\n \xbf\xf8\xf9vt>\xbc\x06@C\xe9I\x01C\xa3\xc3O \xbc\xaf\xbf\xb3\b\xb2UHh\xe8TM\xb3\xba\x10\x01"
+        	            	├── "age"
+        	            	│   ├── "Cora" -> "1"
+        	            	│   └── "Lindsay" -> "34"
+        	            	├── "balances"
+        	            	│   ├── "Caitlin" -> "2344"
+        	            	│   ├── "Cora" -> "654456"
+        	            	│   ├── "Edward" -> "34"
+        	            	│   └── "Lindsay" -> "654"
+        	            	└── "names"
+        	            	    ├── "Caitlin" -> "female"
+        	            	    ├── "Cora" -> "female"
+        	            	    ├── "Edward" -> "male"
+        	            	    └── "Lindsay" -> "unisex"
+        	            	`)
 }
 
 func setForest(t *testing.T, forest *MutableForest, prefix, key, value string) {
@@ -153,10 +160,9 @@ func setForest(t *testing.T, forest *MutableForest, prefix, key, value string) {
 func assertDump(t *testing.T, forest interface{ Dump() string }, expectedDump string) {
 	actual := forest.Dump()
 	expectedDump = trimMargin(expectedDump)
-	if expectedDump != actual {
-		t.Errorf("forest.Dump() did not match expected dump:\n%s\nDo you want this assertion instead:\n\n"+
+	assert.Equal(t, expectedDump, actual,
+		"forest.Dump() did not match expected dump:\n%s\nDo you want this assertion instead:\n\n"+
 			"assertDump(t, forest,`\n%s`)\n\n", expectedDump, actual)
-	}
 }
 
 func trimMargin(str string) string {

--- a/storage/rwtree.go
+++ b/storage/rwtree.go
@@ -2,11 +2,8 @@ package storage
 
 import (
 	"fmt"
-	"unicode/utf8"
 
 	"github.com/tendermint/iavl"
-
-	hex "github.com/tmthrgd/go-hex"
 
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/xlab/treeprint"
@@ -98,16 +95,9 @@ func (rwt *RWTree) Dump() string {
 }
 
 func AddTreePrintTree(edge string, tree treeprint.Tree, rwt KVCallbackIterableReader) {
-	tree = tree.AddBranch(stringOrHex(edge))
+	tree = tree.AddBranch(fmt.Sprintf("%q", edge))
 	rwt.Iterate(nil, nil, true, func(key []byte, value []byte) error {
-		tree.AddNode(fmt.Sprintf("%s -> %s", stringOrHex(string(key)), stringOrHex(string(value))))
+		tree.AddNode(fmt.Sprintf("%q -> %q", string(key), string(value)))
 		return nil
 	})
-}
-
-func stringOrHex(str string) string {
-	if utf8.ValidString(str) {
-		return str
-	}
-	return hex.EncodeUpperToString([]byte(str))
 }

--- a/storage/rwtree_test.go
+++ b/storage/rwtree_test.go
@@ -97,3 +97,28 @@ func TestVersionDivergence(t *testing.T) {
 	assert.Equal(t, hash11, hash21)
 	assert.NotEqual(t, hash11, hash22)
 }
+
+func TestMutableTree_Iterate(t *testing.T) {
+	mut := NewMutableTree(dbm.NewMemDB(), 100)
+	mut.Set(bz("aa"), bz("1"))
+	mut.Set(bz("aab"), bz("2"))
+	mut.Set(bz("aac"), bz("3"))
+	mut.Set(bz("aad"), bz("4"))
+	mut.Set(bz("ab"), bz("5"))
+	_, _, err := mut.SaveVersion()
+	require.NoError(t, err)
+	mut.IterateRange(bz("aab"), bz("aad"), true, func(key []byte, value []byte) bool {
+		fmt.Printf("%q -> %q\n", key, value)
+		return false
+	})
+	fmt.Println("foo")
+	mut.IterateRange(bz("aab"), bz("aad"), false, func(key []byte, value []byte) bool {
+		fmt.Printf("%q -> %q\n", key, value)
+		return false
+	})
+	fmt.Println("foo")
+	mut.IterateRange(bz("aad"), bz("aab"), true, func(key []byte, value []byte) bool {
+		fmt.Printf("%q -> %q\n", key, value)
+		return false
+	})
+}


### PR DESCRIPTION
@seanyoung discovered non-determinism when testing dump/restore. This was because we were iterating of a map when updating dirty trees. It felt like this would not matter but of course IAVL is order dependent and our commit tree is an IAVL tree.

`KVCache` was also soaking up tens of seconds as used by `CacheDB` because of excessive sorting. It could be sped up by maintaining a sorted list and performing sorted inserts but since keeping it was a marginal act of database sync paranoia I've opted to remove it.

We note there is a slight speed-up by using a single storage tree rather than one for acocunt, but since this was a major motivation behind introducing `MutableForest` and the speedup is modest compared to the above we avoid reverting that for now. Down the line we could probably do with a prefix tree (maybe https://github.com/monax/trieste will see the light of day...)