### PR TITLE
dial local keys identified by phonebook

### DIFF
--- a/cmd/burrow/commands/start.go
+++ b/cmd/burrow/commands/start.go
@@ -42,6 +42,10 @@ func Start(output Output) func(cmd *cli.Cmd) {
 				output.Fatalf("could not boot Burrow kernel: %v", err)
 			}
 
+			if pb := conf.Tendermint.PhoneBook; len(pb) > 0 {
+				kern.DialPeersFromKeyStore(pb)
+			}
+
 			kern.WaitForShutdown()
 		}
 	}

--- a/consensus/tendermint/config.go
+++ b/consensus/tendermint/config.go
@@ -3,6 +3,7 @@ package tendermint
 import (
 	"fmt"
 	"math"
+	"net"
 	"net/url"
 	"strings"
 	"time"
@@ -11,9 +12,9 @@ import (
 	tmConfig "github.com/tendermint/tendermint/config"
 )
 
-// Burrow's view on Tendermint's config. Since we operate as a Tendermint harness not all configuration values
-// are applicable, we may not allow some values to specified, or we may not allow some to be set independently.
-// So this serves as a layer of indirection over Tendermint's real config that we derive from ours.
+// BurrowTendermintConfig is our view on Tendermint's config. Since we operate as a Tendermint harness not all
+// configuration values are applicable, we may not allow some values to specified, or we may not allow some to
+// be set independently. So this serves as a layer of indirection over Tendermint's real config that we derive from ours.
 type BurrowTendermintConfig struct {
 	Enabled bool
 	// Initial peers we connect to for peer exchange
@@ -22,14 +23,21 @@ type BurrowTendermintConfig struct {
 	SeedMode bool
 	// Peers to which we automatically connect
 	PersistentPeers string
-	ListenHost      string
-	ListenPort      string
+	// Address for incoming peer connections
+	ListenHost string
+	ListenPort string
 	// Optional external that nodes may provide with their NodeInfo
 	ExternalAddress string
 	// Set true for strict address routability rules
 	// Set false for private or local networks
 	AddrBookStrict bool
-	Moniker        string
+	// Human readable node name
+	Moniker string
+	// Automatically connect to hosts by moniker
+	PhoneBook map[string]struct {
+		IP   net.IP
+		Port uint16
+	}
 	// Peers ID or address this node is authorize to sync with
 	AuthorizedPeers string
 	// EmptyBlocks mode and possible interval between empty blocks in seconds


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

This PR introduces a `PhoneBook` mapping in the Tendermint configuration to automatically dial local peers identified by their IP address and port. This is a separation of concern from IdentifyTx, where we simply want to enable a fresh deployment (local or [remote](https://github.com/helm/charts/tree/master/stable/burrow)) to instantly connect.