### PR TITLE
Fix --pool

### DIFF
--- a/logging/logconfig/config.go
+++ b/logging/logconfig/config.go
@@ -2,14 +2,12 @@ package logconfig
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"github.com/eapache/channels"
 	"github.com/go-kit/kit/log"
 	"github.com/hyperledger/burrow/logging"
-	"github.com/hyperledger/burrow/logging/structure"
-
-	"encoding/json"
 
 	"github.com/BurntSushi/toml"
 	"github.com/hyperledger/burrow/logging/loggers"
@@ -33,7 +31,6 @@ func DefaultNodeLoggingConfig() *LoggingConfig {
 	// Output only Burrow messages on stdout
 	return &LoggingConfig{
 		RootSink: Sink().
-			SetTransform(FilterTransform(ExcludeWhenAnyMatches, structure.ComponentKey, structure.Tendermint)).
 			SetOutput(StdoutOutput().SetFormat(loggers.JSONFormat)),
 	}
 }


### PR DESCRIPTION
`--pool` will not work with current tendermint because it generates node address with uppercase node IDs (addresses) which, rather annoyingly, is no longer allowed. This fixes that.

Also:
- Allow `--pool` and `--separate-genesis-doc` to work together see #1183 
- It's rather unhelpful to suppress Tendermint logging by default. I have removed this from the default logging config. Excessive Tendermint logs are less of an issue with default empty block settings anyway.

We should add integration tests for `--pool`