### PR TITLE
make test fails in circleci due to out of memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,8 @@ solang: $(SOLANG_GO_FILES)
 
 .PHONY: test
 test: check bin/solc
-	@tests/scripts/bin_wrapper.sh go test ./... ${GOPACKAGES_NOVENDOR}
+# limit parallelism with -p to prevent OOM on circleci
+	@tests/scripts/bin_wrapper.sh go test ./... -p 2
 
 .PHONY: test_keys
 test_keys: build_burrow


### PR DESCRIPTION
Signed-off-by: Sean Young <sean.young@monax.io>