### PR TITLE
Refactor keys server test as integration test

### DIFF
--- a/integration/core/kernel_test.go
+++ b/integration/core/kernel_test.go
@@ -43,7 +43,7 @@ import (
 var genesisDoc, privateAccounts, privateValidators = genesis.NewDeterministicGenesis(123).GenesisDoc(1, true, 1000, 1, true, 1000)
 
 func TestBootThenShutdown(t *testing.T) {
-	cleanup := integration.EnterTestDirectory()
+	_, cleanup := integration.EnterTestDirectory()
 	defer cleanup()
 	//logger, _ := lifecycle.NewStdErrLogger()
 	logger := logging.NewNoopLogger()
@@ -52,7 +52,7 @@ func TestBootThenShutdown(t *testing.T) {
 }
 
 func TestBootShutdownResume(t *testing.T) {
-	cleanup := integration.EnterTestDirectory()
+	_, cleanup := integration.EnterTestDirectory()
 	defer cleanup()
 	//logger, _ := lifecycle.NewStdErrLogger()
 	logger := logging.NewNoopLogger()

--- a/integration/governance/main_test.go
+++ b/integration/governance/main_test.go
@@ -40,7 +40,7 @@ var kernels []*core.Kernel
 
 // Needs to be in a _test.go file to be picked up
 func TestMain(m *testing.M) {
-	cleanup := integration.EnterTestDirectory()
+	_, cleanup := integration.EnterTestDirectory()
 	defer cleanup()
 	testConfigs = make([]*config.BurrowConfig, len(privateAccounts))
 	kernels = make([]*core.Kernel, len(privateAccounts))

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -95,8 +95,9 @@ func TestKernel(validatorAccount *acm.PrivateAccount, keysAccounts []*acm.Privat
 	return kernel
 }
 
-func EnterTestDirectory() (cleanup func()) {
-	testDir, err := ioutil.TempDir("", scratchDir)
+func EnterTestDirectory() (testDir string, cleanup func()) {
+	var err error
+	testDir, err = ioutil.TempDir("", scratchDir)
 	if err != nil {
 		panic(fmt.Errorf("couldnot make temp dir for integration tests: %v", err))
 	}
@@ -106,7 +107,7 @@ func EnterTestDirectory() (cleanup func()) {
 	os.MkdirAll(testDir, 0777)
 	os.Chdir(testDir)
 	os.MkdirAll("config", 0777)
-	return func() { os.RemoveAll(testDir) }
+	return testDir, func() { os.RemoveAll(testDir) }
 }
 
 func TestGenesisDoc(addressables []*acm.PrivateAccount) *genesis.GenesisDoc {

--- a/integration/rpcevents/main_test.go
+++ b/integration/rpcevents/main_test.go
@@ -34,7 +34,7 @@ var kern *core.Kernel
 
 // Needs to be in a _test.go file to be picked up
 func TestMain(m *testing.M) {
-	cleanup := integration.EnterTestDirectory()
+	_, cleanup := integration.EnterTestDirectory()
 	defer cleanup()
 	kern = integration.TestKernel(rpctest.PrivateAccounts[0], rpctest.PrivateAccounts, testConfig, nil)
 	err := kern.Boot()

--- a/integration/rpcinfo/main_test.go
+++ b/integration/rpcinfo/main_test.go
@@ -41,7 +41,7 @@ var clients = map[string]tmClient.RPCClient{
 
 // Needs to be in a _test.go file to be picked up
 func TestMain(m *testing.M) {
-	cleanup := integration.EnterTestDirectory()
+	_, cleanup := integration.EnterTestDirectory()
 	defer cleanup()
 	kern = integration.TestKernel(rpctest.PrivateAccounts[0], rpctest.PrivateAccounts, testConfig, nil)
 	err := kern.Boot()

--- a/integration/rpcquery/main_test.go
+++ b/integration/rpcquery/main_test.go
@@ -33,7 +33,7 @@ var kern *core.Kernel
 
 // Needs to be in a _test.go file to be picked up
 func TestMain(m *testing.M) {
-	cleanup := integration.EnterTestDirectory()
+	_, cleanup := integration.EnterTestDirectory()
 	defer cleanup()
 	kern = integration.TestKernel(rpctest.PrivateAccounts[0], rpctest.PrivateAccounts, testConfig, nil)
 	err := kern.Boot()

--- a/integration/rpctransact/main_test.go
+++ b/integration/rpctransact/main_test.go
@@ -34,7 +34,7 @@ var kern *core.Kernel
 
 // Needs to be in a _test.go file to be picked up
 func TestMain(m *testing.M) {
-	cleanup := integration.EnterTestDirectory()
+	_, cleanup := integration.EnterTestDirectory()
 	defer cleanup()
 	kern = integration.TestKernel(rpctest.PrivateAccounts[0], rpctest.PrivateAccounts, testConfig,
 		logconfig.New().Root(func(sink *logconfig.SinkConfig) *logconfig.SinkConfig {

--- a/vent/service/main_test.go
+++ b/vent/service/main_test.go
@@ -19,7 +19,7 @@ var testConfig = integration.NewTestConfig(genesisDoc)
 var kern *core.Kernel
 
 func TestMain(m *testing.M) {
-	cleanup := integration.EnterTestDirectory()
+	_, cleanup := integration.EnterTestDirectory()
 	defer cleanup()
 
 	kern = integration.TestKernel(inputAccount, privateAccounts, testConfig, nil)


### PR DESCRIPTION
I noticed some intermittent failures with the keys go test, I think it was to do with timing issues and the keys server setup being done in `init()`. The right way to do this is with TestMain so I implemented it. While I was at it I also made the keys sever test an integration test since it binds to ports and touches the filesystem.