### PR TITLE
Allow -p 2 to be set for circleci, and for not for local testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ jobs:
       - run: make test
       # In case we miss compile errors not pulled into test paths
       - run: make build
+    environment:
+      - GO_TEST_ARGS: -p 2
 
   test_cover:
     <<: *defaults

--- a/Makefile
+++ b/Makefile
@@ -164,12 +164,12 @@ solang: $(SOLANG_GO_FILES)
 
 .PHONY: test
 test: check bin/solc
-# limit parallelism with -p to prevent OOM on circleci
-	@tests/scripts/bin_wrapper.sh go test ./... -p 2
+# on circleci we might want to limit memory usage through GO_TEST_ARGS
+	@tests/scripts/bin_wrapper.sh go test ./... ${GO_TEST_ARGS}
 
 .PHONY: test_cover
 test_cover: check bin/solc
-	@tests/scripts/bin_wrapper.sh go test -coverprofile=c.out ./... -p 2
+	@tests/scripts/bin_wrapper.sh go test -coverprofile=c.out ./... ${GO_TEST_ARGS}
 	@tests/scripts/bin_wrapper.sh go tool cover -html=c.out -o coverage.html
 
 .PHONY: test_keys


### PR DESCRIPTION
This makes sure we locally test faster and test more parallelism.

Signed-off-by: Sean Young <sean.young@monax.io>