### PR TITLE
Remove stack traces from errors that might make there way into

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 ## [Unreleased]
 
 
+## [0.24.3] - 2019-03-06
+### Fixed
+- [State] Avoid stack traces which may be code-path-dependent or non-deterministic from being pushed to TxExecutions and so to merkle state where they can lead to breaking consensus
+
+
 ## [0.24.2] - 2019-02-28
 ### Changed
 - [Genesis] Use HexBytes for Genesis AppHash
@@ -398,7 +403,8 @@ This release marks the start of Eris-DB as the full permissioned blockchain node
   - [Blockchain] Fix getBlocks to respect block height cap.
 
 
-[Unreleased]: https://github.com/hyperledger/burrow/compare/v0.24.2...HEAD
+[Unreleased]: https://github.com/hyperledger/burrow/compare/v0.24.3...HEAD
+[0.24.3]: https://github.com/hyperledger/burrow/compare/v0.24.2...v0.24.3
 [0.24.2]: https://github.com/hyperledger/burrow/compare/v0.24.1...v0.24.2
 [0.24.1]: https://github.com/hyperledger/burrow/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/hyperledger/burrow/compare/v0.23.3...v0.24.0

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,14 +1,3 @@
-### Changed
-- [Genesis] Use HexBytes for Genesis AppHash
-
 ### Fixed
-- [Vent] Stop Vent from swallowing errors (e.g. GRPC streaming errors)
-- [Consensus] Updated to patched version of Tendermint that does not pull in go-ethereum dependency
-- [CLI] Removed duplicate -t flag from burrow configure
-
-
-### Added
-- [Kernel] Added announce message for startup and shutdown including version, key address, and other useful metadata
-- [EVM] Attempt to provide REVERT reason where possible
-- [Vent] --abi and --spec can be provided multiple times to provide multiple paths to search
+- [State] Avoid stack traces which may be code-path-dependent or non-deterministic from being pushed to TxExecutions and so to merkle state where they can lead to breaking consensus
 

--- a/execution/contexts/call_context.go
+++ b/execution/contexts/call_context.go
@@ -188,8 +188,8 @@ func (ctx *CallContext) Deliver(inAcc, outAcc *acm.Account, value uint64) error 
 		ctx.Logger.InfoMsg("Error on execution",
 			structure.ErrorKey, exception)
 
-		ctx.txe.PushError(errors.ErrorCodef(exception.ErrorCode(), "call error: %s\ntrace: %s",
-			exception.String(), ctx.txe.Trace()))
+		ctx.txe.PushError(errors.ErrorCodef(exception.ErrorCode(), "call error: %s\nEVM call trace: %s",
+			exception.String(), ctx.txe.CallTrace()))
 	} else {
 		ctx.Logger.TraceMsg("Successful execution")
 		if createContract {

--- a/execution/contexts/proposal_context.go
+++ b/execution/contexts/proposal_context.go
@@ -196,8 +196,6 @@ func (ctx *ProposalContext) Execute(txe *exec.TxExecution, p payload.Payload) er
 				if r := recover(); r != nil {
 					err = fmt.Errorf("recovered from panic in executor.Execute(%s): %v\n%s", txEnv.String(), r,
 						debug.Stack())
-					// If we recover here we are in a position to promulgate the error to the TxExecution
-					containedTxe.PushError(err)
 				}
 			}()
 

--- a/execution/evm/state.go
+++ b/execution/evm/state.go
@@ -3,7 +3,6 @@ package evm
 import (
 	"fmt"
 
-	"github.com/go-stack/stack"
 	"github.com/hyperledger/burrow/acm"
 	"github.com/hyperledger/burrow/acm/acmstate"
 	"github.com/hyperledger/burrow/binary"
@@ -93,12 +92,14 @@ func (st *State) Error() errors.CodedError {
 	return st.error
 }
 
+// Errors pushed to state may end up in TxExecutions and therefore the merkle state so it is essential that errors are
+// deterministic and independent of the code path taken to execution (e.g. replay takes a different path to that of
+// normal consensus reactor so stack traces may differ - as they may across architectures)
 func (st *State) PushError(err error) {
 	if st.error == nil {
 		// Make sure we are not wrapping a known nil value
 		ex := errors.AsException(err)
 		if ex != nil {
-			ex.Exception = fmt.Sprintf("%s\nstack trace: %s", ex.Exception, stack.Trace().String())
 			st.error = ex
 		}
 	}

--- a/execution/exec/tx_execution.go
+++ b/execution/exec/tx_execution.go
@@ -135,6 +135,9 @@ func (txe *TxExecution) GovernAccount(governAccount *GovernAccountEvent, excepti
 	})
 }
 
+// Errors pushed to TxExecutions end up in merkle state so it is essential that they are deterministic and independent
+// of the code path taken to execution (e.g. replay takes a different path to that of normal consensus reactor so stack
+// traces may differ - as they may across architectures)
 func (txe *TxExecution) PushError(err error) {
 	if txe.Exception == nil {
 		// Don't forget the nil jig
@@ -145,7 +148,7 @@ func (txe *TxExecution) PushError(err error) {
 	}
 }
 
-func (txe *TxExecution) Trace() string {
+func (txe *TxExecution) CallTrace() string {
 	var calls []string
 	for _, ev := range txe.Events {
 		if ev.Call != nil {

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -204,6 +204,7 @@ func (exe *executor) Execute(txEnv *txs.Envelope) (txe *exec.TxExecution, err er
 	}()
 
 	logger := exe.logger.WithScope("executor.Execute(tx txs.Tx)").With(
+		"height", exe.block.Height,
 		"run_call", exe.runCall,
 		"tx_hash", txEnv.Tx.Hash())
 
@@ -223,8 +224,6 @@ func (exe *executor) Execute(txEnv *txs.Envelope) (txe *exec.TxExecution, err er
 			if r := recover(); r != nil {
 				err = fmt.Errorf("recovered from panic in executor.Execute(%s): %v\n%s", txEnv.String(), r,
 					debug.Stack())
-				// If we recover here we are in a position to promulgate the error to the TxExecution
-				txe.PushError(err)
 			}
 		}()
 

--- a/execution/state/events_test.go
+++ b/execution/state/events_test.go
@@ -25,7 +25,7 @@ func TestWriteState_AddBlock(t *testing.T) {
 
 	txIndex := uint64(0)
 	eventIndex := uint64(0)
-	err = s.IterateStreamEvents(exec.StreamKey{Height: height}, exec.StreamKey{Height: height + 1},
+	err = s.IterateStreamEvents(&exec.StreamKey{Height: height}, &exec.StreamKey{Height: height + 1},
 		func(ev *exec.StreamEvent) error {
 			switch {
 			case ev.BeginTx != nil:

--- a/forensics/forensics.go
+++ b/forensics/forensics.go
@@ -1,0 +1,8 @@
+// +build forensics
+
+// This package contains tools for examining, replaying, and debugging Tendermint-side and Burrow-side blockchain state.
+// Some code is quick and dirty from particular investigations and some is better extracted, encapsulated and generalised.
+// The sketchy code is included so that useful tools can be progressively put together as the generality of the types of
+// forensic debugging needed in the wild are determined.
+
+package forensics

--- a/forensics/replay.go
+++ b/forensics/replay.go
@@ -1,3 +1,5 @@
+// +build forensics
+
 package forensics
 
 import (
@@ -14,7 +16,6 @@ import (
 	"github.com/hyperledger/burrow/execution/exec"
 	"github.com/hyperledger/burrow/genesis"
 	"github.com/hyperledger/burrow/logging"
-	"github.com/hyperledger/burrow/storage"
 	"github.com/hyperledger/burrow/txs"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/types"
@@ -22,7 +23,7 @@ import (
 
 type Replay struct {
 	explorer   *bcm.BlockStore
-	burrowDB   *storage.CacheDB
+	burrowDB   dbm.DB
 	blockchain *bcm.Blockchain
 	genesisDoc *genesis.GenesisDoc
 	logger     *logging.Logger
@@ -40,7 +41,7 @@ func (recap *ReplayCapture) String() string {
 
 func NewReplay(dbDir string, genesisDoc *genesis.GenesisDoc, logger *logging.Logger) *Replay {
 	// Avoid writing through to underlying DB
-	burrowDB := storage.NewCacheDB(core.NewBurrowDB(dbDir))
+	burrowDB := core.NewBurrowDB(dbDir)
 	return &Replay{
 		explorer:   bcm.NewBlockExplorer(dbm.LevelDBBackend, dbDir),
 		burrowDB:   burrowDB,
@@ -50,8 +51,17 @@ func NewReplay(dbDir string, genesisDoc *genesis.GenesisDoc, logger *logging.Log
 	}
 }
 
+func (re *Replay) LatestBlockchain() (*bcm.Blockchain, error) {
+	blockchain, err := bcm.LoadOrNewBlockchain(re.burrowDB, re.genesisDoc, re.logger)
+	if err != nil {
+		return nil, err
+	}
+	re.blockchain = blockchain
+	return blockchain, nil
+}
+
 func (re *Replay) State(height uint64) (*state.State, error) {
-	return state.LoadState(re.burrowDB, int64(height))
+	return state.LoadState(re.burrowDB, execution.VersionAtHeight(height))
 }
 
 func (re *Replay) Block(height uint64) (*ReplayCapture, error) {
@@ -102,11 +112,16 @@ func (re *Replay) Block(height uint64) (*ReplayCapture, error) {
 	if execErr != nil {
 		return nil, execErr
 	}
-	//abciHeader := types.TM2PB.Header(&block.Header)
-	recap.AppHashAfter, err = committer.Commit(nil)
+	abciHeader := types.TM2PB.Header(&block.Header)
+	recap.AppHashAfter, err = committer.Commit(&abciHeader)
 	if err != nil {
 		return nil, err
 	}
+	block, err = re.explorer.Block(int64(height + 1))
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println(block.AppHash)
 	return recap, nil
 }
 

--- a/forensics/replay_test.go
+++ b/forensics/replay_test.go
@@ -16,13 +16,13 @@ import (
 
 // This serves as a testbed for looking at non-deterministic burrow instances capture from the wild
 // Put the path to 'good' and 'bad' burrow directories here (containing the config files and .burrow dir)
-const goodDir = "/home/silas/burrows/legal-platform-non-determinism/000-working"
-const badDir = "/home/silas/burrows/legal-platform-non-determinism/001-not-working"
-const criticalBlock uint64 = 39
+const goodDir = "/home/silas/burrows/t7-dev-studio-burrow-000/001"
+const badDir = "/home/silas/burrows/t7-dev-studio-burrow-000/003"
+const criticalBlock uint64 = 33675
 
 func TestReplay_Good(t *testing.T) {
 	replay := newReplay(t, goodDir)
-	recaps, err := replay.Blocks(1, criticalBlock+1)
+	recaps, err := replay.Blocks(2, criticalBlock+1)
 	require.NoError(t, err)
 	for _, recap := range recaps {
 		fmt.Println(recap.String())

--- a/forensics/revert_test.go
+++ b/forensics/revert_test.go
@@ -1,0 +1,64 @@
+// +build forensics
+
+package forensics
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"github.com/hyperledger/burrow/execution/exec"
+	"github.com/stretchr/testify/require"
+)
+
+const devStudioPath = "/home/silas/burrows/t7-dev-studio-burrow-000/t7-dev-studio-burrow-000"
+
+func testLoadStudio(t *testing.T, i int) {
+	re := newReplay(t, studioDir(i))
+	bc, err := re.LatestBlockchain()
+	require.NoError(t, err)
+	fmt.Println(bc.LastBlockHeight())
+
+	st, err := re.State(bc.LastBlockHeight())
+	require.NoError(t, err)
+
+	fmt.Printf("Validator %d hash: %X\n", i, st.Hash())
+	//txHash := hex.MustDecodeString("DEF358F2CD8746CC2CEADE6EDF6518699FA91C512C45A3894FBB0E746E57B749")
+
+	accum := new(exec.BlockAccumulator)
+	buf := new(bytes.Buffer)
+	err = st.IterateStreamEvents(nil, nil, func(ev *exec.StreamEvent) error {
+		be := accum.Consume(ev)
+		if be != nil {
+			buf.WriteString(fmt.Sprintf("Block %d: %X\n\n", be.Height, be.Header.AppHash))
+			for _, txe := range be.TxExecutions {
+				if txe.Exception != nil {
+					buf.WriteString(fmt.Sprintf("Tx %v: %v\n\n", txe.TxExecutions, txe.Exception))
+				}
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = ioutil.WriteFile(fmt.Sprintf("test-out-%d.txt", i), buf.Bytes(), 0644)
+	require.NoError(t, err)
+}
+
+func TestStudioTx0(t *testing.T) {
+	testLoadStudio(t, 0)
+}
+
+func TestStudioTx(t *testing.T) {
+	for i := 0; i < 4; i++ {
+		burrowDir := studioDir(i)
+		fmt.Println(burrowDir)
+		testLoadStudio(t, i)
+	}
+}
+
+func studioDir(i int) string {
+	return path.Join(devStudioPath, fmt.Sprintf("%03d", i))
+}

--- a/project/history.go
+++ b/project/history.go
@@ -49,6 +49,10 @@ func FullVersion() string {
 var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "https://github.com/hyperledger/burrow").
 	MustDeclareReleases("",
 		``,
+		"0.24.3 - 2019-03-06",
+		`### Fixed
+- [State] Avoid stack traces which may be code-path-dependent or non-deterministic from being pushed to TxExecutions and so to merkle state where they can lead to breaking consensus
+`,
 		"0.24.2 - 2019-02-28",
 		`### Changed
 - [Genesis] Use HexBytes for Genesis AppHash

--- a/rpc/rpcdump/dump_server.go
+++ b/rpc/rpcdump/dump_server.go
@@ -87,7 +87,7 @@ func (ds *dumpServer) GetDump(param *GetDumpParam, stream Dump_GetDumpServer) er
 	var blockTime time.Time
 	var origin *exec.Origin
 
-	return ds.state.IterateStreamEvents(exec.StreamKey{}, exec.StreamKey{Height: height},
+	return ds.state.IterateStreamEvents(nil, &exec.StreamKey{Height: height},
 		func(ev *exec.StreamEvent) error {
 			switch {
 			case ev.BeginBlock != nil:

--- a/rpc/rpcevents/execution_events_server.go
+++ b/rpc/rpcevents/execution_events_server.go
@@ -16,7 +16,7 @@ const SubscribeBufferSize = 100
 
 type Provider interface {
 	// Get transactions
-	IterateStreamEvents(start, end exec.StreamKey, consumer func(*exec.StreamEvent) error) (err error)
+	IterateStreamEvents(start, end *exec.StreamKey, consumer func(*exec.StreamEvent) error) (err error)
 	// Get a particular TxExecution by hash
 	TxByHash(txHash []byte) (*exec.TxExecution, error)
 }
@@ -202,7 +202,7 @@ func (ees *executionEventsServer) iterateStreamEvents(startHeight, endHeight uin
 	// NOTE: this will underflow when start is 0 (as it often will be - and needs to be for restored chains)
 	// however we at most underflow by 1 and we always add 1 back on when returning so we get away with this.
 	lastHeightSeen := startHeight - 1
-	err := ees.eventsProvider.IterateStreamEvents(exec.StreamKey{Height: startHeight}, exec.StreamKey{Height: endHeight},
+	err := ees.eventsProvider.IterateStreamEvents(&exec.StreamKey{Height: startHeight}, &exec.StreamKey{Height: endHeight},
 		func(blockEvent *exec.StreamEvent) error {
 			if blockEvent.EndBlock != nil {
 				lastHeightSeen = blockEvent.EndBlock.GetHeight()


### PR DESCRIPTION
TxExecutions and so merkle state causing non-determinism.

Signed-off-by: Silas Davis <silas@monax.io>