### PR TITLE
Create bin directory for build jobs

### DIFF
--- a/deploy/jobs/jobs_contracts.go
+++ b/deploy/jobs/jobs_contracts.go
@@ -47,6 +47,12 @@ func BuildJob(build *def.Build, binPath string, resp *compilers.Response) (resul
 		binP = binPath
 	}
 
+	if _, err := os.Stat(binP); os.IsNotExist(err) {
+		if err := os.Mkdir(binP, 0775); err != nil {
+			return "", err
+		}
+	}
+
 	for _, res := range resp.Objects {
 		switch build.Instance {
 		case "":


### PR DESCRIPTION
This fixes a regression in commit 71e3bfc7: create bin directory before
we try to read it.

Signed-off-by: Sean Young <sean.young@monax.io>