### PR TITLE
Fixes vent's behaviour when it cannot find ABIs

### DIFF
--- a/vent/sqldb/adapters/postgres_adapter.go
+++ b/vent/sqldb/adapters/postgres_adapter.go
@@ -404,8 +404,8 @@ func (adapter *PostgresAdapter) DeleteQuery(table types.SQLTable, row types.Even
 }
 
 func (adapter *PostgresAdapter) RestoreDBQuery() string {
-	return fmt.Sprintf(`SELECT %s, %s, %s, %s FROM %s.%s 
-								WHERE to_char(%s,'YYYY-MM-DD HH24:MI:SS')<=$1 
+	return fmt.Sprintf(`SELECT %s, %s, %s, %s FROM %s.%s
+								WHERE to_char(%s,'YYYY-MM-DD HH24:MI:SS')<=$1
 								ORDER BY %s;`,
 		types.SQLColumnLabelTableName, types.SQLColumnLabelAction, types.SQLColumnLabelSqlStmt, types.SQLColumnLabelSqlValues,
 		adapter.Schema, types.SQLLogTableName,
@@ -417,10 +417,10 @@ func (adapter *PostgresAdapter) CleanDBQueries() types.SQLCleanDBQuery {
 
 	// Chain info
 	selectChainIDQry := fmt.Sprintf(`
-		SELECT 
+		SELECT
 		COUNT(*) REGISTERS,
 		COALESCE(MAX(%s),'') CHAINID,
-		COALESCE(MAX(%s),'') BVERSION 
+		COALESCE(MAX(%s),'') BVERSION
 		FROM %s.%s;`,
 		types.SQLColumnLabelChainID, types.SQLColumnLabelBurrowVer,
 		adapter.Schema, types.SQLChainInfoTableName)
@@ -436,8 +436,8 @@ func (adapter *PostgresAdapter) CleanDBQueries() types.SQLCleanDBQuery {
 
 	// Dictionary
 	selectDictionaryQry := fmt.Sprintf(`
-		SELECT DISTINCT %s 
-		FROM %s.%s 
+		SELECT DISTINCT %s
+		FROM %s.%s
  		WHERE %s
 		NOT IN ('%s','%s','%s');`,
 		types.SQLColumnLabelTableName,
@@ -446,8 +446,8 @@ func (adapter *PostgresAdapter) CleanDBQueries() types.SQLCleanDBQuery {
 		types.SQLLogTableName, types.SQLDictionaryTableName, types.SQLChainInfoTableName)
 
 	deleteDictionaryQry := fmt.Sprintf(`
-		DELETE FROM %s.%s 
-		WHERE %s 
+		DELETE FROM %s.%s
+		WHERE %s
 		NOT IN ('%s','%s','%s');`,
 		adapter.Schema, types.SQLDictionaryTableName,
 		types.SQLColumnLabelTableName,
@@ -458,6 +458,11 @@ func (adapter *PostgresAdapter) CleanDBQueries() types.SQLCleanDBQuery {
 		DELETE FROM %s.%s;`,
 		adapter.Schema, types.SQLLogTableName)
 
+	// errors table
+	deleteErrorsQry := fmt.Sprintf(`
+		DELETE FROM %s.%s;`,
+		adapter.Schema, types.SQLErrorsTableName)
+
 	return types.SQLCleanDBQuery{
 		SelectChainIDQry:    selectChainIDQry,
 		DeleteChainIDQry:    deleteChainIDQry,
@@ -465,6 +470,7 @@ func (adapter *PostgresAdapter) CleanDBQueries() types.SQLCleanDBQuery {
 		SelectDictionaryQry: selectDictionaryQry,
 		DeleteDictionaryQry: deleteDictionaryQry,
 		DeleteLogQry:        deleteLogQry,
+		DeleteErrorsQry:     deleteErrorsQry,
 	}
 }
 

--- a/vent/sqldb/utils.go
+++ b/vent/sqldb/utils.go
@@ -40,6 +40,7 @@ func (db *SQLDB) getSysTablesDefinition() types.EventTables {
 	dicCol := make(map[string]types.SQLTableColumn)
 	logCol := make(map[string]types.SQLTableColumn)
 	chainCol := make(map[string]types.SQLTableColumn)
+	errorsCol := make(map[string]types.SQLTableColumn)
 
 	// log table
 	logCol[types.SQLColumnLabelId] = types.SQLTableColumn{
@@ -194,6 +195,31 @@ func (db *SQLDB) getSysTablesDefinition() types.EventTables {
 		Order:   2,
 	}
 
+	// errors info table
+	errorsCol[types.SQLColumnLabelErrorsHeight] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelErrorsHeight,
+		Type:    types.SQLColumnTypeVarchar,
+		Length:  100,
+		Primary: false,
+		Order:   1,
+	}
+
+	errorsCol[types.SQLColumnLabelErrorsTxHash] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelErrorsTxHash,
+		Type:    types.SQLColumnTypeVarchar,
+		Length:  txs.HashLengthHex,
+		Primary: true,
+		Order:   2,
+	}
+
+	errorsCol[types.SQLColumnLabelErrorsMessage] = types.SQLTableColumn{
+		Name:    types.SQLColumnLabelErrorsMessage,
+		Type:    types.SQLColumnTypeVarchar,
+		Length:  300,
+		Primary: false,
+		Order:   3,
+	}
+
 	// add tables
 	//log
 	tables[types.SQLLogTableName] = types.SQLTable{
@@ -211,6 +237,11 @@ func (db *SQLDB) getSysTablesDefinition() types.EventTables {
 	tables[types.SQLChainInfoTableName] = types.SQLTable{
 		Name:    types.SQLChainInfoTableName,
 		Columns: chainCol,
+	}
+
+	tables[types.SQLErrorsTableName] = types.SQLTable{
+		Name:    types.SQLErrorsTableName,
+		Columns: errorsCol,
 	}
 
 	return tables

--- a/vent/types/sql_table.go
+++ b/vent/types/sql_table.go
@@ -33,6 +33,7 @@ const (
 	SQLBlockTableName      = "_vent_block"
 	SQLTxTableName         = "_vent_tx"
 	SQLChainInfoTableName  = "_vent_chain"
+	SQLErrorsTableName     = "_vent_errors"
 )
 
 // fixed sql column names in tables
@@ -60,6 +61,11 @@ const (
 	// chain info
 	SQLColumnLabelBurrowVer = "_burrowversion"
 	SQLColumnLabelChainID   = "_chainid"
+
+	// errors table
+	SQLColumnLabelErrorsHeight  = "_height"
+	SQLColumnLabelErrorsTxHash  = "_txhash"
+	SQLColumnLabelErrorsMessage = "_result"
 
 	// context
 	SQLColumnLabelIndex       = "_index"

--- a/vent/types/sql_utils.go
+++ b/vent/types/sql_utils.go
@@ -20,4 +20,5 @@ type SQLCleanDBQuery struct {
 	SelectDictionaryQry string
 	DeleteDictionaryQry string
 	DeleteLogQry        string
+	DeleteErrorsQry     string
 }


### PR DESCRIPTION
Currently when vent fails to find an ABI for an event it reads from the
chain it just exit(1)'s. This is nonsensical behaviour on complex chains
which may evolve and especially on public or semi-public chains where
the operational unit running a single instance of vent may not be able
to control a given event type+filter. The way vent currently operates
it would be trivially easy to take down a system by deploying a contract
which it's ABIs are not registered with vent instances and have that
contract emit events which are filtered in other's vent instances.

This patch starts to change that behaviour by refusing to fail when an
event cannot be decoded (this happens in pretty much every case when
vent doesn't have the ABI for an event). Instead vent logs the _txhash
and error for further decoding by operators if they need to do so. Vent
still will fall over in the previously defined cases and will fall over
if it cannot save the error log in the table. So that behaviour is not
modified by this patch.

**Note**: this patch will require some tests; however due to other
obligations I do not have time to add those just now. I'll leave that to
another of the burrow maintainers for now.

Signed-off-by: Casey Kuhlman <casey@monax.io>