### PR TITLE
Atomically write solidity compiler output as bin file

### DIFF
--- a/deploy/jobs/jobs_contracts.go
+++ b/deploy/jobs/jobs_contracts.go
@@ -2,9 +2,7 @@ package jobs
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,13 +61,10 @@ func BuildJob(build *def.Build, binPath string, resp *compilers.Response) (resul
 		}
 
 		// saving binary
-		b, err := json.Marshal(res.Contract)
+		log.WithField("=>", res.Objectname).Warn("Saving Binary")
+
+		err = res.Contract.Save(binP, fmt.Sprintf("%s.bin", res.Objectname))
 		if err != nil {
-			return "", err
-		}
-		contractName := filepath.Join(binP, fmt.Sprintf("%s.bin", res.Objectname))
-		log.WithField("=>", contractName).Warn("Saving Binary")
-		if err := ioutil.WriteFile(contractName, b, 0664); err != nil {
 			return "", err
 		}
 	}
@@ -268,9 +263,8 @@ func DeployJob(deploy *def.Deploy, do *def.DeployArgs, script *def.Playbook, cli
 		if contracts != nil && contractAddress != nil {
 			contract := contracts[i].Contract
 			// saving binary
-			addressBin := filepath.Join(do.BinPath, contractAddress.String())
-			log.WithField("=>", addressBin).Debug("Saving Binary")
-			err = contract.Save(addressBin)
+			log.WithField("=>", contractAddress.String()).Debug("Saving Binary")
+			err = contract.Save(do.BinPath, contractAddress.String())
 			if err != nil {
 				return "", err
 			}
@@ -312,9 +306,9 @@ func deployContract(deploy *def.Deploy, do *def.DeployArgs, script *def.Playbook
 	log.WithField("=>", string(compilersResponse.Contract.Abi)).Debug("Specification (From Compilers)")
 
 	contract := compilersResponse.Contract
-	contractName := filepath.Join(do.BinPath, fmt.Sprintf("%s.bin", compilersResponse.Objectname))
+	contractName := compilersResponse.Objectname
 	log.WithField("=>", contractName).Warn("Saving Binary")
-	err := contract.Save(contractName)
+	err := contract.Save(do.BinPath, fmt.Sprintf("%s.bin", contractName))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If we are running multiple burow deploy jobs concurrently, then one might compile a solidity contract and save the bin file. Another burrow deploy might want to use the bin file for that contract and might read it before it was completely written.
