### PR TITLE
dial identified validator from cli

### DIFF
--- a/cmd/burrow/commands/start.go
+++ b/cmd/burrow/commands/start.go
@@ -12,7 +12,9 @@ func Start(output Output) func(cmd *cli.Cmd) {
 
 		configOpt := cmd.StringOpt("c config", "", "Use the specified burrow config file")
 
-		cmd.Spec = "[--config=<config file>] [--genesis=<genesis json file>]"
+		dialOpt := cmd.StringsOpt("d dial", nil, "Dial the specified moniker on a given host address (moniker=host)")
+
+		cmd.Spec = "[--config=<config file>] [--genesis=<genesis json file>] [--dial=<moniker=host>]"
 
 		configOpts := addConfigOptions(cmd)
 
@@ -40,6 +42,11 @@ func Start(output Output) func(cmd *cli.Cmd) {
 
 			if err = kern.Boot(); err != nil {
 				output.Fatalf("could not boot Burrow kernel: %v", err)
+			}
+
+			// dialOpt should be of the form moniker=host
+			if pb := *dialOpt; len(pb) > 0 {
+				kern.DialPeersFromGenesis(pb)
 			}
 
 			kern.WaitForShutdown()

--- a/consensus/tendermint/config.go
+++ b/consensus/tendermint/config.go
@@ -11,9 +11,9 @@ import (
 	tmConfig "github.com/tendermint/tendermint/config"
 )
 
-// Burrow's view on Tendermint's config. Since we operate as a Tendermint harness not all configuration values
-// are applicable, we may not allow some values to specified, or we may not allow some to be set independently.
-// So this serves as a layer of indirection over Tendermint's real config that we derive from ours.
+// BurrowTendermintConfig is our view on Tendermint's config. Since we operate as a Tendermint harness not all
+// configuration values are applicable, we may not allow some values to specified, or we may not allow some to
+// be set independently. So this serves as a layer of indirection over Tendermint's real config that we derive from ours.
 type BurrowTendermintConfig struct {
 	Enabled bool
 	// Initial peers we connect to for peer exchange
@@ -22,14 +22,16 @@ type BurrowTendermintConfig struct {
 	SeedMode bool
 	// Peers to which we automatically connect
 	PersistentPeers string
-	ListenHost      string
-	ListenPort      string
+	// Address for incoming peer connections
+	ListenHost string
+	ListenPort string
 	// Optional external that nodes may provide with their NodeInfo
 	ExternalAddress string
 	// Set true for strict address routability rules
 	// Set false for private or local networks
 	AddrBookStrict bool
-	Moniker        string
+	// Human readable node name
+	Moniker string
 	// Peers ID or address this node is authorize to sync with
 	AuthorizedPeers string
 	// EmptyBlocks mode and possible interval between empty blocks in seconds


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

This is a replacement to my earlier PR, as the NodeAddress is also identified in the GenesisDoc, I can simplify connecting multiple nodes by dialing a given peer on start (i.e. `--dial "Full_0=127.0.0.1:26656"`).