### PR TITLE
Ensure BlockTime is persisted to avoid non-determinism in EVM with TIMESTAMP opcode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 ## [Unreleased]
 
 
+## [0.26.2] - 2019-06-19
+### Fixed
+- [Blockchain] Persist LastBlockTime in Blockchain - before this patch LastBlockTime would only be set correctly after the first block had been received after a node is restarted - this can lead to non-determinism in the EVM via the TIMESTAMP opcode that use the LastBlockTime which is itself sourced from Tendermint's block header (from their implementation of BFT time). Implementing no empty blocks made observing this bug more likely by increasing the amount of time spent in a bad state (LastBlockTime is initially set to GenesisTime).
+
+
 ## [0.26.1] - 2019-06-16
 ### Changed
 - [CLI] 'burrow dump' renamed 'burrow dump remote'
@@ -502,7 +507,8 @@ This release marks the start of Eris-DB as the full permissioned blockchain node
   - [Blockchain] Fix getBlocks to respect block height cap.
 
 
-[Unreleased]: https://github.com/hyperledger/burrow/compare/v0.26.1...HEAD
+[Unreleased]: https://github.com/hyperledger/burrow/compare/v0.26.2...HEAD
+[0.26.2]: https://github.com/hyperledger/burrow/compare/v0.26.1...v0.26.2
 [0.26.1]: https://github.com/hyperledger/burrow/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/hyperledger/burrow/compare/v0.25.1...v0.26.0
 [0.25.1]: https://github.com/hyperledger/burrow/compare/v0.25.0...v0.25.1

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,15 +1,3 @@
-### Changed
-- [CLI] 'burrow dump' renamed 'burrow dump remote'
-- [Consensus] By default Burrow no longer creates empty blocks at the end of a round - though does make on every 5 minutes by default. Set CreateEmptyBlocks to "never" or omit to create no blocks unless there are transactions, or "always" to generate blocks even when there are no transactions.
-- [State] Burrow state does not store empty blocks in the execution event store even when Tendermint creates them.
-- [Build] 'make install_burrow' is now just 'make install'
-
 ### Fixed
-- [Deploy] Always read TxExecution exception in Burrow deploy to avoid panics later on
-- [Restore] Set restore transaction hash to non-zero (sha256 of original ChainID + Height)
-- [Vent] --txs and --blocks now actually enable their respective tables in the Vent database
-- [Consensus] Tendermint config CreateEmptyBlocks, CreateEmptyBlocksInterval now work as intended and prevent empty blocks being produced (except when needed for proof purposes) or when the interval expires (when set)
-
-### Added
-- [Dump] burrow dump now has local variant that produces a dump directly from a compatible burrow directory rather than over GRPC. If dumping/restoring between state-incompatible versions use burrow dump remote. 
+- [Blockchain] Persist LastBlockTime in Blockchain - before this patch LastBlockTime would only be set correctly after the first block had been received after a node is restarted - this can lead to non-determinism in the EVM via the TIMESTAMP opcode that use the LastBlockTime which is itself sourced from Tendermint's block header (from their implementation of BFT time). Implementing no empty blocks made observing this bug more likely by increasing the amount of time spent in a bad state (LastBlockTime is initially set to GenesisTime).
 

--- a/bcm/block_store.go
+++ b/bcm/block_store.go
@@ -11,23 +11,23 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-type BlockExplorer struct {
+type BlockStore struct {
 	txDecoder txs.Decoder
 	state.BlockStoreRPC
 }
 
-func NewBlockStore(blockStore state.BlockStoreRPC) *BlockExplorer {
-	return &BlockExplorer{
+func NewBlockStore(blockStore state.BlockStoreRPC) *BlockStore {
+	return &BlockStore{
 		txDecoder:     txs.NewAminoCodec(),
 		BlockStoreRPC: blockStore,
 	}
 }
 
-func NewBlockExplorer(dbBackendType db.DBBackendType, dbDir string) *BlockExplorer {
+func NewBlockExplorer(dbBackendType db.DBBackendType, dbDir string) *BlockStore {
 	return NewBlockStore(blockchain.NewBlockStore(db.NewDB("blockstore", dbBackendType, dbDir)))
 }
 
-func (bs *BlockExplorer) Block(height int64) (_ *Block, err error) {
+func (bs *BlockStore) Block(height int64) (_ *Block, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("BlockStore.Block(): could not get block at height %v: %v", height, r)
@@ -41,7 +41,7 @@ func (bs *BlockExplorer) Block(height int64) (_ *Block, err error) {
 	return NewBlock(bs.txDecoder, tmBlock), nil
 }
 
-func (bs *BlockExplorer) BlockMeta(height int64) (_ *types.BlockMeta, err error) {
+func (bs *BlockStore) BlockMeta(height int64) (_ *types.BlockMeta, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("BlockStore.BlockMeta() could not get BlockMeta at height %d: %v\n%s",
@@ -52,7 +52,7 @@ func (bs *BlockExplorer) BlockMeta(height int64) (_ *types.BlockMeta, err error)
 }
 
 // Iterate over blocks between start (inclusive) and end (exclusive)
-func (bs *BlockExplorer) Blocks(start, end int64, iter func(*Block) error) error {
+func (bs *BlockStore) Blocks(start, end int64, iter func(*Block) error) error {
 	if end > 0 && start >= end {
 		return fmt.Errorf("end height must be strictly greater than start height")
 	}

--- a/bcm/blockchain_test.go
+++ b/bcm/blockchain_test.go
@@ -1,0 +1,82 @@
+package bcm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hyperledger/burrow/crypto/sha3"
+	"github.com/hyperledger/burrow/genesis"
+	"github.com/hyperledger/burrow/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tendermint/libs/db"
+)
+
+func TestLoadOrNewBlockchain(t *testing.T) {
+	// Initial load - fresh chain
+	genesisDoc := newGenesisDoc()
+	db := dbm.NewMemDB()
+	blockchain, exists, err := LoadOrNewBlockchain(db, genesisDoc, logging.NewNoopLogger())
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assert.Equal(t, genesisDoc.GenesisTime, blockchain.LastBlockTime())
+	assert.Equal(t, uint64(0), blockchain.LastBlockHeight())
+	assert.Equal(t, genesisDoc.Hash(), blockchain.AppHashAfterLastBlock())
+
+	// First block
+	blockTime1 := genesisDoc.GenesisTime.Add(time.Second * 10)
+	blockHash1 := sha3.Sha3([]byte("blockHash"))
+	appHash1 := sha3.Sha3([]byte("appHash"))
+	err = blockchain.CommitBlock(blockTime1, blockHash1, appHash1)
+	require.NoError(t, err)
+	assertState(t, blockchain, 1, blockTime1, appHash1)
+
+	// Second block
+	blockTime2a := blockTime1.Add(time.Second * 30)
+	blockHash2a := sha3.Sha3(append(blockHash1, 2))
+	appHash2a := sha3.Sha3(append(appHash1, 2))
+	err = blockchain.CommitBlock(blockTime2a, blockHash2a, appHash2a)
+	require.NoError(t, err)
+	assertState(t, blockchain, 2, blockTime2a, appHash2a)
+
+	// Load at checkpoint (i.e. first block)
+	blockchain, exists, err = LoadOrNewBlockchain(db, genesisDoc, logging.NewNoopLogger())
+	require.NoError(t, err)
+	assert.True(t, exists)
+	// Assert first block values
+	assertState(t, blockchain, 1, blockTime1, appHash1)
+
+	// Commit (overwriting previous block 2 pointer
+	blockTime2b := blockTime1.Add(time.Second * 30)
+	blockHash2b := sha3.Sha3(append(blockHash1, 2))
+	appHash2b := sha3.Sha3(append(appHash1, 2))
+	err = blockchain.CommitBlock(blockTime2b, blockHash2b, appHash2b)
+	require.NoError(t, err)
+	assertState(t, blockchain, 2, blockTime2b, appHash2b)
+
+	// Commit again to check things are okay
+	blockTime3 := blockTime2b.Add(time.Second * 30)
+	blockHash3 := sha3.Sha3(append(blockHash2b, 2))
+	appHash3 := sha3.Sha3(append(appHash2b, 2))
+	err = blockchain.CommitBlock(blockTime3, blockHash3, appHash3)
+	require.NoError(t, err)
+	assertState(t, blockchain, 3, blockTime3, appHash3)
+
+	// Load at checkpoint (i.e. block 2b)
+	blockchain, exists, err = LoadOrNewBlockchain(db, genesisDoc, logging.NewNoopLogger())
+	require.NoError(t, err)
+	assert.True(t, exists)
+	// Assert first block values
+	assertState(t, blockchain, 2, blockTime2b, appHash2b)
+}
+
+func assertState(t *testing.T, blockchain *Blockchain, height uint64, blockTime time.Time, appHash []byte) {
+	assert.Equal(t, height, blockchain.LastBlockHeight())
+	assert.Equal(t, blockTime, blockchain.LastBlockTime())
+	assert.Equal(t, appHash, blockchain.AppHashAfterLastBlock())
+}
+
+func newGenesisDoc() *genesis.GenesisDoc {
+	genesisDoc, _, _ := genesis.NewDeterministicGenesis(3450976).GenesisDoc(23, true, 4, 10, true, 4)
+	return genesisDoc
+}

--- a/cmd/burrow/commands/examine.go
+++ b/cmd/burrow/commands/examine.go
@@ -14,7 +14,7 @@ func Examine(output Output) func(cmd *cli.Cmd) {
 	return func(dump *cli.Cmd) {
 		configOpts := addConfigOptions(dump)
 
-		var explorer *bcm.BlockExplorer
+		var explorer *bcm.BlockStore
 
 		dump.Before = func() {
 			conf, err := configOpts.obtainBurrowConfig()

--- a/core/kernel.go
+++ b/core/kernel.go
@@ -113,7 +113,7 @@ func (kern *Kernel) SetLogger(logger *logging.Logger) {
 // LoadState starts from scratch or previous chain
 func (kern *Kernel) LoadState(genesisDoc *genesis.GenesisDoc) (err error) {
 	var existing bool
-	existing, kern.Blockchain, err = bcm.LoadOrNewBlockchain(kern.database, genesisDoc, kern.Logger)
+	kern.Blockchain, existing, err = bcm.LoadOrNewBlockchain(kern.database, genesisDoc, kern.Logger)
 	if err != nil {
 		return fmt.Errorf("error creating or loading blockchain state: %v", err)
 	}
@@ -154,7 +154,7 @@ func (kern *Kernel) LoadState(genesisDoc *genesis.GenesisDoc) (err error) {
 // LoadDump restores chain state from the given dump file
 func (kern *Kernel) LoadDump(genesisDoc *genesis.GenesisDoc, restoreFile string, silent bool) (err error) {
 	var exists bool
-	if exists, kern.Blockchain, err = bcm.LoadOrNewBlockchain(kern.database, genesisDoc, kern.Logger); err != nil {
+	if kern.Blockchain, exists, err = bcm.LoadOrNewBlockchain(kern.database, genesisDoc, kern.Logger); err != nil {
 		return fmt.Errorf("error creating or loading blockchain state: %v", err)
 	}
 

--- a/execution/execution_test.go
+++ b/execution/execution_test.go
@@ -1508,7 +1508,7 @@ func makeUsers(n int) []acm.AddressableSigner {
 
 func newBlockchain(genesisDoc *genesis.GenesisDoc) *bcm.Blockchain {
 	testDB := dbm.NewDB("test", dbBackend, ".")
-	_, blockchain, _ := bcm.LoadOrNewBlockchain(testDB, testGenesisDoc, logger)
+	blockchain, _, _ := bcm.LoadOrNewBlockchain(testDB, testGenesisDoc, logger)
 	return blockchain
 }
 

--- a/forensics/replay.go
+++ b/forensics/replay.go
@@ -24,7 +24,7 @@ import (
 )
 
 type Replay struct {
-	Explorer   *bcm.BlockExplorer
+	Explorer   *bcm.BlockStore
 	db         dbm.DB
 	cacheDB    dbm.DB
 	blockchain *bcm.Blockchain
@@ -60,7 +60,7 @@ func NewReplay(dbDir string, genesisDoc *genesis.GenesisDoc, logger *logging.Log
 }
 
 func (re *Replay) LatestBlockchain() (*bcm.Blockchain, error) {
-	_, blockchain, err := bcm.LoadOrNewBlockchain(re.db, re.genesisDoc, re.logger)
+	blockchain, _, err := bcm.LoadOrNewBlockchain(re.db, re.genesisDoc, re.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/project/history.go
+++ b/project/history.go
@@ -47,8 +47,13 @@ func FullVersion() string {
 // To cut a new release add a release to the front of this slice then run the
 // release tagging script: ./scripts/tag_release.sh
 var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "https://github.com/hyperledger/burrow").
-	MustDeclareReleases("",
+	MustDeclareReleases(
+		"",
 		``,
+		"0.26.2 - 2019-06-19",
+		`### Fixed
+- [Blockchain] Persist LastBlockTime in Blockchain - before this patch LastBlockTime would only be set correctly after the first block had been received after a node is restarted - this can lead to non-determinism in the EVM via the TIMESTAMP opcode that use the LastBlockTime which is itself sourced from Tendermint's block header (from their implementation of BFT time). Implementing no empty blocks made observing this bug more likely by increasing the amount of time spent in a bad state (LastBlockTime is initially set to GenesisTime).
+`,
 		"0.26.1 - 2019-06-16",
 		`### Changed
 - [CLI] 'burrow dump' renamed 'burrow dump remote'


### PR DESCRIPTION
Also adds test for blockchain and makes PersistedState part of
Blockchain to avoid any divergence between in-memory and on-disk values.

Signed-off-by: Silas Davis <silas@monax.io>