### PR TITLE
WIP: Preserve origin height

### DIFF
--- a/dump/dump.go
+++ b/dump/dump.go
@@ -161,17 +161,19 @@ func (ds *Dumper) Transmit(sink Sink, startHeight, endHeight uint64, options Opt
 				case ev.BeginTx != nil:
 					origin = ev.BeginTx.TxHeader.Origin
 				case ev.Event != nil && ev.Event.Log != nil:
-					evmevent := EVMEvent{Event: ev.Event.Log}
+					row := &Dump{EVMEvent: &EVMEvent{Event: ev.Event.Log}}
 					if origin != nil {
 						// this event was already restored
-						evmevent.ChainID = origin.ChainID
-						evmevent.Time = origin.Time
+						row.EVMEvent.ChainID = origin.ChainID
+						row.EVMEvent.Time = origin.Time
+						row.Height = origin.Height
 					} else {
 						// this event was generated on this chain
-						evmevent.ChainID = ds.blockchain.ChainID()
-						evmevent.Time = blockTime
+						row.EVMEvent.ChainID = ds.blockchain.ChainID()
+						row.EVMEvent.Time = blockTime
+						row.Height = ev.Event.Header.Height
 					}
-					err := sink.Send(&Dump{Height: ev.Event.Header.Height, EVMEvent: &evmevent})
+					err := sink.Send(row)
 					if err != nil {
 						return err
 					}

--- a/protobuf/dump.proto
+++ b/protobuf/dump.proto
@@ -40,7 +40,6 @@ message EVMEvent {
     google.protobuf.Timestamp Time = 2 [(gogoproto.nullable)=false, (gogoproto.stdtime)=true];
     // The event itself
     exec.LogEvent Event = 3;
-
 }
 
 message Dump {


### PR DESCRIPTION
Currently we will lose original height if repeatedly dumping (more than once).

Making this PR while I'm thinking about it, but we should also test this and we need to think through what guarantees we make about `_height` and `_chain_id` metadata columns in Vent. This is important for consumer who rely on origin chain info.

