### PR TITLE
start burrow by account, global cli config and genesis options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,10 @@ bin/
 # tests
 test_scratch/
 *.log
-.burrow
 .keys
+.burrow*
 burrow.toml
+burrow???.toml
 
 # Temporary / cached
 *.swp
@@ -20,3 +21,4 @@ commit_hash.txt
 
 tests/keys/
 .output.json
+vendor/

--- a/cmd/burrow/commands/deploy.go
+++ b/cmd/burrow/commands/deploy.go
@@ -17,6 +17,7 @@ import (
 // 15 seconds is like a long time man
 const defaultChainTimeout = 15 * time.Second
 
+// Deploy runs the desired playbook(s)
 func Deploy(output Output) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		chainOpt := cmd.StringOpt("c chain", "127.0.0.1:10997", "chain to be used in IP:PORT format")

--- a/cmd/burrow/commands/dump.go
+++ b/cmd/burrow/commands/dump.go
@@ -19,13 +19,14 @@ import (
 
 var cdc = amino.NewCodec()
 
+// Dump saves the state from a remote chain
 func Dump(output Output) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		chainURLOpt := cmd.StringOpt("c chain", "127.0.0.1:10997", "chain to be used in IP:PORT format")
 		heightOpt := cmd.IntOpt("h height", 0, "Block height to dump to, defaults to latest block height")
 		filename := cmd.StringArg("FILE", "", "Save dump here")
 		useJSON := cmd.BoolOpt("j json", false, "Output in json")
-		timeoutOpt := cmd.IntOpt("t timeout", 0, "GRPC timeout in seconds")
+		timeoutOpt := cmd.IntOpt("t timeout", 0, "Timeout in seconds")
 
 		s := state.NewState(db.NewMemDB())
 

--- a/cmd/burrow/commands/examine.go
+++ b/cmd/burrow/commands/examine.go
@@ -12,12 +12,12 @@ import (
 
 func Examine(output Output) func(cmd *cli.Cmd) {
 	return func(dump *cli.Cmd) {
-		configOpt := dump.StringOpt("c config", "", "Use the a specified burrow config file")
+		configOpts := addConfigOptions(dump)
 
 		var explorer *bcm.BlockStore
 
 		dump.Before = func() {
-			conf, err := obtainBurrowConfig(*configOpt, "")
+			conf, err := configOpts.obtainBurrowConfig()
 			if err != nil {
 				output.Fatalf("Could not obtain config: %v", err)
 			}

--- a/cmd/burrow/commands/helpers.go
+++ b/cmd/burrow/commands/helpers.go
@@ -20,7 +20,7 @@ type Output interface {
 	Fatalf(format string, args ...interface{})
 }
 
-func obtainBurrowConfig(configFile, genesisDocFile string) (*config.BurrowConfig, error) {
+func obtainDefaultConfig(configFile, genesisDocFile string) (*config.BurrowConfig, error) {
 	// We need to reflect on whether this obscures where values are coming from
 	conf := config.DefaultBurrowConfig()
 	// We treat logging a little differently in that if anything is set for logging we will not

--- a/cmd/burrow/commands/keys.go
+++ b/cmd/burrow/commands/keys.go
@@ -5,37 +5,35 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
-
-	"github.com/hyperledger/burrow/deployment"
-	cli "github.com/jawher/mow.cli"
-
 	"time"
-
-	"io/ioutil"
 
 	"github.com/howeyc/gopass"
 	"github.com/hyperledger/burrow/config"
 	"github.com/hyperledger/burrow/crypto"
+	"github.com/hyperledger/burrow/deployment"
 	"github.com/hyperledger/burrow/keys"
+	cli "github.com/jawher/mow.cli"
 	"google.golang.org/grpc"
 )
 
+// Keys runs as either client or server
 func Keys(output Output) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		keysHost := cmd.String(cli.StringOpt{
 			Name:   "host",
 			Desc:   "set the host for talking to the key daemon",
 			Value:  keys.DefaultHost,
-			EnvVar: "MONAX_KEYS_HOST",
+			EnvVar: "BURROW_KEYS_HOST",
 		})
 
 		keysPort := cmd.String(cli.StringOpt{
 			Name:   "port",
 			Desc:   "set the port for key daemon",
 			Value:  keys.DefaultPort,
-			EnvVar: "MONAX_KEYS_PORT",
+			EnvVar: "BURROW_KEYS_PORT",
 		})
 
 		grpcKeysClient := func(output Output) keys.KeysClient {
@@ -57,7 +55,7 @@ func Keys(output Output) func(cmd *cli.Cmd) {
 
 			cmd.Before = func() {
 				var err error
-				conf, err = obtainBurrowConfig(*configOpt, "")
+				conf, err = obtainDefaultConfig(*configOpt, "")
 				if err != nil {
 					output.Fatalf("Could not obtain config: %v", err)
 				}

--- a/cmd/burrow/commands/spec.go
+++ b/cmd/burrow/commands/spec.go
@@ -8,6 +8,7 @@ import (
 	cli "github.com/jawher/mow.cli"
 )
 
+// Spec generates a list of genesis accounts with certain permissions
 func Spec(output Output) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		tomlOpt := cmd.BoolOpt("t toml", false, "Emit GenesisSpec as TOML rather than the "+

--- a/cmd/burrow/commands/start.go
+++ b/cmd/burrow/commands/start.go
@@ -5,33 +5,22 @@ import (
 	cli "github.com/jawher/mow.cli"
 )
 
+// Start launches the burrow daemon
 func Start(output Output) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
-		genesisOpt := cmd.StringOpt("g genesis", "",
-			"Use the specified genesis JSON file rather than a key in the main config, use - to read from STDIN")
-
-		configOpt := cmd.StringOpt("c config", "", "Use the specified burrow config file")
-
-		cmd.Spec = "[--config=<config file>] [--genesis=<genesis json file>]"
-
 		configOpts := addConfigOptions(cmd)
 
 		cmd.Action = func() {
-			conf, err := obtainBurrowConfig(*configOpt, *genesisOpt)
+			conf, err := configOpts.obtainBurrowConfig()
 			if err != nil {
-				output.Fatalf("could not obtain config: %v", err)
+				output.Fatalf("could not set up config: %v", err)
 			}
 
-			err = configOpts.configure(conf)
-			if err != nil {
-				output.Fatalf("could not update burrow config: %v", err)
+			if err := conf.Verify(); err != nil {
+				output.Fatalf("cannot continue with config: %v", err)
 			}
 
-			if conf.ValidatorAddress == nil {
-				output.Fatalf("could not finalise validator address - please provide one in config or via --validator-address")
-			}
-
-			output.Logf("Using validator address: %s", *conf.ValidatorAddress)
+			output.Logf("Using validator address: %s", *conf.Address)
 
 			kern, err := core.LoadKernelFromConfig(conf)
 			if err != nil {

--- a/cmd/burrow/commands/vent.go
+++ b/cmd/burrow/commands/vent.go
@@ -7,11 +7,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/hyperledger/burrow/config/source"
 	"github.com/hyperledger/burrow/execution/evm/abi"
 	"github.com/hyperledger/burrow/vent/config"
-
-	"github.com/hyperledger/burrow/config/source"
-
 	"github.com/hyperledger/burrow/vent/logger"
 	"github.com/hyperledger/burrow/vent/service"
 	"github.com/hyperledger/burrow/vent/sqlsol"
@@ -19,6 +17,7 @@ import (
 	cli "github.com/jawher/mow.cli"
 )
 
+// Vent consumes EVM events and commits to a DB
 func Vent(output Output) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/hyperledger/burrow/config/source"
 	"github.com/hyperledger/burrow/consensus/tendermint"
 	"github.com/hyperledger/burrow/crypto"
@@ -18,8 +20,8 @@ const DefaultGenesisDocJSONFileName = "genesis.json"
 
 type BurrowConfig struct {
 	// Set on startup
-	ValidatorAddress    *crypto.Address `json:",omitempty" toml:",omitempty"`
-	ValidatorPassphrase *string         `json:",omitempty" toml:",omitempty"`
+	Address    *crypto.Address `json:",omitempty" toml:",omitempty"`
+	Passphrase *string         `json:",omitempty" toml:",omitempty"`
 	// From config file
 	BurrowDir  string
 	GenesisDoc *genesis.GenesisDoc                `json:",omitempty" toml:",omitempty"`
@@ -39,6 +41,13 @@ func DefaultBurrowConfig() *BurrowConfig {
 		Execution:  execution.DefaultExecutionConfig(),
 		Logging:    logconfig.DefaultNodeLoggingConfig(),
 	}
+}
+
+func (conf *BurrowConfig) Verify() error {
+	if conf.Address == nil {
+		return fmt.Errorf("could not finalise address - please provide one in config or via --account-address")
+	}
+	return nil
 }
 
 func (conf *BurrowConfig) TendermintConfig() *tmConfig.Config {

--- a/config/source/source_test.go
+++ b/config/source/source_test.go
@@ -40,7 +40,7 @@ func TestCascade(t *testing.T) {
 	envVar := "FISH_SPOON_ALPHA"
 	// Both fall through so baseConfig returned
 	conf := newTestConfig()
-	err := Cascade(os.Stderr, true,
+	err := Cascade(true,
 		Environment(envVar),
 		File("", false)).Apply(conf)
 	assert.NoError(t, err)
@@ -51,7 +51,7 @@ func TestCascade(t *testing.T) {
 	file := writeConfigFile(t, fileConfig)
 	defer os.Remove(file)
 	conf = new(animalConfig)
-	err = Cascade(os.Stderr, true,
+	err = Cascade(true,
 		Environment(envVar),
 		File(file, false)).Apply(conf)
 	assert.NoError(t, err)
@@ -64,7 +64,7 @@ func TestCascade(t *testing.T) {
 	}
 	os.Setenv(envVar, JSONString(envConfig))
 	conf = newTestConfig()
-	err = Cascade(os.Stderr, true,
+	err = Cascade(true,
 		Environment(envVar),
 		File(file, false)).Apply(conf)
 	assert.NoError(t, err)

--- a/core/config.go
+++ b/core/config.go
@@ -126,13 +126,13 @@ func LoadKernelFromConfig(conf *config.BurrowConfig) (*Kernel, error) {
 		return nil, fmt.Errorf("could not load state: %v", err)
 	}
 
-	if conf.ValidatorAddress == nil {
-		return nil, fmt.Errorf("ValidatorAddress must be set")
+	if conf.Address == nil {
+		return nil, fmt.Errorf("Address must be set")
 	}
 
-	privVal, err := kern.PrivValidator(*conf.ValidatorAddress)
+	privVal, err := kern.PrivValidator(*conf.Address)
 	if err != nil {
-		return nil, fmt.Errorf("could not form PrivValidator from ValidatorAddress: %v", err)
+		return nil, fmt.Errorf("could not form PrivValidator from Address: %v", err)
 	}
 
 	err = kern.LoadTendermintFromConfig(conf, privVal)

--- a/docs/quickstart/add-validators.md
+++ b/docs/quickstart/add-validators.md
@@ -59,7 +59,7 @@ If you haven't already, swap in the public key for your new validator and run th
 
 ```bash
 sed -i "s/NEW_VALIDATOR/$NEW_VALIDATOR/" deploy.yaml
-burrow deploy -u 127.0.0.1:10997 --mempool-signing=true --address=$OLD_VALIDATOR deploy.yaml
+burrow deploy -c 127.0.0.1:10997 --mempool-signing=true --address=$OLD_VALIDATOR deploy.yaml
 ```
 
 If this returns successfully, you'll be able to see that the new validator is now in the running set:

--- a/docs/quickstart/deploy-contracts.md
+++ b/docs/quickstart/deploy-contracts.md
@@ -250,7 +250,7 @@ From inside that directory, we are ready to deploy.
 burrow deploy --address F71831847564B7008AD30DD56336D9C42787CF63 deploy.yaml
 ```
 
-where you should replace the `--address` field with the `ValidatorAddress` at the top of your `burrow.toml`.
+where you should replace the `--address` field with the `Address` at the top of your `burrow.toml`.
 
 That's it! You've successfully deployed (and tested) a Solidity contract to a Burrow node.
 

--- a/docs/quickstart/seed-nodes.md
+++ b/docs/quickstart/seed-nodes.md
@@ -41,7 +41,7 @@ burrow spec --full-accounts=3 | burrow configure -s- > .burrow_init.toml
 
 ### Generate one additional key in another local store for seed node
 ```bash
-burrow spec -f1 | burrow configure --keysdir=.keys_seed -s- > /dev/null
+burrow spec -f1 | burrow configure --keys-dir=.keys_seed -s- > /dev/null
 ```
 
 ### Make 3 validator nodes and one seed node config files
@@ -189,7 +189,7 @@ BurrowDir = ".burrow_node2"
 
 #### Start the seed node
 ```bash
-burrow start --validator-address=`basename .keys_seed/data/* .json` --config=.burrow_seed.toml  > .burrow_seed.log 2>&1 &
+burrow start --address=`basename .keys_seed/data/* .json` --config=.burrow_seed.toml  > .burrow_seed.log 2>&1 &
 ```
 
 #### Find seed node external address
@@ -209,9 +209,9 @@ sed -i s%PUT_HERE_SEED_NODE_ID@LISTEN_EXTERNAL_ADDRESS%${SEED_URL}% .burrow_val2
 
 #### Start validator nodes
 ```bash
-burrow start --validator-index=0 --config=.burrow_val0.toml  > .burrow_val0.log 2>&1 &
-burrow start --validator-index=1 --config=.burrow_val1.toml  > .burrow_val1.log 2>&1 &
-burrow start --validator-index=2 --config=.burrow_val2.toml  > .burrow_val2.log 2>&1 &
+burrow start -v=0 --config=.burrow_val0.toml  > .burrow_val0.log 2>&1 &
+burrow start -v=1 --config=.burrow_val1.toml  > .burrow_val1.log 2>&1 &
+burrow start -v=2 --config=.burrow_val2.toml  > .burrow_val2.log 2>&1 &
 ```
 
 Nodes will connect to seed node and request addresses, then they will connect to each other and start submitting and voting on blocks.

--- a/docs/quickstart/send-transactions.md
+++ b/docs/quickstart/send-transactions.md
@@ -16,7 +16,7 @@ SIGNING_ADDRESS=HERE_ONE_VALIDATOR_ADDRESS_OF_THE_GENESIS
 burrow deploy --address $SIGNING_ADDRESS test.yaml
 ```
 
-where you should replace the `--address` field with the `ValidatorAddress` at the top of your `burrow.toml`.
+where you should replace the `--address` field with the `Address` at the top of your `burrow.toml`.
 
 if you have updated the default burrow GRPC port, parameter `-u` `--chain` is your burrow running node ip:GRPCport.
 

--- a/docs/quickstart/single-full-node.md
+++ b/docs/quickstart/single-full-node.md
@@ -28,9 +28,9 @@ Once the `burrow.toml` has been created, we run:
 
 ```
 # To select our validator address by index in the GenesisDoc
-burrow start --validator-index=0
+burrow start --validator=0
 # Or to select based on address directly (substituting the example address below with your validator's):
-burrow start --validator-address=BE584820DC904A55449D7EB0C97607B40224B96E
+burrow start --address=BE584820DC904A55449D7EB0C97607B40224B96E
 ```
 
 and the logs will start streaming through.

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365
 	github.com/imdario/mergo v0.3.7
 	github.com/jawher/mow.cli v1.0.5
+	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/lib/pq v1.1.0
 	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/monax/relic v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -71,10 +71,13 @@ github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/jawher/mow.cli v1.0.5 h1:MEWYfyzcJXp8yvqtJYBMa8GLW073pM7RXN1zRDayMU8=
 github.com/jawher/mow.cli v1.0.5/go.mod h1:rZZcz2ygDSemQyV66jOaCszjT/zAL3FcEGNj5ReUpkQ=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
+github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
+github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/lib/pq v1.1.0 h1:/5u4a+KGJptBRqGzPvYQL9p0d/tPR4S31+Tnzj9lEO4=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/tests/dump/test.sh
+++ b/tests/dump/test.sh
@@ -9,7 +9,6 @@
 # - Stop chain and delete
 # - Restore chain from dump
 # - Check all bits are present (account, namereg, code, events)
-#
 
 set -e
 
@@ -21,11 +20,10 @@ rm -rf .burrow genesis.json burrow.toml burrow.log
 
 burrow_bin=${burrow_bin:-burrow}
 
-echo "------------------------------------"
-echo "Creating new chain..."
-echo "------------------------------------"
+title="Creating new chain..."
+echo -e "\n${title//?/-}\n${title}\n${title//?/-}\n"
 
-$burrow_bin spec -n "Fresh Chain" -v1 | $burrow_bin configure -m BurrowTestDumpNode -s- -w genesis.json > burrow.toml
+$burrow_bin spec -n "Fresh Chain" -v1 | $burrow_bin configure -n BurrowTestDumpNode -s- --separate-genesis-doc genesis.json > burrow.toml
 
 $burrow_bin start 2>> burrow.log &
 burrow_pid=$!
@@ -37,16 +35,13 @@ trap kill_burrow EXIT
 
 sleep 1
 
-echo "------------------------------------"
-echo "Creating code, events and names..."
-echo "------------------------------------"
+title="Creating code, events and names..."
+echo -e "\n${title//?/-}\n${title}\n${title//?/-}\n"
 
 $burrow_bin deploy -o '' -a Validator_0 --dir $burrow_dump deploy.yaml
 
-
-echo "------------------------------------"
-echo "Dumping chain..."
-echo "------------------------------------"
+title="Dumping chain..."
+echo -e "${title//?/-}\n${title}\n${title//?/-}\n"
 
 $burrow_bin dump dump.bin
 $burrow_bin dump -j dump.json
@@ -59,20 +54,18 @@ kill $burrow_pid
 mv genesis.json genesis-original.json
 rm -rf .burrow burrow.toml
 
-echo "------------------------------------"
-echo "Create new chain based of dump with new name..."
-echo "------------------------------------"
+title="Create new chain based of dump with new name..."
+echo -e "\n${title//?/-}\n${title}\n${title//?/-}\n"
 
-$burrow_bin configure -m BurrowTestRestoreNode -n "Restored Chain" -g genesis-original.json -w genesis.json --restore-dump dump.json > burrow.toml
+$burrow_bin configure -m BurrowTestRestoreNode -n "Restored Chain" --genesis genesis-original.json --separate-genesis-doc genesis.json --restore-dump dump.json > burrow.toml
 
 $burrow_bin restore dump.json
 $burrow_bin start 2>> burrow.log &
 burrow_pid=$!
 sleep 13
 
-echo "------------------------------------"
-echo "Dumping restored chain for comparison..."
-echo "------------------------------------"
+title="Dumping restored chain for comparison..."
+echo -e "\n${title//?/-}\n${title}\n${title//?/-}\n"
 
 burrow dump -j --height $height dump-after-restore.json
 
@@ -80,9 +73,8 @@ kill $burrow_pid
 
 if cmp dump.json dump-after-restore.json
 then
-	echo "------------------------------------"
-	echo "Done."
-	echo "------------------------------------"
+	title="Done."
+	echo -e "\n${title//?/-}\n${title}\n${title//?/-}\n"
 else
 	echo "RESTORE FAILURE"
 	echo "restored dump is different"


### PR DESCRIPTION
Signed-off-by: Gregory Hill <greg.hill@monax.io>

Reuse config and genesis file across commands. Rename `validator` to `node` in options and use this index into genesis accounts instead of validators.

## Added

`BURROW_CONFIG_FILE` `BURROW_GENESIS_FILE`

## Fixed

Closes #1086 - `burrow configure --pool --json`
