### PR TITLE
separate host/port, prevent restore overwriting, fix restore msg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ NOTES.md: project/history.go project/cmd/notes/main.go
 docs: CHANGELOG.md NOTES.md
 
 # Tag the current HEAD commit with the current release defined in
-# ./release/release.go
+# ./project/history.go
 .PHONY: tag_release
 tag_release: test check CHANGELOG.md NOTES.md build
 	@scripts/tag_release.sh

--- a/bcm/blockchain.go
+++ b/bcm/blockchain.go
@@ -69,6 +69,7 @@ type PersistedState struct {
 	GenesisDoc            genesis.GenesisDoc
 }
 
+// LoadOrNewBlockchain returns true if state already exists
 func LoadOrNewBlockchain(db dbm.DB, genesisDoc *genesis.GenesisDoc, logger *logging.Logger) (bool, *Blockchain, error) {
 	logger = logger.WithScope("LoadOrNewBlockchain")
 	logger.InfoMsg("Trying to load blockchain state from database",
@@ -92,7 +93,7 @@ func LoadOrNewBlockchain(db dbm.DB, genesisDoc *genesis.GenesisDoc, logger *logg
 	return false, NewBlockchain(db, genesisDoc), nil
 }
 
-// Pointer to blockchain state initialised from genesis
+// NewBlockchain returns a pointer to blockchain state initialised from genesis
 func NewBlockchain(db dbm.DB, genesisDoc *genesis.GenesisDoc) *Blockchain {
 	bc := &Blockchain{
 		db:                    db,

--- a/cmd/burrow/commands/configure.go
+++ b/cmd/burrow/commands/configure.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger/burrow/logging"
 	"github.com/hyperledger/burrow/logging/logconfig"
 	"github.com/hyperledger/burrow/logging/logconfig/presets"
+	"github.com/hyperledger/burrow/rpc"
 	cli "github.com/jawher/mow.cli"
 	amino "github.com/tendermint/go-amino"
 	tmEd25519 "github.com/tendermint/tendermint/crypto/ed25519"
@@ -331,10 +332,19 @@ func Configure(output Output) func(cmd *cli.Cmd) {
 					conf.ValidatorAddress = &v.Address
 					conf.BurrowDir = fmt.Sprintf("burrow%03d", i)
 					conf.Tendermint.PersistentPeers = seeds
-					conf.Tendermint.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", 26656+i)
-					conf.RPC.Info.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", 26758+i)
-					conf.RPC.GRPC.ListenAddress = fmt.Sprintf("127.0.0.1:%d", 10997+i)
-					conf.RPC.Metrics.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", 9102+i)
+
+					conf.Tendermint.ListenHost = rpc.LocalHost
+					conf.Tendermint.ListenPort = string(26656 + i)
+
+					conf.RPC.Info.ListenHost = rpc.LocalHost
+					conf.RPC.Info.ListenPort = string(26758 + i)
+
+					conf.RPC.GRPC.ListenHost = rpc.LocalHost
+					conf.RPC.GRPC.ListenPort = string(10997 + i)
+
+					conf.RPC.Metrics.ListenHost = rpc.LocalHost
+					conf.RPC.Metrics.ListenPort = string(9102 + i)
+
 					conf.Logging.RootSink.Output.OutputType = "file"
 					conf.Logging.RootSink.Output.FileConfig = &logconfig.FileConfig{Path: fmt.Sprintf("burrow%03d.log", i)}
 

--- a/cmd/burrow/commands/deploy.go
+++ b/cmd/burrow/commands/deploy.go
@@ -19,7 +19,7 @@ const defaultChainTimeout = 15 * time.Second
 
 func Deploy(output Output) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
-		chainOpt := cmd.StringOpt("u chain", "127.0.0.1:10997", "chain to be used in IP:PORT format")
+		chainOpt := cmd.StringOpt("c chain", "127.0.0.1:10997", "chain to be used in IP:PORT format")
 
 		signerOpt := cmd.StringOpt("s keys", "",
 			"IP:PORT of Burrow GRPC service which jobs should or otherwise transaction submitted unsigned for mempool signing in Burrow")
@@ -49,7 +49,7 @@ func Deploy(output Output) func(cmd *cli.Cmd) {
 			"default number of concurrent playbooks to run if multiple are specified")
 
 		addressOpt := cmd.StringOpt("a address", "",
-			"default address to use; operates the same way as the [account] job, only before the deploy file is ran")
+			"default address (or account name) to use; operates the same way as the [account] job, only before the deploy file is ran")
 
 		defaultFeeOpt := cmd.StringOpt("n fee", "9999", "default fee to use")
 

--- a/cmd/burrow/commands/dump.go
+++ b/cmd/burrow/commands/dump.go
@@ -21,7 +21,7 @@ var cdc = amino.NewCodec()
 
 func Dump(output Output) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
-		chainURLOpt := cmd.StringOpt("u chain-url", "127.0.0.1:10997", "chain-url to be used in IP:PORT format")
+		chainURLOpt := cmd.StringOpt("c chain", "127.0.0.1:10997", "chain to be used in IP:PORT format")
 		heightOpt := cmd.IntOpt("h height", 0, "Block height to dump to, defaults to latest block height")
 		filename := cmd.StringArg("FILE", "", "Save dump here")
 		useJSON := cmd.BoolOpt("j json", false, "Output in json")

--- a/cmd/burrow/commands/restore.go
+++ b/cmd/burrow/commands/restore.go
@@ -12,6 +12,8 @@ func Restore(output Output) func(cmd *cli.Cmd) {
 
 		configOpt := cmd.StringOpt("c config", "", "Use the specified burrow config file")
 
+		silentOpt := cmd.BoolOpt("s silent", false, "If state already exists don't throw error")
+
 		filename := cmd.StringArg("FILE", "", "Restore from this dump")
 
 		cmd.Spec = "[--config=<config file>] [--genesis=<genesis json file>] [FILE]"
@@ -44,7 +46,7 @@ func Restore(output Output) func(cmd *cli.Cmd) {
 				output.Fatalf("could not create Burrow kernel: %v", err)
 			}
 
-			if err = kern.LoadDump(conf.GenesisDoc, *filename); err != nil {
+			if err = kern.LoadDump(conf.GenesisDoc, *filename, *silentOpt); err != nil {
 				output.Fatalf("could not create Burrow kernel: %v", err)
 			}
 

--- a/consensus/tendermint/config.go
+++ b/consensus/tendermint/config.go
@@ -1,6 +1,7 @@
 package tendermint
 
 import (
+	"fmt"
 	"math"
 	"net/url"
 	"strings"
@@ -21,7 +22,8 @@ type BurrowTendermintConfig struct {
 	SeedMode bool
 	// Peers to which we automatically connect
 	PersistentPeers string
-	ListenAddress   string
+	ListenHost      string
+	ListenPort      string
 	// Optional external that nodes may provide with their NodeInfo
 	ExternalAddress string
 	// Set true for strict address routability rules
@@ -37,9 +39,14 @@ type BurrowTendermintConfig struct {
 
 func DefaultBurrowTendermintConfig() *BurrowTendermintConfig {
 	tmDefaultConfig := tmConfig.DefaultConfig()
+	url, err := url.ParseRequestURI(tmDefaultConfig.P2P.ListenAddress)
+	if err != nil {
+		return nil
+	}
 	return &BurrowTendermintConfig{
 		Enabled:                   true,
-		ListenAddress:             tmDefaultConfig.P2P.ListenAddress,
+		ListenHost:                url.Hostname(),
+		ListenPort:                url.Port(),
 		ExternalAddress:           tmDefaultConfig.P2P.ExternalAddress,
 		CreateEmptyBlocks:         tmDefaultConfig.Consensus.CreateEmptyBlocks,
 		CreateEmptyBlocksInterval: tmDefaultConfig.Consensus.CreateEmptyBlocksInterval,
@@ -72,7 +79,7 @@ func (btc *BurrowTendermintConfig) Config(rootDir string, timeoutFactor float64)
 		conf.P2P.Seeds = btc.Seeds
 		conf.P2P.SeedMode = btc.SeedMode
 		conf.P2P.PersistentPeers = btc.PersistentPeers
-		conf.P2P.ListenAddress = btc.ListenAddress
+		conf.P2P.ListenAddress = fmt.Sprintf("%s:%s", btc.ListenHost, btc.ListenPort)
 		conf.P2P.ExternalAddress = btc.ExternalAddress
 		conf.P2P.AddrBookStrict = btc.AddrBookStrict
 		// We use this in tests and I am not aware of a strong reason to reject nodes on the same IP with different ports

--- a/core/processes.go
+++ b/core/processes.go
@@ -59,7 +59,7 @@ func ProfileLauncher(kern *Kernel, conf *rpc.ServerConfig) process.Launcher {
 		Enabled: conf.Enabled,
 		Launch: func() (process.Process, error) {
 			debugServer := &http.Server{
-				Addr: conf.ListenAddress,
+				Addr: fmt.Sprintf("%s:%s", conf.ListenHost, conf.ListenPort),
 			}
 			go func() {
 				err := debugServer.ListenAndServe()
@@ -202,7 +202,7 @@ func InfoLauncher(kern *Kernel, conf *rpc.ServerConfig) process.Launcher {
 		Name:    InfoProcessName,
 		Enabled: conf.Enabled,
 		Launch: func() (process.Process, error) {
-			listener, err := process.ListenerFromAddress(conf.ListenAddress)
+			listener, err := process.ListenerFromAddress(fmt.Sprintf("%s:%s", conf.ListenHost, conf.ListenPort))
 			if err != nil {
 				return nil, err
 			}
@@ -224,7 +224,7 @@ func MetricsLauncher(kern *Kernel, conf *rpc.MetricsConfig) process.Launcher {
 		Name:    MetricsProcessName,
 		Enabled: conf.Enabled,
 		Launch: func() (process.Process, error) {
-			listener, err := process.ListenerFromAddress(conf.ListenAddress)
+			listener, err := process.ListenerFromAddress(fmt.Sprintf("%s:%s", conf.ListenHost, conf.ListenPort))
 			if err != nil {
 				return nil, err
 			}
@@ -252,7 +252,7 @@ func GRPCLauncher(kern *Kernel, conf *rpc.ServerConfig, keyConfig *keys.KeysConf
 				return nil, err
 			}
 
-			listener, err := process.ListenerFromAddress(conf.ListenAddress)
+			listener, err := process.ListenerFromAddress(fmt.Sprintf("%s:%s", conf.ListenHost, conf.ListenPort))
 			if err != nil {
 				return nil, err
 			}

--- a/deploy/keys/keys.go
+++ b/deploy/keys/keys.go
@@ -13,14 +13,7 @@ type LocalKeyClient struct {
 	keys.KeyClient
 }
 
-const DefaultKeysHost = "localhost"
-const DefaultKeysPort = "10997"
-
 var keysTimeout = 5 * time.Second
-
-func DefaultKeysURL() string {
-	return fmt.Sprintf("%s:%s", DefaultKeysHost, DefaultKeysPort)
-}
 
 // Returns an initialized key client to a docker container
 // running the keys server

--- a/docs/quickstart/add-validators.md
+++ b/docs/quickstart/add-validators.md
@@ -22,7 +22,7 @@ Let's generate the config and keys for a new validator account. As this node wil
 ```bash
 burrow spec -v1 | burrow configure -s- --json > burrow-new.json
 NEW_VALIDATOR=$(jq -r '.GenesisDoc.Accounts[0].PublicKey.PublicKey' burrow-new.json)
-jq 'del(.GenesisDoc)' burrow-new.json | jq ".Tendermint.PersistentPeers=\"$PERSISTENT_PEER\"" | jq '.RPC.Info.Enabled=false' | jq '.RPC.GRPC.Enabled=false' | jq '.Tendermint.ListenAddress="tcp://0.0.0.0:25565"' > burrow003.json 
+jq 'del(.GenesisDoc)' burrow-new.json | jq ".Tendermint.PersistentPeers=\"$PERSISTENT_PEER\"" | jq '.RPC.Info.Enabled=false' | jq '.RPC.GRPC.Enabled=false' | jq '.Tendermint.ListenPort="25565"' > burrow003.json 
 ```
 
 Copy the following script into `deploy.yaml`:

--- a/docs/quickstart/seed-nodes.md
+++ b/docs/quickstart/seed-nodes.md
@@ -49,11 +49,13 @@ From the generated `.burrow_init.toml `file, create new files for each node, and
 
 #### Seed node `.burrow_seed.toml` modified line from `.burrow_init.toml`
 ```toml
+BurrowDir = ".burrow_seed_0"
+
 [Tendermint]
   SeedMode = true
-  ListenAddress = "tcp://0.0.0.0:10000"
+  ListenHost = "0.0.0.0"
+  ListenPort = "10000"
   Moniker = "seed_node_0"
-  TendermintRoot = ".burrow_seed_0"
 
 [Execution]
 
@@ -66,7 +68,8 @@ From the generated `.burrow_init.toml `file, create new files for each node, and
 [RPC]
   [RPC.Info]
     Enabled = true
-    ListenAddress = "tcp://127.0.0.1:10001"
+    ListenHost = "127.0.0.1"
+    ListenPort = "10001"
   [RPC.Profiler]
     Enabled = false
   [RPC.GRPC]
@@ -78,13 +81,15 @@ From the generated `.burrow_init.toml `file, create new files for each node, and
 #### Validator 1 node `.burrow_val0.toml` modified line from `.burrow_init.toml`
 
 ```toml
+BurrowDir = ".burrow_node0"
+
 [Tendermint]
   Seeds = "PUT_HERE_SEED_NODE_ID@LISTEN_EXTERNAL_ADDRESS"
   SeedMode = false
   PersistentPeers = ""
-  ListenAddress = "tcp://0.0.0.0:20000"
+  ListenHost = "0.0.0.0"
+  ListenPort = "20000"
   Moniker = "val_node_0"
-  TendermintRoot = ".burrow_node0"
 
 [Execution]
 
@@ -97,12 +102,14 @@ From the generated `.burrow_init.toml `file, create new files for each node, and
 [RPC]
   [RPC.Info]
     Enabled = true
-    ListenAddress = "tcp://127.0.0.1:20001"
+    ListenHost = "127.0.0.1"
+    ListenPort = "20001"
   [RPC.Profiler]
     Enabled = false
   [RPC.GRPC]
     Enabled = true
-    ListenAddress = "127.0.0.1:20002"
+    ListenHost = "127.0.0.1"
+    ListenPort = "20002"
   [RPC.Metrics]
     Enabled = false
 ```
@@ -110,13 +117,15 @@ From the generated `.burrow_init.toml `file, create new files for each node, and
 #### Validator 2 node `.burrow_val1.toml` modified line from `.burrow_init.toml`
 
 ```toml
+BurrowDir = ".burrow_node1"
+
 [Tendermint]
   Seeds = "PUT_HERE_SEED_NODE_ID@LISTEN_EXTERNAL_ADDRESS"
   SeedMode = false
   PersistentPeers = ""
-  ListenAddress = "tcp://0.0.0.0:30000"
+  ListenHost = "0.0.0.0"
+  ListenPort = "30000"
   Moniker = "val_node_1"
-  TendermintRoot = ".burrow_node1"
 
 [Execution]
 
@@ -129,12 +138,14 @@ From the generated `.burrow_init.toml `file, create new files for each node, and
 [RPC]
   [RPC.Info]
     Enabled = true
-    ListenAddress = "tcp://127.0.0.1:30001"
+    ListenHost = "127.0.0.1"
+    ListenPort = "30001"
   [RPC.Profiler]
     Enabled = false
   [RPC.GRPC]
     Enabled = true
-    ListenAddress = "127.0.0.1:30002"
+    ListenHost = "127.0.0.1"
+    ListenPort = "30002"
   [RPC.Metrics]
     Enabled = false
 ```
@@ -143,13 +154,15 @@ From the generated `.burrow_init.toml `file, create new files for each node, and
 #### Validator 3 node `.burrow_val2.toml` modified line from `.burrow_init.toml`
 
 ```toml
+BurrowDir = ".burrow_node2"
+
 [Tendermint]
   Seeds = "PUT_HERE_SEED_NODE_ID@LISTEN_EXTERNAL_ADDRESS"
   SeedMode = false
   PersistentPeers = ""
-  ListenAddress = "tcp://0.0.0.0:40000"
+  ListenHost = "0.0.0.0"
+  ListenPort = "40000"
   Moniker = "val_node_2"
-  TendermintRoot = ".burrow_node2"
 
 [Execution]
 
@@ -162,12 +175,14 @@ From the generated `.burrow_init.toml `file, create new files for each node, and
 [RPC]
   [RPC.Info]
     Enabled = true
-    ListenAddress = "tcp://127.0.0.1:40001"
+    ListenHost = "127.0.0.1"
+    ListenPort = "40001"
   [RPC.Profiler]
     Enabled = false
   [RPC.GRPC]
     Enabled = true
-    ListenAddress = "127.0.0.1:40002"
+    ListenHost = "127.0.0.1"
+    ListenPort = "40002"
   [RPC.Metrics]
     Enabled = false
 ```

--- a/integration/governance/governance_test.go
+++ b/integration/governance/governance_test.go
@@ -55,7 +55,11 @@ func TestGovernance(t *testing.T) {
 		// the listener and start the node
 		l, err := net.Listen("tcp", "localhost:0")
 		require.NoError(t, err)
-		testConfig.Tendermint.ListenAddress = fmt.Sprintf("tcp://%v", l.Addr().String())
+		host, port, err := net.SplitHostPort(l.Addr().String())
+		require.NoError(t, err)
+
+		testConfig.Tendermint.ListenHost = host
+		testConfig.Tendermint.ListenPort = port
 
 		kernels[i], err = integration.TestKernel(acc, privateAccounts, testConfig, logconf)
 		require.NoError(t, err)

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -39,6 +39,7 @@ import (
 	"github.com/hyperledger/burrow/logging/logconfig"
 	lConfig "github.com/hyperledger/burrow/logging/logconfig"
 	"github.com/hyperledger/burrow/permission"
+	"github.com/hyperledger/burrow/rpc"
 )
 
 const (
@@ -92,11 +93,15 @@ func NewTestConfig(genesisDoc *genesis.GenesisDoc,
 	conf.Tendermint.Moniker = name
 	conf.Keys.RemoteAddress = ""
 	// Assign run of ports
-	const localhostFreePort = "tcp://localhost:0"
-	conf.Tendermint.ListenAddress = localhostFreePort
-	conf.RPC.GRPC.ListenAddress = localhostFreePort
-	conf.RPC.Metrics.ListenAddress = localhostFreePort
-	conf.RPC.Info.ListenAddress = localhostFreePort
+	const freeport = "0"
+	conf.Tendermint.ListenHost = rpc.LocalHost
+	conf.Tendermint.ListenPort = freeport
+	conf.RPC.GRPC.ListenHost = rpc.LocalHost
+	conf.RPC.GRPC.ListenPort = freeport
+	conf.RPC.Metrics.ListenHost = rpc.LocalHost
+	conf.RPC.Metrics.ListenPort = freeport
+	conf.RPC.Info.ListenHost = rpc.LocalHost
+	conf.RPC.Info.ListenPort = freeport
 	conf.Execution.TimeoutFactor = 0.5
 	conf.Execution.VMOptions = []execution.VMOption{execution.DebugOpcodes}
 	for _, opt := range options {

--- a/process/process.go
+++ b/process/process.go
@@ -26,13 +26,14 @@ type Launcher struct {
 
 func ListenerFromAddress(listenAddress string) (net.Listener, error) {
 	const errHeader = "ListenerFromAddress():"
+
+	var scheme string
 	parts := strings.Split(listenAddress, "://")
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("%s expects a fully qualified listen address like 'tcp://localhost:12345' but got '%s'",
-			errHeader, listenAddress)
+	if len(parts) == 2 {
+		scheme = parts[0]
+		listenAddress = parts[1]
 	}
-	scheme := parts[0]
-	address := parts[1]
+
 	switch scheme {
 	case "unix", "tcp":
 	case "":
@@ -40,7 +41,8 @@ func ListenerFromAddress(listenAddress string) (net.Listener, error) {
 	default:
 		return nil, fmt.Errorf("%s did not recognise protocol %s in address '%s'", errHeader, scheme, listenAddress)
 	}
-	listener, err := net.Listen(scheme, address)
+
+	listener, err := net.Listen(scheme, listenAddress)
 	if err != nil {
 		return nil, fmt.Errorf("%s %v", errHeader, err)
 	}

--- a/project/history.go
+++ b/project/history.go
@@ -49,8 +49,9 @@ func FullVersion() string {
 var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "https://github.com/hyperledger/burrow").
 	MustDeclareReleases(
 		"",
-		`### Added
-- [CLI] Introduced burrow configure --pool for generation of multiple validator configs suitable for running on a single (or many) machines
+		`### Changed
+- [Config] Split ListenAddress into ListenHost and ListenPort to ease parsing in the Helm charts
+- [CLI] Burrow restore now always fails if state is detected but can be made --silent
 `,
 		"0.25.0 - 2019-04-05",
 		`### Changed
@@ -60,6 +61,7 @@ var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "htt
 - [Kernel] Refactored and various exported methods changed
 
 ### Added
+- [CLI] Introduced burrow configure --pool for generation of multiple validator configs suitable for running on a single (or many) machines
 - [CLI] Burrow deploy can now run multiple burrow deploy files (aka playbooks) and run them in parallel
 - [Consensus] Now possible to run Burrow without Tendermint in 'NoConsensus' mode by setting Tendermint.Enabled = false  for faster local testing. Execution.TimeoutFactor can be used to control how regularly Burrow commits (and is used 
 

--- a/rpc/config.go
+++ b/rpc/config.go
@@ -1,10 +1,8 @@
 package rpc
 
-import "fmt"
-
-// 'localhost' gets interpreted as ipv6
+// 'LocalHost' gets interpreted as ipv6
 // TODO: revisit this
-const localhost = "127.0.0.1"
+const LocalHost = "127.0.0.1"
 
 type RPCConfig struct {
 	Info     *ServerConfig  `json:",omitempty" toml:",omitempty"`
@@ -14,8 +12,9 @@ type RPCConfig struct {
 }
 
 type ServerConfig struct {
-	Enabled       bool
-	ListenAddress string
+	Enabled    bool
+	ListenHost string
+	ListenPort string
 }
 
 type MetricsConfig struct {
@@ -35,30 +34,34 @@ func DefaultRPCConfig() *RPCConfig {
 
 func DefaultInfoConfig() *ServerConfig {
 	return &ServerConfig{
-		Enabled:       true,
-		ListenAddress: fmt.Sprintf("tcp://%s:26658", localhost),
+		Enabled:    true,
+		ListenHost: LocalHost,
+		ListenPort: "26658",
 	}
 }
 
 func DefaultGRPCConfig() *ServerConfig {
 	return &ServerConfig{
-		Enabled:       true,
-		ListenAddress: fmt.Sprintf("tcp://%s:10997", localhost),
+		Enabled:    true,
+		ListenHost: LocalHost,
+		ListenPort: "10997",
 	}
 }
 
 func DefaultProfilerConfig() *ServerConfig {
 	return &ServerConfig{
-		Enabled:       false,
-		ListenAddress: fmt.Sprintf("tcp://%s:6060", localhost),
+		Enabled:    false,
+		ListenHost: LocalHost,
+		ListenPort: "6060",
 	}
 }
 
 func DefaultMetricsConfig() *MetricsConfig {
 	return &MetricsConfig{
 		ServerConfig: ServerConfig{
-			Enabled:       false,
-			ListenAddress: fmt.Sprintf("tcp://%s:9102", localhost),
+			Enabled:    false,
+			ListenHost: LocalHost,
+			ListenPort: "9102",
 		},
 		MetricsPath:     "/metrics",
 		BlockSampleSize: 100,

--- a/tests/chain/burrow.toml
+++ b/tests/chain/burrow.toml
@@ -3,7 +3,8 @@ BurrowDir = ".burrow"
 [Tendermint]
   Seeds = ""
   PersistentPeers = ""
-  ListenAddress = "tcp://0.0.0.0:36656"
+  ListenHost = "0.0.0.0"
+  ListenPort = "36656"
   ExternalAddress = ""
   Moniker = "BurrowIntegrationTestNode"
 
@@ -19,16 +20,20 @@ BurrowDir = ".burrow"
 [RPC]
   [RPC.TM]
     Enabled = true
-    ListenAddress = "tcp://127.0.0.1:36658"
+    ListenHost = "127.0.0.1"
+    ListenPort = "36658"
   [RPC.Profiler]
     Enabled = false
-    ListenAddress = "tcp://127.0.0.1:7060"
+    ListenHost = "127.0.0.1"
+    ListenPort = "7060"
   [RPC.GRPC]
     Enabled = true
-    ListenAddress = "tcp://127.0.0.1:20997"
+    ListenHost = "127.0.0.1"
+    ListenPort = "20997"
   [RPC.Metrics]
     Enabled = false
-    ListenAddress = "tcp://127.0.0.1:10102"
+    ListenAddress = "127.0.0.1"
+    ListenPort = "10102"
     MetricsPath = "/metrics"
     BlockSampleSize = 100
 


### PR DESCRIPTION
I've separated the listening addresses to simplify configuration in the helm charts. With the operation of the state restore mechanism, a restarting pod may attempt to re-overwrite state. The default is now to ignore LoadDump if state is already detected, but I've added a cli option to override this. 

Signed-off-by: Gregory Hill <greg.hill@monax.io>