### PR TITLE
Query and ABI

### DIFF
--- a/acm/acm.pb.go
+++ b/acm/acm.pb.go
@@ -5,6 +5,10 @@ package acm
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
@@ -12,8 +16,6 @@ import (
 	crypto "github.com/hyperledger/burrow/crypto"
 	github_com_hyperledger_burrow_crypto "github.com/hyperledger/burrow/crypto"
 	permission "github.com/hyperledger/burrow/permission"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -225,17 +227,17 @@ func (m *Account) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintAcm(dAtA, i, uint64(m.Address.Size()))
-	n1, err := m.Address.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n1, err1 := m.Address.MarshalTo(dAtA[i:])
+	if err1 != nil {
+		return 0, err1
 	}
 	i += n1
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintAcm(dAtA, i, uint64(m.PublicKey.Size()))
-	n2, err := m.PublicKey.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n2, err2 := m.PublicKey.MarshalTo(dAtA[i:])
+	if err2 != nil {
+		return 0, err2
 	}
 	i += n2
 	if m.Sequence != 0 {
@@ -251,33 +253,33 @@ func (m *Account) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x2a
 	i++
 	i = encodeVarintAcm(dAtA, i, uint64(m.EVMCode.Size()))
-	n3, err := m.EVMCode.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n3, err3 := m.EVMCode.MarshalTo(dAtA[i:])
+	if err3 != nil {
+		return 0, err3
 	}
 	i += n3
 	dAtA[i] = 0x32
 	i++
 	i = encodeVarintAcm(dAtA, i, uint64(m.Permissions.Size()))
-	n4, err := m.Permissions.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n4, err4 := m.Permissions.MarshalTo(dAtA[i:])
+	if err4 != nil {
+		return 0, err4
 	}
 	i += n4
 	dAtA[i] = 0x3a
 	i++
 	i = encodeVarintAcm(dAtA, i, uint64(m.WASMCode.Size()))
-	n5, err := m.WASMCode.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n5, err5 := m.WASMCode.MarshalTo(dAtA[i:])
+	if err5 != nil {
+		return 0, err5
 	}
 	i += n5
 	dAtA[i] = 0x42
 	i++
 	i = encodeVarintAcm(dAtA, i, uint64(m.CodeHash.Size()))
-	n6, err := m.CodeHash.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n6, err6 := m.CodeHash.MarshalTo(dAtA[i:])
+	if err6 != nil {
+		return 0, err6
 	}
 	i += n6
 	if len(m.ContractMeta) > 0 {
@@ -296,9 +298,9 @@ func (m *Account) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x52
 		i++
 		i = encodeVarintAcm(dAtA, i, uint64(m.Forebear.Size()))
-		n7, err := m.Forebear.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n7, err7 := m.Forebear.MarshalTo(dAtA[i:])
+		if err7 != nil {
+			return 0, err7
 		}
 		i += n7
 	}
@@ -326,17 +328,17 @@ func (m *ContractMeta) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintAcm(dAtA, i, uint64(m.CodeHash.Size()))
-	n8, err := m.CodeHash.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n8, err8 := m.CodeHash.MarshalTo(dAtA[i:])
+	if err8 != nil {
+		return 0, err8
 	}
 	i += n8
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintAcm(dAtA, i, uint64(m.MetadataHash.Size()))
-	n9, err := m.MetadataHash.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n9, err9 := m.MetadataHash.MarshalTo(dAtA[i:])
+	if err9 != nil {
+		return 0, err9
 	}
 	i += n9
 	if len(m.Metadata) > 0 {
@@ -421,14 +423,7 @@ func (m *ContractMeta) Size() (n int) {
 }
 
 func sovAcm(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozAcm(x uint64) (n int) {
 	return sovAcm(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/acm/balance/balance.pb.go
+++ b/acm/balance/balance.pb.go
@@ -5,11 +5,13 @@ package balance
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -159,14 +161,7 @@ func (m *Balance) Size() (n int) {
 }
 
 func sovBalance(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozBalance(x uint64) (n int) {
 	return sovBalance(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/acm/validator/validator.pb.go
+++ b/acm/validator/validator.pb.go
@@ -5,12 +5,14 @@ package validator
 
 import (
 	fmt "fmt"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
 	crypto "github.com/hyperledger/burrow/crypto"
 	github_com_hyperledger_burrow_crypto "github.com/hyperledger/burrow/crypto"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -123,14 +125,7 @@ func (m *Validator) Size() (n int) {
 }
 
 func sovValidator(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozValidator(x uint64) (n int) {
 	return sovValidator(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/bcm/bcm.pb.go
+++ b/bcm/bcm.pb.go
@@ -5,6 +5,11 @@ package bcm
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+	time "time"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
@@ -12,9 +17,6 @@ import (
 	_ "github.com/golang/protobuf/ptypes/duration"
 	_ "github.com/golang/protobuf/ptypes/timestamp"
 	github_com_hyperledger_burrow_binary "github.com/hyperledger/burrow/binary"
-	io "io"
-	math "math"
-	time "time"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -227,41 +229,41 @@ func (m *SyncInfo) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintBcm(dAtA, i, uint64(m.LatestBlockHash.Size()))
-	n1, err := m.LatestBlockHash.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n1, err1 := m.LatestBlockHash.MarshalTo(dAtA[i:])
+	if err1 != nil {
+		return 0, err1
 	}
 	i += n1
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintBcm(dAtA, i, uint64(m.LatestAppHash.Size()))
-	n2, err := m.LatestAppHash.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n2, err2 := m.LatestAppHash.MarshalTo(dAtA[i:])
+	if err2 != nil {
+		return 0, err2
 	}
 	i += n2
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintBcm(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.LatestBlockTime)))
-	n3, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.LatestBlockTime, dAtA[i:])
-	if err != nil {
-		return 0, err
+	n3, err3 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.LatestBlockTime, dAtA[i:])
+	if err3 != nil {
+		return 0, err3
 	}
 	i += n3
 	dAtA[i] = 0x2a
 	i++
 	i = encodeVarintBcm(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.LatestBlockSeenTime)))
-	n4, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.LatestBlockSeenTime, dAtA[i:])
-	if err != nil {
-		return 0, err
+	n4, err4 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.LatestBlockSeenTime, dAtA[i:])
+	if err4 != nil {
+		return 0, err4
 	}
 	i += n4
 	dAtA[i] = 0x32
 	i++
 	i = encodeVarintBcm(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.LatestBlockDuration)))
-	n5, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.LatestBlockDuration, dAtA[i:])
-	if err != nil {
-		return 0, err
+	n5, err5 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.LatestBlockDuration, dAtA[i:])
+	if err5 != nil {
+		return 0, err5
 	}
 	i += n5
 	if m.XXX_unrecognized != nil {
@@ -288,17 +290,17 @@ func (m *PersistedState) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintBcm(dAtA, i, uint64(m.AppHashAfterLastBlock.Size()))
-	n6, err := m.AppHashAfterLastBlock.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n6, err6 := m.AppHashAfterLastBlock.MarshalTo(dAtA[i:])
+	if err6 != nil {
+		return 0, err6
 	}
 	i += n6
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintBcm(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.LastBlockTime)))
-	n7, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.LastBlockTime, dAtA[i:])
-	if err != nil {
-		return 0, err
+	n7, err7 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.LastBlockTime, dAtA[i:])
+	if err7 != nil {
+		return 0, err7
 	}
 	i += n7
 	if m.LastBlockHeight != 0 {
@@ -309,9 +311,9 @@ func (m *PersistedState) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintBcm(dAtA, i, uint64(m.GenesisHash.Size()))
-	n8, err := m.GenesisHash.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n8, err8 := m.GenesisHash.MarshalTo(dAtA[i:])
+	if err8 != nil {
+		return 0, err8
 	}
 	i += n8
 	if m.XXX_unrecognized != nil {
@@ -376,14 +378,7 @@ func (m *PersistedState) Size() (n int) {
 }
 
 func sovBcm(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozBcm(x uint64) (n int) {
 	return sovBcm(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/consensus/tendermint/tendermint.pb.go
+++ b/consensus/tendermint/tendermint.pb.go
@@ -5,12 +5,14 @@ package tendermint
 
 import (
 	fmt "fmt"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
 	github_com_hyperledger_burrow_binary "github.com/hyperledger/burrow/binary"
 	github_com_hyperledger_burrow_crypto "github.com/hyperledger/burrow/crypto"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -182,14 +184,7 @@ func (m *NodeInfo) Size() (n int) {
 }
 
 func sovTendermint(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTendermint(x uint64) (n int) {
 	return sovTendermint(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/crypto/crypto.pb.go
+++ b/crypto/crypto.pb.go
@@ -5,12 +5,14 @@ package crypto
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
 	github_com_hyperledger_burrow_binary "github.com/hyperledger/burrow/binary"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -224,9 +226,9 @@ func (m *PublicKey) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintCrypto(dAtA, i, uint64(m.PublicKey.Size()))
-	n1, err := m.PublicKey.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n1, err1 := m.PublicKey.MarshalTo(dAtA[i:])
+	if err1 != nil {
+		return 0, err1
 	}
 	i += n1
 	if m.XXX_unrecognized != nil {
@@ -374,14 +376,7 @@ func (m *Signature) Size() (n int) {
 }
 
 func sovCrypto(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCrypto(x uint64) (n int) {
 	return sovCrypto(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/dump/dump.pb.go
+++ b/dump/dump.pb.go
@@ -5,6 +5,11 @@ package dump
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+	time "time"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
@@ -15,9 +20,6 @@ import (
 	github_com_hyperledger_burrow_crypto "github.com/hyperledger/burrow/crypto"
 	exec "github.com/hyperledger/burrow/execution/exec"
 	names "github.com/hyperledger/burrow/execution/names"
-	io "io"
-	math "math"
-	time "time"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -342,17 +344,17 @@ func (m *Storage) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDump(dAtA, i, uint64(m.Key.Size()))
-	n1, err := m.Key.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n1, err1 := m.Key.MarshalTo(dAtA[i:])
+	if err1 != nil {
+		return 0, err1
 	}
 	i += n1
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDump(dAtA, i, uint64(m.Value.Size()))
-	n2, err := m.Value.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n2, err2 := m.Value.MarshalTo(dAtA[i:])
+	if err2 != nil {
+		return 0, err2
 	}
 	i += n2
 	if m.XXX_unrecognized != nil {
@@ -379,9 +381,9 @@ func (m *AccountStorage) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintDump(dAtA, i, uint64(m.Address.Size()))
-	n3, err := m.Address.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n3, err3 := m.Address.MarshalTo(dAtA[i:])
+	if err3 != nil {
+		return 0, err3
 	}
 	i += n3
 	if len(m.Storage) > 0 {
@@ -426,18 +428,18 @@ func (m *EVMEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintDump(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Time)))
-	n4, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Time, dAtA[i:])
-	if err != nil {
-		return 0, err
+	n4, err4 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Time, dAtA[i:])
+	if err4 != nil {
+		return 0, err4
 	}
 	i += n4
 	if m.Event != nil {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintDump(dAtA, i, uint64(m.Event.Size()))
-		n5, err := m.Event.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n5, err5 := m.Event.MarshalTo(dAtA[i:])
+		if err5 != nil {
+			return 0, err5
 		}
 		i += n5
 	}
@@ -476,9 +478,9 @@ func (m *Dump) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintDump(dAtA, i, uint64(m.Account.Size()))
-		n6, err := m.Account.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n6, err6 := m.Account.MarshalTo(dAtA[i:])
+		if err6 != nil {
+			return 0, err6
 		}
 		i += n6
 	}
@@ -486,9 +488,9 @@ func (m *Dump) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintDump(dAtA, i, uint64(m.AccountStorage.Size()))
-		n7, err := m.AccountStorage.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n7, err7 := m.AccountStorage.MarshalTo(dAtA[i:])
+		if err7 != nil {
+			return 0, err7
 		}
 		i += n7
 	}
@@ -496,9 +498,9 @@ func (m *Dump) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x22
 		i++
 		i = encodeVarintDump(dAtA, i, uint64(m.EVMEvent.Size()))
-		n8, err := m.EVMEvent.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n8, err8 := m.EVMEvent.MarshalTo(dAtA[i:])
+		if err8 != nil {
+			return 0, err8
 		}
 		i += n8
 	}
@@ -506,9 +508,9 @@ func (m *Dump) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2a
 		i++
 		i = encodeVarintDump(dAtA, i, uint64(m.Name.Size()))
-		n9, err := m.Name.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n9, err9 := m.Name.MarshalTo(dAtA[i:])
+		if err9 != nil {
+			return 0, err9
 		}
 		i += n9
 	}
@@ -620,14 +622,7 @@ func (m *Dump) Size() (n int) {
 }
 
 func sovDump(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozDump(x uint64) (n int) {
 	return sovDump(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/encoding/encoding.pb.go
+++ b/encoding/encoding.pb.go
@@ -5,11 +5,13 @@ package encoding
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -161,14 +163,7 @@ func (m *TestMessage) Size() (n int) {
 }
 
 func sovEncoding(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozEncoding(x uint64) (n int) {
 	return sovEncoding(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/event/query/query.go
+++ b/event/query/query.go
@@ -50,7 +50,9 @@ type Condition struct {
 // New parses the given string and returns a query or error if the string is
 // invalid.
 func New(s string) (*PegQuery, error) {
-	p := &QueryParser{Buffer: s}
+	p := &QueryParser{
+		Buffer: s,
+	}
 	err := p.Init()
 	if err != nil {
 		return nil, err

--- a/execution/errors/errors.pb.go
+++ b/execution/errors/errors.pb.go
@@ -5,11 +5,13 @@ package errors
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -163,14 +165,7 @@ func (m *Exception) Size() (n int) {
 }
 
 func sovErrors(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozErrors(x uint64) (n int) {
 	return sovErrors(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/execution/evm/abi/abi.go
+++ b/execution/evm/abi/abi.go
@@ -1,27 +1,16 @@
 package abi
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	"reflect"
-	"regexp"
-	"strconv"
-	"strings"
-
-	hex "github.com/tmthrgd/go-hex"
-
-	burrow_binary "github.com/hyperledger/burrow/binary"
-	"github.com/hyperledger/burrow/crypto"
-	"github.com/hyperledger/burrow/crypto/sha3"
-
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 
+	"github.com/hyperledger/burrow/crypto"
 	"github.com/hyperledger/burrow/deploy/compile"
-	"github.com/hyperledger/burrow/execution/errors"
 	"github.com/hyperledger/burrow/logging"
 )
 
@@ -32,17 +21,36 @@ type Variable struct {
 	Value string
 }
 
-func init() {
-	var err error
-	revertAbi, err = ReadSpec([]byte(`[{"name":"Error","type":"function","outputs":[{"type":"string"}],"inputs":[{"type":"string"}]}]`))
-	if err != nil {
-		panic(fmt.Sprintf("internal error: failed to build revert abi: %v", err))
+// LoadPath loads one abi file or finds all files in a directory
+func LoadPath(abiFileOrDirs ...string) (*Spec, error) {
+	if len(abiFileOrDirs) == 0 {
+		return &Spec{}, fmt.Errorf("no ABI file or directory provided")
 	}
-}
 
-// revertAbi exists to decode reverts. Any contract function call fail using revert(), assert() or require().
-// If a function exits this way, the this hardcoded ABI will be used.
-var revertAbi *Spec
+	specs := make([]*Spec, 0)
+
+	for _, dir := range abiFileOrDirs {
+		err := filepath.Walk(dir, func(path string, fi os.FileInfo, err error) error {
+			if err != nil {
+				return fmt.Errorf("error returned while walking abiDir '%s': %v", dir, err)
+			}
+			ext := filepath.Ext(path)
+			if fi.IsDir() || !(ext == ".bin" || ext == ".abi") {
+				return nil
+			}
+			abiSpc, err := ReadSpecFile(path)
+			if err != nil {
+				return fmt.Errorf("error parsing abi file at %s: %v", path, err)
+			}
+			specs = append(specs, abiSpc)
+			return nil
+		})
+		if err != nil {
+			return &Spec{}, err
+		}
+	}
+	return MergeSpec(specs), nil
+}
 
 // EncodeFunctionCallFromFile ABI encodes a function call based on ABI in file, and the
 // arguments specified as strings.
@@ -157,303 +165,7 @@ func DecodeFunctionReturn(abiData, name string, data []byte) ([]*Variable, error
 	return vars, nil
 }
 
-func readAbi(root, contract string, logger *logging.Logger) (string, error) {
-	p := path.Join(root, stripHex(contract))
-	if _, err := os.Stat(p); err != nil {
-		logger.TraceMsg("abifile not found", "tried", p)
-		p = path.Join(root, stripHex(contract)+".bin")
-		if _, err = os.Stat(p); err != nil {
-			logger.TraceMsg("abifile not found", "tried", p)
-			return "", fmt.Errorf("abi doesn't exist for =>\t%s", p)
-		}
-	}
-	logger.TraceMsg("Found ABI file", "path", p)
-	sol, err := compile.LoadSolidityContract(p)
-	if err != nil {
-		return "", err
-	}
-	return string(sol.Abi), nil
-}
-
-// LoadPath loads one abi file or finds all files in a directory
-func LoadPath(abiFileOrDirs ...string) (*Spec, error) {
-	if len(abiFileOrDirs) == 0 {
-		return &Spec{}, fmt.Errorf("no ABI file or directory provided")
-	}
-
-	specs := make([]*Spec, 0)
-
-	for _, dir := range abiFileOrDirs {
-		err := filepath.Walk(dir, func(path string, fi os.FileInfo, err error) error {
-			if err != nil {
-				return fmt.Errorf("error returned while walking abiDir '%s': %v", dir, err)
-			}
-			ext := filepath.Ext(path)
-			if fi.IsDir() || !(ext == ".bin" || ext == ".abi") {
-				return nil
-			}
-			if err == nil {
-				abiSpc, err := ReadSpecFile(path)
-				if err != nil {
-					return errors.Wrap(err, "Error parsing abi file "+path)
-				}
-				specs = append(specs, abiSpc)
-			}
-			return nil
-		})
-		if err != nil {
-			return &Spec{}, err
-		}
-	}
-	return MergeSpec(specs), nil
-}
-
-func stripHex(s string) string {
-	if len(s) > 1 {
-		if s[:2] == "0x" {
-			s = s[2:]
-			if len(s)%2 != 0 {
-				s = "0" + s
-			}
-			return s
-		}
-	}
-	return s
-}
-
-// Argument is a decoded function parameter, return or event field
-type Argument struct {
-	Name        string
-	EVM         EVMType
-	IsArray     bool
-	Indexed     bool
-	Hashed      bool
-	ArrayLength uint64
-}
-
-// FunctionIDSize is the length of the function selector
-const FunctionIDSize = 4
-
-type FunctionID [FunctionIDSize]byte
-
-// EventIDSize is the length of the event selector
-const EventIDSize = 32
-
-type EventID [EventIDSize]byte
-
-func (e EventID) String() string {
-	return hex.EncodeUpperToString(e[:])
-}
-
-type FunctionSpec struct {
-	FunctionID FunctionID
-	Constant   bool
-	Inputs     []Argument
-	Outputs    []Argument
-}
-
-type EventSpec struct {
-	EventID   EventID
-	Inputs    []Argument
-	Name      string
-	Anonymous bool
-}
-
-// Spec is the ABI for contract decoded.
-type Spec struct {
-	Constructor  FunctionSpec
-	Fallback     FunctionSpec
-	Functions    map[string]FunctionSpec
-	EventsByName map[string]EventSpec
-	EventsByID   map[EventID]EventSpec
-}
-
-type argumentJSON struct {
-	Name       string
-	Type       string
-	Components []argumentJSON
-	Indexed    bool
-}
-
-type specJSON struct {
-	Name            string
-	Type            string
-	Inputs          []argumentJSON
-	Outputs         []argumentJSON
-	Constant        bool
-	Payable         bool
-	StateMutability string
-	Anonymous       bool
-}
-
-func readArgSpec(argsJ []argumentJSON) ([]Argument, error) {
-	args := make([]Argument, len(argsJ))
-	var err error
-
-	for i, a := range argsJ {
-		args[i].Name = a.Name
-		args[i].Indexed = a.Indexed
-
-		baseType := a.Type
-		isArray := regexp.MustCompile(`(.*)\[([0-9]+)\]`)
-		m := isArray.FindStringSubmatch(a.Type)
-		if m != nil {
-			args[i].IsArray = true
-			args[i].ArrayLength, err = strconv.ParseUint(m[2], 10, 32)
-			if err != nil {
-				return nil, err
-			}
-			baseType = m[1]
-		} else if strings.HasSuffix(a.Type, "[]") {
-			args[i].IsArray = true
-			baseType = strings.TrimSuffix(a.Type, "[]")
-		}
-
-		isM := regexp.MustCompile("(bytes|uint|int)([0-9]+)")
-		m = isM.FindStringSubmatch(baseType)
-		if m != nil {
-			M, err := strconv.ParseUint(m[2], 10, 32)
-			if err != nil {
-				return nil, err
-			}
-			switch m[1] {
-			case "bytes":
-				if M < 1 || M > 32 {
-					return nil, fmt.Errorf("bytes%d is not valid type", M)
-				}
-				args[i].EVM = EVMBytes{M}
-			case "uint":
-				if M < 8 || M > 256 || (M%8) != 0 {
-					return nil, fmt.Errorf("uint%d is not valid type", M)
-				}
-				args[i].EVM = EVMUint{M}
-			case "int":
-				if M < 8 || M > 256 || (M%8) != 0 {
-					return nil, fmt.Errorf("uint%d is not valid type", M)
-				}
-				args[i].EVM = EVMInt{M}
-			}
-			continue
-		}
-
-		isMxN := regexp.MustCompile("(fixed|ufixed)([0-9]+)x([0-9]+)")
-		m = isMxN.FindStringSubmatch(baseType)
-		if m != nil {
-			M, err := strconv.ParseUint(m[2], 10, 32)
-			if err != nil {
-				return nil, err
-			}
-			N, err := strconv.ParseUint(m[3], 10, 32)
-			if err != nil {
-				return nil, err
-			}
-			if M < 8 || M > 256 || (M%8) != 0 {
-				return nil, fmt.Errorf("%s is not valid type", baseType)
-			}
-			if N == 0 || N > 80 {
-				return nil, fmt.Errorf("%s is not valid type", baseType)
-			}
-			if m[1] == "fixed" {
-				args[i].EVM = EVMFixed{N: N, M: M, signed: true}
-			} else if m[1] == "ufixed" {
-				args[i].EVM = EVMFixed{N: N, M: M, signed: false}
-			} else {
-				panic(m[1])
-			}
-			continue
-		}
-		switch baseType {
-		case "uint":
-			args[i].EVM = EVMUint{M: 256}
-		case "int":
-			args[i].EVM = EVMInt{M: 256}
-		case "address":
-			args[i].EVM = EVMAddress{}
-		case "bool":
-			args[i].EVM = EVMBool{}
-		case "fixed":
-			args[i].EVM = EVMFixed{M: 128, N: 8, signed: true}
-		case "ufixed":
-			args[i].EVM = EVMFixed{M: 128, N: 8, signed: false}
-		case "bytes":
-			args[i].EVM = EVMBytes{M: 0}
-		case "string":
-			args[i].EVM = EVMString{}
-		default:
-			// Assume it is a type of Contract
-			args[i].EVM = EVMAddress{}
-		}
-	}
-
-	return args, nil
-}
-
-// ReadSpec takes an ABI and decodes it for futher use
-func ReadSpec(specBytes []byte) (*Spec, error) {
-	var specJ []specJSON
-	err := json.Unmarshal(specBytes, &specJ)
-	if err != nil {
-		// The abi spec file might a bin file, with the Abi under the Abi field in json
-		var binFile struct {
-			Abi []specJSON
-		}
-		err = json.Unmarshal(specBytes, &binFile)
-		if err != nil {
-			return nil, err
-		}
-		specJ = binFile.Abi
-	}
-
-	abiSpec := Spec{
-		EventsByName: make(map[string]EventSpec),
-		EventsByID:   make(map[EventID]EventSpec),
-		Functions:    make(map[string]FunctionSpec),
-	}
-
-	for _, s := range specJ {
-		switch s.Type {
-		case "constructor":
-			abiSpec.Constructor.Inputs, err = readArgSpec(s.Inputs)
-			if err != nil {
-				return nil, err
-			}
-		case "fallback":
-			abiSpec.Fallback.Inputs = make([]Argument, 0)
-			abiSpec.Fallback.Outputs = make([]Argument, 0)
-		case "event":
-			inputs, err := readArgSpec(s.Inputs)
-			if err != nil {
-				return nil, err
-			}
-			// Get signature before we deal with hashed types
-			sig := Signature(s.Name, inputs)
-			for i := range inputs {
-				if inputs[i].Indexed && inputs[i].EVM.Dynamic() {
-					// For Dynamic types, the hash is stored in stead
-					inputs[i].EVM = EVMBytes{M: 32}
-					inputs[i].Hashed = true
-				}
-			}
-			ev := EventSpec{Name: s.Name, EventID: GetEventID(sig), Inputs: inputs, Anonymous: s.Anonymous}
-			abiSpec.EventsByName[ev.Name] = ev
-			abiSpec.EventsByID[ev.EventID] = ev
-		case "function":
-			inputs, err := readArgSpec(s.Inputs)
-			if err != nil {
-				return nil, err
-			}
-			outputs, err := readArgSpec(s.Outputs)
-			if err != nil {
-				return nil, err
-			}
-			fs := FunctionSpec{Inputs: inputs, Outputs: outputs, Constant: s.Constant}
-			fs.SetFunctionID(s.Name)
-			abiSpec.Functions[s.Name] = fs
-		}
-	}
-
-	return &abiSpec, nil
-}
+// Spec
 
 // ReadSpecFile reads an ABI file from a file
 func ReadSpecFile(filename string) (*Spec, error) {
@@ -465,65 +177,7 @@ func ReadSpecFile(filename string) (*Spec, error) {
 	return ReadSpec(specBytes)
 }
 
-// MergeSpec takes multiple Specs and merges them into once structure. Note that
-// the same function name or event name can occur in different abis, so there might be
-// some information loss.
-func MergeSpec(abiSpec []*Spec) *Spec {
-	newSpec := Spec{
-		EventsByName: make(map[string]EventSpec),
-		EventsByID:   make(map[EventID]EventSpec),
-		Functions:    make(map[string]FunctionSpec),
-	}
-
-	for _, s := range abiSpec {
-		for n, f := range s.Functions {
-			newSpec.Functions[n] = f
-		}
-
-		// Different Abis can have the Event name, but with a different signature
-		// Loop over the signatures, as these are less likely to have collisions
-		for _, e := range s.EventsByID {
-			newSpec.EventsByName[e.Name] = e
-			newSpec.EventsByID[e.EventID] = e
-		}
-	}
-
-	return &newSpec
-}
-
-func typeFromReflect(v reflect.Type) Argument {
-	arg := Argument{Name: v.Name()}
-
-	if v == reflect.TypeOf(crypto.Address{}) {
-		arg.EVM = EVMAddress{}
-	} else if v == reflect.TypeOf(big.Int{}) {
-		arg.EVM = EVMInt{M: 256}
-	} else {
-		if v.Kind() == reflect.Array {
-			arg.IsArray = true
-			arg.ArrayLength = uint64(v.Len())
-			v = v.Elem()
-		} else if v.Kind() == reflect.Slice {
-			arg.IsArray = true
-			v = v.Elem()
-		}
-
-		switch v.Kind() {
-		case reflect.Bool:
-			arg.EVM = EVMBool{}
-		case reflect.String:
-			arg.EVM = EVMString{}
-		case reflect.Uint64:
-			arg.EVM = EVMUint{M: 64}
-		case reflect.Int64:
-			arg.EVM = EVMInt{M: 64}
-		default:
-			panic(fmt.Sprintf("no mapping for type %v", v.Kind()))
-		}
-	}
-
-	return arg
-}
+// Struct reflection
 
 // SpecFromStructReflect generates a FunctionSpec where the arguments and return values are
 // described a struct. Both args and rets should be set to the return value of reflect.TypeOf()
@@ -573,312 +227,6 @@ func SpecFromFunctionReflect(fname string, v reflect.Value, skipIn, skipOut int)
 	return &s
 }
 
-func argsToSignature(args []Argument, addIndexedName bool) (str string) {
-	str = "("
-	for i, a := range args {
-		if i > 0 {
-			str += ","
-		}
-		str += a.EVM.GetSignature()
-		if addIndexedName && a.Indexed {
-			str += " indexed"
-		}
-		if a.IsArray {
-			if a.ArrayLength > 0 {
-				str += fmt.Sprintf("[%d]", a.ArrayLength)
-			} else {
-				str += "[]"
-			}
-		}
-		if addIndexedName && a.Name != "" {
-			str += " " + a.Name
-		}
-	}
-	str += ")"
-	return
-}
-
-func Signature(name string, args []Argument) string {
-	return name + argsToSignature(args, false)
-}
-
-func (functionSpec *FunctionSpec) SetFunctionID(functionName string) {
-	sig := Signature(functionName, functionSpec.Inputs)
-	functionSpec.FunctionID = GetFunctionID(sig)
-}
-
-func (f *FunctionSpec) String(name string) string {
-	return name + argsToSignature(f.Inputs, true) +
-		" returns " + argsToSignature(f.Outputs, true)
-}
-
-func (e *EventSpec) String() string {
-	str := e.Name + argsToSignature(e.Inputs, true)
-	if e.Anonymous {
-		str += " anonymous"
-	}
-
-	return str
-}
-
-func (fs FunctionID) Bytes() []byte {
-	return fs[:]
-}
-
-func GetFunctionID(signature string) (id FunctionID) {
-	hash := sha3.NewKeccak256()
-	hash.Write([]byte(signature))
-	copy(id[:], hash.Sum(nil)[:4])
-	return
-}
-
-func (fs EventID) Bytes() []byte {
-	return fs[:]
-}
-
-func GetEventID(signature string) (id EventID) {
-	hash := sha3.NewKeccak256()
-	hash.Write([]byte(signature))
-	copy(id[:], hash.Sum(nil))
-	return
-}
-
-// UnpackRevert decodes the revert reason if a contract called revert. If no
-// reason was given, message will be nil else it will point to the string
-func UnpackRevert(data []byte) (message *string, err error) {
-	if len(data) > 0 {
-		var msg string
-		err = revertAbi.UnpackWithID(data, &msg)
-		message = &msg
-	}
-	return
-}
-
-// UnpackEvent decodes all the fields in an event (indexed topic fields or not)
-func UnpackEvent(eventSpec *EventSpec, topics []burrow_binary.Word256, data []byte, args ...interface{}) error {
-	// First unpack the topic fields
-	topicIndex := 0
-	if !eventSpec.Anonymous {
-		topicIndex++
-	}
-
-	for i, a := range eventSpec.Inputs {
-		if a.Indexed {
-			_, err := a.EVM.unpack(topics[topicIndex].Bytes(), 0, args[i])
-			if err != nil {
-				return err
-			}
-			topicIndex++
-		}
-	}
-
-	// Now unpack the other fields. unpack will step over any indexed fields
-	return unpack(eventSpec.Inputs, data, func(i int) interface{} {
-		return args[i]
-	})
-}
-
-// Unpack decodes the return values from a function call
-func (abiSpec *Spec) Unpack(data []byte, fname string, args ...interface{}) error {
-	var funcSpec FunctionSpec
-	var argSpec []Argument
-	if fname != "" {
-		if _, ok := abiSpec.Functions[fname]; ok {
-			funcSpec = abiSpec.Functions[fname]
-		} else {
-			funcSpec = abiSpec.Fallback
-		}
-	} else {
-		funcSpec = abiSpec.Constructor
-	}
-
-	argSpec = funcSpec.Outputs
-
-	if argSpec == nil {
-		return fmt.Errorf("Unknown function %s", fname)
-	}
-
-	return unpack(argSpec, data, func(i int) interface{} {
-		return args[i]
-	})
-}
-
-func (abiSpec *Spec) UnpackWithID(data []byte, args ...interface{}) error {
-	var argSpec []Argument
-
-	var id FunctionID
-	copy(id[:], data)
-	for _, fspec := range abiSpec.Functions {
-		if id == fspec.FunctionID {
-			argSpec = fspec.Outputs
-		}
-	}
-
-	if argSpec == nil {
-		return fmt.Errorf("Unknown function %x", id)
-	}
-
-	return unpack(argSpec, data[4:], func(i int) interface{} {
-		return args[i]
-	})
-}
-
-// Pack ABI encodes a function call. The fname specifies which function should called, if
-// it doesn't exist exist the fallback function will be called. If fname is the empty
-// string, the constructor is called. The arguments must be specified in args. The count
-// must match the function being called.
-// Returns the ABI encoded function call, whether the function is constant according
-// to the ABI (which means it does not modified contract state)
-func (abiSpec *Spec) Pack(fname string, args ...interface{}) ([]byte, *FunctionSpec, error) {
-	var funcSpec FunctionSpec
-	var argSpec []Argument
-	if fname != "" {
-		if _, ok := abiSpec.Functions[fname]; ok {
-			funcSpec = abiSpec.Functions[fname]
-		} else {
-			return nil, nil, fmt.Errorf("Unknown function %s", fname)
-		}
-	} else {
-		if abiSpec.Constructor.Inputs != nil {
-			funcSpec = abiSpec.Constructor
-		} else {
-			return nil, nil, fmt.Errorf("Contract does not have a constructor")
-		}
-	}
-
-	argSpec = funcSpec.Inputs
-
-	packed := make([]byte, 0)
-
-	if fname != "" {
-		packed = funcSpec.FunctionID[:]
-	}
-
-	packedArgs, err := Pack(argSpec, args...)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return append(packed, packedArgs...), &funcSpec, nil
-}
-
-func PackIntoStruct(argSpec []Argument, st interface{}) ([]byte, error) {
-	v := reflect.ValueOf(st)
-
-	fields := v.NumField()
-	if fields != len(argSpec) {
-		return nil, fmt.Errorf("%d arguments expected, %d received", len(argSpec), fields)
-	}
-
-	return pack(argSpec, func(i int) interface{} {
-		return v.Field(i).Interface()
-	})
-}
-
-func Pack(argSpec []Argument, args ...interface{}) ([]byte, error) {
-	if len(args) != len(argSpec) {
-		return nil, fmt.Errorf("%d arguments expected, %d received", len(argSpec), len(args))
-	}
-
-	return pack(argSpec, func(i int) interface{} {
-		return args[i]
-	})
-}
-
-func pack(argSpec []Argument, getArg func(int) interface{}) ([]byte, error) {
-	packed := make([]byte, 0)
-	packedDynamic := []byte{}
-	fixedSize := 0
-	// Anything dynamic is stored after the "fixed" block. For the dynamic types, the fixed
-	// block contains byte offsets to the data. We need to know the length of the fixed
-	// block, so we can calcute the offsets
-	for _, a := range argSpec {
-		if a.IsArray {
-			if a.ArrayLength > 0 {
-				fixedSize += ElementSize * int(a.ArrayLength)
-			} else {
-				fixedSize += ElementSize
-			}
-		} else {
-			fixedSize += ElementSize
-		}
-	}
-
-	addArg := func(v interface{}, a Argument) error {
-		var b []byte
-		var err error
-		if a.EVM.Dynamic() {
-			offset := EVMUint{M: 256}
-			b, _ = offset.pack(fixedSize)
-			d, err := a.EVM.pack(v)
-			if err != nil {
-				return err
-			}
-			fixedSize += len(d)
-			packedDynamic = append(packedDynamic, d...)
-		} else {
-			b, err = a.EVM.pack(v)
-			if err != nil {
-				return err
-			}
-		}
-		packed = append(packed, b...)
-		return nil
-	}
-
-	for i, as := range argSpec {
-		a := getArg(i)
-		if as.IsArray {
-			s, ok := a.(string)
-			if ok && s[0:1] == "[" && s[len(s)-1:] == "]" {
-				a = strings.Split(s[1:len(s)-1], ",")
-			}
-
-			val := reflect.ValueOf(a)
-			if val.Kind() != reflect.Slice && val.Kind() != reflect.Array {
-				return nil, fmt.Errorf("argument %d should be array or slice, not %s", i, val.Kind().String())
-			}
-
-			if as.ArrayLength > 0 {
-				if as.ArrayLength != uint64(val.Len()) {
-					return nil, fmt.Errorf("argumment %d should be array of %d, not %d", i, as.ArrayLength, val.Len())
-				}
-
-				for n := 0; n < val.Len(); n++ {
-					err := addArg(val.Index(n).Interface(), as)
-					if err != nil {
-						return nil, err
-					}
-				}
-			} else {
-				// dynamic array
-				offset := EVMUint{M: 256}
-				b, _ := offset.pack(fixedSize)
-				packed = append(packed, b...)
-				fixedSize += len(b)
-
-				// store length
-				b, _ = offset.pack(val.Len())
-				packedDynamic = append(packedDynamic, b...)
-				for n := 0; n < val.Len(); n++ {
-					d, err := as.EVM.pack(val.Index(n).Interface())
-					if err != nil {
-						return nil, err
-					}
-					packedDynamic = append(packedDynamic, d...)
-				}
-			}
-		} else {
-			err := addArg(a, as)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return append(packed, packedDynamic...), nil
-}
-
 func GetPackingTypes(args []Argument) []interface{} {
 	res := make([]interface{}, len(args))
 
@@ -894,155 +242,67 @@ func GetPackingTypes(args []Argument) []interface{} {
 	return res
 }
 
-func UnpackIntoStruct(argSpec []Argument, data []byte, st interface{}) error {
-	v := reflect.ValueOf(st).Elem()
-	return unpack(argSpec, data, func(i int) interface{} {
-		return v.Field(i).Addr().Interface()
-	})
-}
+func typeFromReflect(v reflect.Type) Argument {
+	arg := Argument{Name: v.Name()}
 
-func Unpack(argSpec []Argument, data []byte, args ...interface{}) error {
-	return unpack(argSpec, data, func(i int) interface{} {
-		return args[i]
-	})
-}
-
-func unpack(argSpec []Argument, data []byte, getArg func(int) interface{}) error {
-	offset := 0
-	offType := EVMInt{M: 64}
-
-	getPrimitive := func(e interface{}, a Argument) error {
-		if a.EVM.Dynamic() {
-			var o int64
-			l, err := offType.unpack(data, offset, &o)
-			if err != nil {
-				return err
-			}
-			offset += l
-			_, err = a.EVM.unpack(data, int(o), e)
-			if err != nil {
-				return err
-			}
-		} else {
-			l, err := a.EVM.unpack(data, offset, e)
-			if err != nil {
-				return err
-			}
-			offset += l
-		}
-
-		return nil
-	}
-
-	for i, a := range argSpec {
-		if a.Indexed {
-			continue
-		}
-
-		arg := getArg(i)
-		if a.IsArray {
-			var array *[]interface{}
-
-			array, ok := arg.(*[]interface{})
-			if !ok {
-				if _, ok := arg.(*string); ok {
-					// We have been asked to return the value as a string; make intermediate
-					// array of strings; we will concatenate after
-					intermediate := make([]interface{}, a.ArrayLength)
-					for i := range intermediate {
-						intermediate[i] = new(string)
-					}
-					array = &intermediate
-				} else {
-					return fmt.Errorf("argument %d should be array, slice or string", i)
-				}
-			}
-
-			if a.ArrayLength > 0 {
-				if int(a.ArrayLength) != len(*array) {
-					return fmt.Errorf("argument %d should be array or slice of %d elements", i, a.ArrayLength)
-				}
-
-				for n := 0; n < len(*array); n++ {
-					err := getPrimitive((*array)[n], a)
-					if err != nil {
-						return err
-					}
-				}
-			} else {
-				var o int64
-				var length int64
-
-				l, err := offType.unpack(data, offset, &o)
-				if err != nil {
-					return err
-				}
-
-				offset += l
-				s, err := offType.unpack(data, int(o), &length)
-				if err != nil {
-					return err
-				}
-				o += int64(s)
-
-				intermediate := make([]interface{}, length)
-
-				if _, ok := arg.(*string); ok {
-					// We have been asked to return the value as a string; make intermediate
-					// array of strings; we will concatenate after
-					for i := range intermediate {
-						intermediate[i] = new(string)
-					}
-				} else {
-					for i := range intermediate {
-						intermediate[i] = a.EVM.getGoType()
-					}
-				}
-
-				for i := 0; i < int(length); i++ {
-					l, err = a.EVM.unpack(data, int(o), intermediate[i])
-					if err != nil {
-						return err
-					}
-					o += int64(l)
-				}
-
-				array = &intermediate
-			}
-
-			// If we were supposed to return a string, convert it back
-			if ret, ok := arg.(*string); ok {
-				s := "["
-				for i, e := range *array {
-					if i > 0 {
-						s += ","
-					}
-					s += *(e.(*string))
-				}
-				s += "]"
-				*ret = s
-			}
-		} else {
-			err := getPrimitive(arg, a)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// quick helper padding
-func pad(input []byte, size int, left bool) []byte {
-	if len(input) >= size {
-		return input[:size]
-	}
-	padded := make([]byte, size)
-	if left {
-		copy(padded[size-len(input):], input)
+	if v == reflect.TypeOf(crypto.Address{}) {
+		arg.EVM = EVMAddress{}
+	} else if v == reflect.TypeOf(big.Int{}) {
+		arg.EVM = EVMInt{M: 256}
 	} else {
-		copy(padded, input)
+		if v.Kind() == reflect.Array {
+			arg.IsArray = true
+			arg.ArrayLength = uint64(v.Len())
+			v = v.Elem()
+		} else if v.Kind() == reflect.Slice {
+			arg.IsArray = true
+			v = v.Elem()
+		}
+
+		switch v.Kind() {
+		case reflect.Bool:
+			arg.EVM = EVMBool{}
+		case reflect.String:
+			arg.EVM = EVMString{}
+		case reflect.Uint64:
+			arg.EVM = EVMUint{M: 64}
+		case reflect.Int64:
+			arg.EVM = EVMInt{M: 64}
+		default:
+			panic(fmt.Sprintf("no mapping for type %v", v.Kind()))
+		}
 	}
-	return padded
+
+	return arg
+}
+
+func readAbi(root, contract string, logger *logging.Logger) (string, error) {
+	p := path.Join(root, stripHex(contract))
+	if _, err := os.Stat(p); err != nil {
+		logger.TraceMsg("abifile not found", "tried", p)
+		p = path.Join(root, stripHex(contract)+".bin")
+		if _, err = os.Stat(p); err != nil {
+			logger.TraceMsg("abifile not found", "tried", p)
+			return "", fmt.Errorf("abi doesn't exist for =>\t%s", p)
+		}
+	}
+	logger.TraceMsg("Found ABI file", "path", p)
+	sol, err := compile.LoadSolidityContract(p)
+	if err != nil {
+		return "", err
+	}
+	return string(sol.Abi), nil
+}
+
+func stripHex(s string) string {
+	if len(s) > 1 {
+		if s[:2] == "0x" {
+			s = s[2:]
+			if len(s)%2 != 0 {
+				s = "0" + s
+			}
+			return s
+		}
+	}
+	return s
 }

--- a/execution/evm/abi/abi_test.go
+++ b/execution/evm/abi/abi_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	hex "github.com/tmthrgd/go-hex"
+	"github.com/tmthrgd/go-hex"
 
 	"github.com/hyperledger/burrow/logging"
 	"github.com/stretchr/testify/assert"

--- a/execution/evm/abi/event_spec.go
+++ b/execution/evm/abi/event_spec.go
@@ -1,0 +1,91 @@
+package abi
+
+import (
+	"encoding/json"
+
+	"github.com/hyperledger/burrow/crypto/sha3"
+	"github.com/tmthrgd/go-hex"
+)
+
+// Argument is a decoded function parameter, return or event field
+type Argument struct {
+	Name        string
+	EVM         EVMType
+	IsArray     bool
+	Indexed     bool
+	Hashed      bool
+	ArrayLength uint64
+}
+
+type argumentJSON struct {
+	Name       string
+	Type       string
+	Components []argumentJSON
+	Indexed    bool
+}
+
+// EventIDSize is the length of the event selector
+const EventIDSize = 32
+
+type EventSpec struct {
+	EventID   EventID
+	Inputs    []Argument
+	Name      string
+	Anonymous bool
+}
+
+func (e *EventSpec) UnmarshalJSON(data []byte) error {
+	s := new(specJSON)
+	err := json.Unmarshal(data, s)
+	if err != nil {
+		return err
+	}
+	return e.unmarshalSpec(s)
+}
+
+func (e *EventSpec) unmarshalSpec(s *specJSON) error {
+	inputs, err := readArgSpec(s.Inputs)
+	if err != nil {
+		return err
+	}
+	// Get signature before we deal with hashed types
+	sig := Signature(s.Name, inputs)
+	for i := range inputs {
+		if inputs[i].Indexed && inputs[i].EVM.Dynamic() {
+			// For Dynamic types, the hash is stored in stead
+			inputs[i].EVM = EVMBytes{M: 32}
+			inputs[i].Hashed = true
+		}
+	}
+	e.Name = s.Name
+	e.EventID = GetEventID(sig)
+	e.Inputs = inputs
+	e.Anonymous = s.Anonymous
+	return nil
+}
+
+type EventID [EventIDSize]byte
+
+func GetEventID(signature string) (id EventID) {
+	hash := sha3.NewKeccak256()
+	hash.Write([]byte(signature))
+	copy(id[:], hash.Sum(nil))
+	return
+}
+
+func (e *EventSpec) String() string {
+	str := e.Name + argsToSignature(e.Inputs, true)
+	if e.Anonymous {
+		str += " anonymous"
+	}
+
+	return str
+}
+
+func (id EventID) String() string {
+	return hex.EncodeUpperToString(id[:])
+}
+
+func (id EventID) Bytes() []byte {
+	return id[:]
+}

--- a/execution/evm/abi/function_spec.go
+++ b/execution/evm/abi/function_spec.go
@@ -1,0 +1,69 @@
+package abi
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/burrow/crypto/sha3"
+)
+
+// FunctionIDSize is the length of the function selector
+const FunctionIDSize = 4
+
+type FunctionSpec struct {
+	FunctionID FunctionID
+	Constant   bool
+	Inputs     []Argument
+	Outputs    []Argument
+}
+
+type FunctionID [FunctionIDSize]byte
+
+func GetFunctionID(signature string) (id FunctionID) {
+	hash := sha3.NewKeccak256()
+	hash.Write([]byte(signature))
+	copy(id[:], hash.Sum(nil)[:4])
+	return
+}
+
+func Signature(name string, args []Argument) string {
+	return name + argsToSignature(args, false)
+}
+
+func (f *FunctionSpec) String(name string) string {
+	return name + argsToSignature(f.Inputs, true) +
+		" returns " + argsToSignature(f.Outputs, true)
+}
+
+func (f *FunctionSpec) SetFunctionID(functionName string) {
+	sig := Signature(functionName, f.Inputs)
+	f.FunctionID = GetFunctionID(sig)
+}
+
+func (fs FunctionID) Bytes() []byte {
+	return fs[:]
+}
+
+func argsToSignature(args []Argument, addIndexedName bool) (str string) {
+	str = "("
+	for i, a := range args {
+		if i > 0 {
+			str += ","
+		}
+		str += a.EVM.GetSignature()
+		if addIndexedName && a.Indexed {
+			str += " indexed"
+		}
+		if a.IsArray {
+			if a.ArrayLength > 0 {
+				str += fmt.Sprintf("[%d]", a.ArrayLength)
+			} else {
+				str += "[]"
+			}
+		}
+		if addIndexedName && a.Name != "" {
+			str += " " + a.Name
+		}
+	}
+	str += ")"
+	return
+}

--- a/execution/evm/abi/packing.go
+++ b/execution/evm/abi/packing.go
@@ -1,0 +1,374 @@
+package abi
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/hyperledger/burrow/binary"
+)
+
+func Pack(argSpec []Argument, args ...interface{}) ([]byte, error) {
+	getArg, err := argGetter(argSpec, args, false)
+	if err != nil {
+		return nil, err
+	}
+	return pack(argSpec, getArg)
+}
+
+func Unpack(argSpec []Argument, data []byte, args ...interface{}) error {
+	getArg, err := argGetter(argSpec, args, true)
+	if err != nil {
+		return err
+	}
+	return unpack(argSpec, data, getArg)
+}
+
+func PackEvent(eventSpec *EventSpec, args ...interface{}) ([]binary.Word256, []byte, error) {
+	getArg, err := argGetter(eventSpec.Inputs, args, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	data, err := pack(eventSpec.Inputs, getArg)
+	if err != nil {
+		return nil, nil, err
+	}
+	topics, err := packTopics(eventSpec, getArg)
+	return topics, data, err
+}
+
+func UnpackEvent(eventSpec *EventSpec, topics []binary.Word256, data []byte, args ...interface{}) error {
+	getArg, err := argGetter(eventSpec.Inputs, args, true)
+	if err != nil {
+		return err
+	}
+	err = unpack(eventSpec.Inputs, data, getArg)
+	if err != nil {
+		return err
+	}
+	return unpackTopics(eventSpec, topics, getArg)
+}
+
+// UnpackRevert decodes the revert reason if a contract called revert. If no
+// reason was given, message will be nil else it will point to the string
+func UnpackRevert(data []byte) (message *string, err error) {
+	if len(data) > 0 {
+		var msg string
+		err = revertAbi.UnpackWithID(data, &msg)
+		message = &msg
+	}
+	return
+}
+
+// revertAbi exists to decode reverts. Any contract function call fail using revert(), assert() or require().
+// If a function exits this way, the this hardcoded ABI will be used.
+var revertAbi *Spec
+
+func init() {
+	var err error
+	revertAbi, err = ReadSpec([]byte(`[{"name":"Error","type":"function","outputs":[{"type":"string"}],"inputs":[{"type":"string"}]}]`))
+	if err != nil {
+		panic(fmt.Sprintf("internal error: failed to build revert abi: %v", err))
+	}
+}
+
+func argGetter(argSpec []Argument, args []interface{}, ptr bool) (func(int) interface{}, error) {
+	if len(args) == 1 {
+		rv := reflect.ValueOf(args[0])
+		if rv.Kind() == reflect.Ptr {
+			rv = rv.Elem()
+		} else if ptr {
+			return nil, fmt.Errorf("struct pointer required in order to set values, but got %v", rv.Kind())
+		}
+		if rv.Kind() != reflect.Struct {
+			if len(args) == 1 {
+				// Treat s single arg
+				return func(i int) interface{} { return args[i] }, nil
+			}
+			return nil, fmt.Errorf("expected single argument to be struct but got %v", rv.Kind())
+		}
+		fields := rv.NumField()
+		if fields != len(argSpec) {
+			return nil, fmt.Errorf("%d arguments in struct expected, %d received", len(argSpec), fields)
+		}
+		if ptr {
+			return func(i int) interface{} {
+				return rv.Field(i).Addr().Interface()
+			}, nil
+		}
+		return func(i int) interface{} {
+			return rv.Field(i).Interface()
+		}, nil
+	}
+	if len(args) == len(argSpec) {
+		return func(i int) interface{} {
+			return args[i]
+		}, nil
+	}
+	return nil, fmt.Errorf("%d arguments expected, %d received", len(argSpec), len(args))
+}
+
+func packTopics(eventSpec *EventSpec, getArg func(int) interface{}) ([]binary.Word256, error) {
+	topics := make([]binary.Word256, 0, 5)
+	if !eventSpec.Anonymous {
+		topics = append(topics, binary.Word256(eventSpec.EventID))
+	}
+	for i, a := range eventSpec.Inputs {
+		if a.Indexed {
+			data, err := a.EVM.pack(getArg(i))
+			if err != nil {
+				return nil, err
+			}
+			var topic binary.Word256
+			copy(topic[:], data)
+			topics = append(topics, topic)
+		}
+	}
+	return topics, nil
+}
+
+// Unpack event topics
+func unpackTopics(eventSpec *EventSpec, topics []binary.Word256, getArg func(int) interface{}) error {
+	// First unpack the topic fields
+	topicIndex := 0
+	if !eventSpec.Anonymous {
+		topicIndex++
+	}
+
+	for i, a := range eventSpec.Inputs {
+		if a.Indexed {
+			_, err := a.EVM.unpack(topics[topicIndex][:], 0, getArg(i))
+			if err != nil {
+				return err
+			}
+			topicIndex++
+		}
+	}
+	return nil
+}
+
+func pack(argSpec []Argument, getArg func(int) interface{}) ([]byte, error) {
+	packed := make([]byte, 0)
+	var packedDynamic []byte
+	fixedSize := 0
+	// Anything dynamic is stored after the "fixed" block. For the dynamic types, the fixed
+	// block contains byte offsets to the data. We need to know the length of the fixed
+	// block, so we can calcute the offsets
+	for _, as := range argSpec {
+		if as.Indexed {
+			continue
+		}
+		if as.IsArray {
+			if as.ArrayLength > 0 {
+				fixedSize += ElementSize * int(as.ArrayLength)
+			} else {
+				fixedSize += ElementSize
+			}
+		} else {
+			fixedSize += ElementSize
+		}
+	}
+
+	addArg := func(v interface{}, a Argument) error {
+		var b []byte
+		var err error
+		if a.EVM.Dynamic() {
+			offset := EVMUint{M: 256}
+			b, _ = offset.pack(fixedSize)
+			d, err := a.EVM.pack(v)
+			if err != nil {
+				return err
+			}
+			fixedSize += len(d)
+			packedDynamic = append(packedDynamic, d...)
+		} else {
+			b, err = a.EVM.pack(v)
+			if err != nil {
+				return err
+			}
+		}
+		packed = append(packed, b...)
+		return nil
+	}
+
+	for i, as := range argSpec {
+		if as.Indexed {
+			continue
+		}
+		a := getArg(i)
+		if as.IsArray {
+			s, ok := a.(string)
+			if ok && s[0:1] == "[" && s[len(s)-1:] == "]" {
+				a = strings.Split(s[1:len(s)-1], ",")
+			}
+
+			val := reflect.ValueOf(a)
+			if val.Kind() != reflect.Slice && val.Kind() != reflect.Array {
+				return nil, fmt.Errorf("argument %d should be array or slice, not %s", i, val.Kind().String())
+			}
+
+			if as.ArrayLength > 0 {
+				if as.ArrayLength != uint64(val.Len()) {
+					return nil, fmt.Errorf("argumment %d should be array of %d, not %d", i, as.ArrayLength, val.Len())
+				}
+
+				for n := 0; n < val.Len(); n++ {
+					err := addArg(val.Index(n).Interface(), as)
+					if err != nil {
+						return nil, err
+					}
+				}
+			} else {
+				// dynamic array
+				offset := EVMUint{M: 256}
+				b, _ := offset.pack(fixedSize)
+				packed = append(packed, b...)
+				fixedSize += len(b)
+
+				// store length
+				b, _ = offset.pack(val.Len())
+				packedDynamic = append(packedDynamic, b...)
+				for n := 0; n < val.Len(); n++ {
+					d, err := as.EVM.pack(val.Index(n).Interface())
+					if err != nil {
+						return nil, err
+					}
+					packedDynamic = append(packedDynamic, d...)
+				}
+			}
+		} else {
+			err := addArg(a, as)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return append(packed, packedDynamic...), nil
+}
+
+func unpack(argSpec []Argument, data []byte, getArg func(int) interface{}) error {
+	offset := 0
+	offType := EVMInt{M: 64}
+
+	getPrimitive := func(e interface{}, a Argument) error {
+		if a.EVM.Dynamic() {
+			var o int64
+			l, err := offType.unpack(data, offset, &o)
+			if err != nil {
+				return err
+			}
+			offset += l
+			_, err = a.EVM.unpack(data, int(o), e)
+			if err != nil {
+				return err
+			}
+		} else {
+			l, err := a.EVM.unpack(data, offset, e)
+			if err != nil {
+				return err
+			}
+			offset += l
+		}
+
+		return nil
+	}
+
+	for i, as := range argSpec {
+		if as.Indexed {
+			continue
+		}
+
+		arg := getArg(i)
+		if as.IsArray {
+			var array *[]interface{}
+
+			array, ok := arg.(*[]interface{})
+			if !ok {
+				if _, ok := arg.(*string); ok {
+					// We have been asked to return the value as a string; make intermediate
+					// array of strings; we will concatenate after
+					intermediate := make([]interface{}, as.ArrayLength)
+					for i := range intermediate {
+						intermediate[i] = new(string)
+					}
+					array = &intermediate
+				} else {
+					return fmt.Errorf("argument %d should be array, slice or string", i)
+				}
+			}
+
+			if as.ArrayLength > 0 {
+				if int(as.ArrayLength) != len(*array) {
+					return fmt.Errorf("argument %d should be array or slice of %d elements", i, as.ArrayLength)
+				}
+
+				for n := 0; n < len(*array); n++ {
+					err := getPrimitive((*array)[n], as)
+					if err != nil {
+						return err
+					}
+				}
+			} else {
+				var o int64
+				var length int64
+
+				l, err := offType.unpack(data, offset, &o)
+				if err != nil {
+					return err
+				}
+
+				offset += l
+				s, err := offType.unpack(data, int(o), &length)
+				if err != nil {
+					return err
+				}
+				o += int64(s)
+
+				intermediate := make([]interface{}, length)
+
+				if _, ok := arg.(*string); ok {
+					// We have been asked to return the value as a string; make intermediate
+					// array of strings; we will concatenate after
+					for i := range intermediate {
+						intermediate[i] = new(string)
+					}
+				} else {
+					for i := range intermediate {
+						intermediate[i] = as.EVM.getGoType()
+					}
+				}
+
+				for i := 0; i < int(length); i++ {
+					l, err = as.EVM.unpack(data, int(o), intermediate[i])
+					if err != nil {
+						return err
+					}
+					o += int64(l)
+				}
+
+				array = &intermediate
+			}
+
+			// If we were supposed to return a string, convert it back
+			if ret, ok := arg.(*string); ok {
+				s := "["
+				for i, e := range *array {
+					if i > 0 {
+						s += ","
+					}
+					s += *(e.(*string))
+				}
+				s += "]"
+				*ret = s
+			}
+		} else {
+			err := getPrimitive(arg, as)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/execution/evm/abi/packing_test.go
+++ b/execution/evm/abi/packing_test.go
@@ -1,0 +1,99 @@
+package abi
+
+import (
+	"encoding/json"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/hyperledger/burrow/execution/solidity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackEvent(t *testing.T) {
+	t.Run("simple event", func(t *testing.T) {
+		eventAbi := `{"anonymous":false,"name":"TestEvent","type":"event","inputs":[{"indexed":true,"name":"direction","type":"bytes32"},{"indexed":false,"name":"trueism","type":"bool"},{"indexed":true,"name":"newDepth","type":"int128"},{"indexed":true,"name":"hash","type":"string"}]}`
+
+		type args struct {
+			Direction string
+			Trueism   bool
+			NewDepth  int64
+			Hash      string
+		}
+		in := &args{
+			Direction: "foo",
+			Trueism:   true,
+			NewDepth:  232,
+			Hash:      "DEADBEEFCAFEBADE01234567DEADBEEF",
+		}
+		eventSpec := new(EventSpec)
+
+		err := json.Unmarshal([]byte(eventAbi), eventSpec)
+		require.NoError(t, err)
+
+		topics, data, err := PackEvent(eventSpec, in)
+		require.NoError(t, err)
+
+		out := new(args)
+		err = UnpackEvent(eventSpec, topics, data, out)
+		require.NoError(t, err)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("EventEmitter", func(t *testing.T) {
+		type args struct {
+			Direction []byte
+			Trueism   bool
+			German    string
+			NewDepth  *big.Int
+			Bignum    int8
+			Hash      string
+		}
+		spec, err := ReadSpec(solidity.Abi_EventEmitter)
+		require.NoError(t, err)
+
+		eventSpec := spec.EventsByName["ManyTypes"]
+
+		dir := make([]byte, 32)
+		copy(dir, "frogs")
+		bignum := big.NewInt(1000)
+		in := args{
+			Direction: dir,
+			Trueism:   false,
+			German:    "foo",
+			NewDepth:  bignum,
+			Bignum:    100,
+			Hash:      "ba",
+		}
+		topics, data, err := PackEvent(&eventSpec, in)
+		require.NoError(t, err)
+
+		out := new(args)
+		err = UnpackEvent(&eventSpec, topics, data, out)
+		require.NoError(t, err)
+	})
+
+}
+
+func splatPtr(v interface{}) []interface{} {
+	rv := reflect.ValueOf(v).Elem()
+
+	vals := make([]interface{}, rv.NumField())
+	for i := 0; i < rv.NumField(); i++ {
+		vals[i] = rv.Field(i).Addr().Interface()
+	}
+
+	return vals
+}
+
+func splat(v interface{}) []interface{} {
+	rv := reflect.ValueOf(v).Elem()
+
+	vals := make([]interface{}, rv.NumField())
+	for i := 0; i < rv.NumField(); i++ {
+		vals[i] = rv.Field(i).Interface()
+	}
+
+	return vals
+}

--- a/execution/evm/abi/primitives_test.go
+++ b/execution/evm/abi/primitives_test.go
@@ -1,0 +1,22 @@
+package abi
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEVMInt(t *testing.T) {
+	t.Run("pack big.Int", func(t *testing.T) {
+		e := EVMInt{256}
+		b := big.NewInt(-23423)
+		data, err := e.pack(b)
+		require.NoError(t, err)
+		bOut := new(big.Int)
+		_, err = e.unpack(data, 0, &bOut)
+		require.NoError(t, err)
+		assert.Equal(t, bOut, b)
+	})
+}

--- a/execution/evm/abi/spec.go
+++ b/execution/evm/abi/spec.go
@@ -1,0 +1,309 @@
+package abi
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hyperledger/burrow/crypto"
+)
+
+// Spec is the ABI for contract decoded.
+type Spec struct {
+	Constructor  FunctionSpec
+	Fallback     FunctionSpec
+	Functions    map[string]FunctionSpec
+	EventsByName map[string]EventSpec
+	EventsByID   map[EventID]EventSpec
+}
+
+type specJSON struct {
+	Name            string
+	Type            string
+	Inputs          []argumentJSON
+	Outputs         []argumentJSON
+	Constant        bool
+	Payable         bool
+	StateMutability string
+	Anonymous       bool
+}
+
+// ReadSpec takes an ABI and decodes it for futher use
+func ReadSpec(specBytes []byte) (*Spec, error) {
+	var specJ []specJSON
+	err := json.Unmarshal(specBytes, &specJ)
+	if err != nil {
+		// The abi spec file might a bin file, with the Abi under the Abi field in json
+		var binFile struct {
+			Abi []specJSON
+		}
+		err = json.Unmarshal(specBytes, &binFile)
+		if err != nil {
+			return nil, err
+		}
+		specJ = binFile.Abi
+	}
+
+	abiSpec := Spec{
+		EventsByName: make(map[string]EventSpec),
+		EventsByID:   make(map[EventID]EventSpec),
+		Functions:    make(map[string]FunctionSpec),
+	}
+
+	for _, s := range specJ {
+		switch s.Type {
+		case "constructor":
+			abiSpec.Constructor.Inputs, err = readArgSpec(s.Inputs)
+			if err != nil {
+				return nil, err
+			}
+		case "fallback":
+			abiSpec.Fallback.Inputs = make([]Argument, 0)
+			abiSpec.Fallback.Outputs = make([]Argument, 0)
+		case "event":
+			var ev EventSpec
+			err = ev.unmarshalSpec(&s)
+			if err != nil {
+				return nil, err
+			}
+			abiSpec.EventsByName[ev.Name] = ev
+			abiSpec.EventsByID[ev.EventID] = ev
+		case "function":
+			inputs, err := readArgSpec(s.Inputs)
+			if err != nil {
+				return nil, err
+			}
+			outputs, err := readArgSpec(s.Outputs)
+			if err != nil {
+				return nil, err
+			}
+			fs := FunctionSpec{Inputs: inputs, Outputs: outputs, Constant: s.Constant}
+			fs.SetFunctionID(s.Name)
+			abiSpec.Functions[s.Name] = fs
+		}
+	}
+
+	return &abiSpec, nil
+}
+
+// MergeSpec takes multiple Specs and merges them into once structure. Note that
+// the same function name or event name can occur in different abis, so there might be
+// some information loss.
+func MergeSpec(abiSpec []*Spec) *Spec {
+	newSpec := Spec{
+		EventsByName: make(map[string]EventSpec),
+		EventsByID:   make(map[EventID]EventSpec),
+		Functions:    make(map[string]FunctionSpec),
+	}
+
+	for _, s := range abiSpec {
+		for n, f := range s.Functions {
+			newSpec.Functions[n] = f
+		}
+
+		// Different Abis can have the Event name, but with a different signature
+		// Loop over the signatures, as these are less likely to have collisions
+		for _, e := range s.EventsByID {
+			newSpec.EventsByName[e.Name] = e
+			newSpec.EventsByID[e.EventID] = e
+		}
+	}
+
+	return &newSpec
+}
+
+func (spec *Spec) GetEventAbi(id EventID, addresses crypto.Address) (*EventSpec, error) {
+	eventSpec, ok := spec.EventsByID[id]
+	if !ok {
+		return nil, fmt.Errorf("could not find ABI for event with ID %v", id)
+	}
+	return &eventSpec, nil
+}
+
+// Pack ABI encodes a function call. The fname specifies which function should called, if
+// it doesn't exist exist the fallback function will be called. If fname is the empty
+// string, the constructor is called. The arguments must be specified in args. The count
+// must match the function being called.
+// Returns the ABI encoded function call, whether the function is constant according
+// to the ABI (which means it does not modified contract state)
+func (spec *Spec) Pack(fname string, args ...interface{}) ([]byte, *FunctionSpec, error) {
+	var funcSpec FunctionSpec
+	var argSpec []Argument
+	if fname != "" {
+		if _, ok := spec.Functions[fname]; ok {
+			funcSpec = spec.Functions[fname]
+		} else {
+			return nil, nil, fmt.Errorf("Unknown function %s", fname)
+		}
+	} else {
+		if spec.Constructor.Inputs != nil {
+			funcSpec = spec.Constructor
+		} else {
+			return nil, nil, fmt.Errorf("Contract does not have a constructor")
+		}
+	}
+
+	argSpec = funcSpec.Inputs
+
+	packed := make([]byte, 0)
+
+	if fname != "" {
+		packed = funcSpec.FunctionID[:]
+	}
+
+	packedArgs, err := Pack(argSpec, args...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return append(packed, packedArgs...), &funcSpec, nil
+}
+
+// Unpack decodes the return values from a function call
+func (spec *Spec) Unpack(data []byte, fname string, args ...interface{}) error {
+	var funcSpec FunctionSpec
+	var argSpec []Argument
+	if fname != "" {
+		if _, ok := spec.Functions[fname]; ok {
+			funcSpec = spec.Functions[fname]
+		} else {
+			funcSpec = spec.Fallback
+		}
+	} else {
+		funcSpec = spec.Constructor
+	}
+
+	argSpec = funcSpec.Outputs
+
+	if argSpec == nil {
+		return fmt.Errorf("Unknown function %s", fname)
+	}
+
+	return unpack(argSpec, data, func(i int) interface{} {
+		return args[i]
+	})
+}
+
+func (spec *Spec) UnpackWithID(data []byte, args ...interface{}) error {
+	var argSpec []Argument
+
+	var id FunctionID
+	copy(id[:], data)
+	for _, fspec := range spec.Functions {
+		if id == fspec.FunctionID {
+			argSpec = fspec.Outputs
+		}
+	}
+
+	if argSpec == nil {
+		return fmt.Errorf("Unknown function %x", id)
+	}
+
+	return unpack(argSpec, data[4:], func(i int) interface{} {
+		return args[i]
+	})
+}
+
+func readArgSpec(argsJ []argumentJSON) ([]Argument, error) {
+	args := make([]Argument, len(argsJ))
+	var err error
+
+	for i, a := range argsJ {
+		args[i].Name = a.Name
+		args[i].Indexed = a.Indexed
+
+		baseType := a.Type
+		isArray := regexp.MustCompile(`(.*)\[([0-9]+)\]`)
+		m := isArray.FindStringSubmatch(a.Type)
+		if m != nil {
+			args[i].IsArray = true
+			args[i].ArrayLength, err = strconv.ParseUint(m[2], 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			baseType = m[1]
+		} else if strings.HasSuffix(a.Type, "[]") {
+			args[i].IsArray = true
+			baseType = strings.TrimSuffix(a.Type, "[]")
+		}
+
+		isM := regexp.MustCompile("(bytes|uint|int)([0-9]+)")
+		m = isM.FindStringSubmatch(baseType)
+		if m != nil {
+			M, err := strconv.ParseUint(m[2], 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			switch m[1] {
+			case "bytes":
+				if M < 1 || M > 32 {
+					return nil, fmt.Errorf("bytes%d is not valid type", M)
+				}
+				args[i].EVM = EVMBytes{M}
+			case "uint":
+				if M < 8 || M > 256 || (M%8) != 0 {
+					return nil, fmt.Errorf("uint%d is not valid type", M)
+				}
+				args[i].EVM = EVMUint{M}
+			case "int":
+				if M < 8 || M > 256 || (M%8) != 0 {
+					return nil, fmt.Errorf("uint%d is not valid type", M)
+				}
+				args[i].EVM = EVMInt{M}
+			}
+			continue
+		}
+
+		isMxN := regexp.MustCompile("(fixed|ufixed)([0-9]+)x([0-9]+)")
+		m = isMxN.FindStringSubmatch(baseType)
+		if m != nil {
+			M, err := strconv.ParseUint(m[2], 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			N, err := strconv.ParseUint(m[3], 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			if M < 8 || M > 256 || (M%8) != 0 {
+				return nil, fmt.Errorf("%s is not valid type", baseType)
+			}
+			if N == 0 || N > 80 {
+				return nil, fmt.Errorf("%s is not valid type", baseType)
+			}
+			if m[1] == "fixed" {
+				args[i].EVM = EVMFixed{N: N, M: M, signed: true}
+			} else if m[1] == "ufixed" {
+				args[i].EVM = EVMFixed{N: N, M: M, signed: false}
+			} else {
+				panic(m[1])
+			}
+			continue
+		}
+		switch baseType {
+		case "uint":
+			args[i].EVM = EVMUint{M: 256}
+		case "int":
+			args[i].EVM = EVMInt{M: 256}
+		case "address":
+			args[i].EVM = EVMAddress{}
+		case "bool":
+			args[i].EVM = EVMBool{}
+		case "fixed":
+			args[i].EVM = EVMFixed{M: 128, N: 8, signed: true}
+		case "ufixed":
+			args[i].EVM = EVMFixed{M: 128, N: 8, signed: false}
+		case "bytes":
+			args[i].EVM = EVMBytes{M: 0}
+		case "string":
+			args[i].EVM = EVMString{}
+		default:
+			// Assume it is a type of Contract
+			args[i].EVM = EVMAddress{}
+		}
+	}
+
+	return args, nil
+}

--- a/execution/evm/snative.go
+++ b/execution/evm/snative.go
@@ -242,7 +242,7 @@ func (contract *SNativeContractDescription) Dispatch(st Interface, caller crypto
 	}
 
 	nativeArgs := reflect.New(function.Arguments).Interface()
-	err = abi.UnpackIntoStruct(function.Abi.Inputs, remainingArgs, nativeArgs)
+	err = abi.Unpack(function.Abi.Inputs, remainingArgs, nativeArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +256,7 @@ func (contract *SNativeContractDescription) Dispatch(st Interface, caller crypto
 		return nil, fmt.Errorf("state error in %v: %v", function, err)
 	}
 
-	return abi.PackIntoStruct(function.Abi.Outputs, nativeRets)
+	return abi.Pack(function.Abi.Outputs, nativeRets)
 }
 
 // We define the address of an SNative contact as the last 20 bytes of the sha3

--- a/execution/evm/snative_test.go
+++ b/execution/evm/snative_test.go
@@ -98,7 +98,7 @@ func TestSNativeContractDescription_Dispatch(t *testing.T) {
 	require.NoError(t, cache.Error())
 	retValue, err := contract.Dispatch(cache, caller.Address, bc.MustSplice(funcID[:],
 		grantee.Address.Word256(), permFlagToWord256(permission.CreateAccount)), &gas, logger)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, retValue, LeftPadBytes([]byte{1}, 32))
 }
 

--- a/execution/exec/event_test.go
+++ b/execution/exec/event_test.go
@@ -9,26 +9,11 @@ import (
 	"github.com/hyperledger/burrow/event/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	hex "github.com/tmthrgd/go-hex"
+	"github.com/tmthrgd/go-hex"
 )
 
 func TestEventTagQueries(t *testing.T) {
-	addressHex := "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
-	address, err := crypto.AddressFromHexString(addressHex)
-	require.NoError(t, err)
-	ev := &Event{
-		Header: &Header{
-			EventType: TypeLog,
-			EventID:   "foo/bar",
-			TxHash:    []byte{2, 3, 4},
-			Height:    34,
-			Index:     2,
-		},
-		Log: &LogEvent{
-			Address: address,
-			Topics:  []binary.Word256{binary.RightPadWord256([]byte("marmot"))},
-		},
-	}
+	ev := logEvent()
 
 	tev := ev.Tagged()
 
@@ -62,7 +47,7 @@ func TestEventTagQueries(t *testing.T) {
 	assert.True(t, qry.Matches(tev))
 	require.NoError(t, qry.MatchError())
 
-	qb = qb.AndEquals(event.AddressKey, addressHex)
+	qb = qb.AndEquals(event.AddressKey, ev.Log.Address)
 	qry, err = qb.Query()
 	require.NoError(t, err)
 	assert.True(t, qry.Matches(tev))
@@ -76,4 +61,39 @@ func TestEventTagQueries(t *testing.T) {
 
 	t.Logf("Query: %v", qry)
 	t.Logf("Keys: %v", tev.Keys())
+}
+
+func BenchmarkMatching(b *testing.B) {
+	b.StopTimer()
+	ev := logEvent()
+	qb := query.NewBuilder().AndEquals(event.EventTypeKey, TypeLog.String()).
+		AndContains(event.EventIDKey, "bar").
+		AndEquals(event.TxHashKey, hex.EncodeUpperToString(ev.Header.TxHash)).
+		AndGreaterThanOrEqual(event.HeightKey, ev.Header.Height).
+		AndStrictlyLessThan(event.IndexKey, ev.Header.Index+1).
+		AndEquals(event.AddressKey, ev.Log.Address).
+		AndEquals(LogNTextKey(0), "marmot")
+	qry, err := qb.Query()
+	require.NoError(b, err)
+	tev := ev.Tagged()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		qry.Matches(tev)
+	}
+}
+
+func logEvent() *Event {
+	return &Event{
+		Header: &Header{
+			EventType: TypeLog,
+			EventID:   "foo/bar",
+			TxHash:    []byte{2, 3, 4},
+			Height:    34,
+			Index:     2,
+		},
+		Log: &LogEvent{
+			Address: crypto.MustAddressFromHexString("DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"),
+			Topics:  []binary.Word256{binary.RightPadWord256([]byte("marmot"))},
+		},
+	}
 }

--- a/execution/exec/exec.pb.go
+++ b/execution/exec/exec.pb.go
@@ -5,6 +5,11 @@ package exec
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+	time "time"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
@@ -20,9 +25,6 @@ import (
 	txs "github.com/hyperledger/burrow/txs"
 	github_com_hyperledger_burrow_txs_payload "github.com/hyperledger/burrow/txs/payload"
 	types "github.com/tendermint/tendermint/abci/types"
-	io "io"
-	math "math"
-	time "time"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1464,9 +1466,9 @@ func (m *StreamEvent) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.BeginBlock.Size()))
-		n1, err := m.BeginBlock.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n1, err1 := m.BeginBlock.MarshalTo(dAtA[i:])
+		if err1 != nil {
+			return 0, err1
 		}
 		i += n1
 	}
@@ -1474,9 +1476,9 @@ func (m *StreamEvent) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.BeginTx.Size()))
-		n2, err := m.BeginTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n2, err2 := m.BeginTx.MarshalTo(dAtA[i:])
+		if err2 != nil {
+			return 0, err2
 		}
 		i += n2
 	}
@@ -1484,9 +1486,9 @@ func (m *StreamEvent) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Envelope.Size()))
-		n3, err := m.Envelope.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n3, err3 := m.Envelope.MarshalTo(dAtA[i:])
+		if err3 != nil {
+			return 0, err3
 		}
 		i += n3
 	}
@@ -1494,9 +1496,9 @@ func (m *StreamEvent) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x22
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Event.Size()))
-		n4, err := m.Event.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n4, err4 := m.Event.MarshalTo(dAtA[i:])
+		if err4 != nil {
+			return 0, err4
 		}
 		i += n4
 	}
@@ -1504,9 +1506,9 @@ func (m *StreamEvent) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2a
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.EndTx.Size()))
-		n5, err := m.EndTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n5, err5 := m.EndTx.MarshalTo(dAtA[i:])
+		if err5 != nil {
+			return 0, err5
 		}
 		i += n5
 	}
@@ -1514,9 +1516,9 @@ func (m *StreamEvent) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x32
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.EndBlock.Size()))
-		n6, err := m.EndBlock.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n6, err6 := m.EndBlock.MarshalTo(dAtA[i:])
+		if err6 != nil {
+			return 0, err6
 		}
 		i += n6
 	}
@@ -1550,9 +1552,9 @@ func (m *BeginBlock) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Header.Size()))
-		n7, err := m.Header.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n7, err7 := m.Header.MarshalTo(dAtA[i:])
+		if err7 != nil {
+			return 0, err7
 		}
 		i += n7
 	}
@@ -1607,9 +1609,9 @@ func (m *BeginTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.TxHeader.Size()))
-		n8, err := m.TxHeader.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n8, err8 := m.TxHeader.MarshalTo(dAtA[i:])
+		if err8 != nil {
+			return 0, err8
 		}
 		i += n8
 	}
@@ -1617,9 +1619,9 @@ func (m *BeginTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Result.Size()))
-		n9, err := m.Result.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n9, err9 := m.Result.MarshalTo(dAtA[i:])
+		if err9 != nil {
+			return 0, err9
 		}
 		i += n9
 	}
@@ -1627,9 +1629,9 @@ func (m *BeginTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x22
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Exception.Size()))
-		n10, err := m.Exception.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n10, err10 := m.Exception.MarshalTo(dAtA[i:])
+		if err10 != nil {
+			return 0, err10
 		}
 		i += n10
 	}
@@ -1657,9 +1659,9 @@ func (m *EndTx) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(m.TxHash.Size()))
-	n11, err := m.TxHash.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n11, err11 := m.TxHash.MarshalTo(dAtA[i:])
+	if err11 != nil {
+		return 0, err11
 	}
 	i += n11
 	if m.XXX_unrecognized != nil {
@@ -1691,9 +1693,9 @@ func (m *TxHeader) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(m.TxHash.Size()))
-	n12, err := m.TxHash.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n12, err12 := m.TxHash.MarshalTo(dAtA[i:])
+	if err12 != nil {
+		return 0, err12
 	}
 	i += n12
 	if m.Height != 0 {
@@ -1710,9 +1712,9 @@ func (m *TxHeader) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2a
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Origin.Size()))
-		n13, err := m.Origin.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n13, err13 := m.Origin.MarshalTo(dAtA[i:])
+		if err13 != nil {
+			return 0, err13
 		}
 		i += n13
 	}
@@ -1746,9 +1748,9 @@ func (m *BlockExecution) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Header.Size()))
-		n14, err := m.Header.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n14, err14 := m.Header.MarshalTo(dAtA[i:])
+		if err14 != nil {
+			return 0, err14
 		}
 		i += n14
 	}
@@ -1820,9 +1822,9 @@ func (m *TxExecution) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.TxHeader.Size()))
-		n15, err := m.TxHeader.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n15, err15 := m.TxHeader.MarshalTo(dAtA[i:])
+		if err15 != nil {
+			return 0, err15
 		}
 		i += n15
 	}
@@ -1830,9 +1832,9 @@ func (m *TxExecution) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x32
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Envelope.Size()))
-		n16, err := m.Envelope.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n16, err16 := m.Envelope.MarshalTo(dAtA[i:])
+		if err16 != nil {
+			return 0, err16
 		}
 		i += n16
 	}
@@ -1852,9 +1854,9 @@ func (m *TxExecution) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x42
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Result.Size()))
-		n17, err := m.Result.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n17, err17 := m.Result.MarshalTo(dAtA[i:])
+		if err17 != nil {
+			return 0, err17
 		}
 		i += n17
 	}
@@ -1862,9 +1864,9 @@ func (m *TxExecution) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x4a
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Receipt.Size()))
-		n18, err := m.Receipt.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n18, err18 := m.Receipt.MarshalTo(dAtA[i:])
+		if err18 != nil {
+			return 0, err18
 		}
 		i += n18
 	}
@@ -1872,9 +1874,9 @@ func (m *TxExecution) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x52
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Exception.Size()))
-		n19, err := m.Exception.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n19, err19 := m.Exception.MarshalTo(dAtA[i:])
+		if err19 != nil {
+			return 0, err19
 		}
 		i += n19
 	}
@@ -1930,9 +1932,9 @@ func (m *Origin) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Time)))
-	n20, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Time, dAtA[i:])
-	if err != nil {
-		return 0, err
+	n20, err20 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Time, dAtA[i:])
+	if err20 != nil {
+		return 0, err20
 	}
 	i += n20
 	if m.XXX_unrecognized != nil {
@@ -1964,9 +1966,9 @@ func (m *Header) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(m.TxHash.Size()))
-	n21, err := m.TxHash.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n21, err21 := m.TxHash.MarshalTo(dAtA[i:])
+	if err21 != nil {
+		return 0, err21
 	}
 	i += n21
 	if m.EventType != 0 {
@@ -1994,9 +1996,9 @@ func (m *Header) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x3a
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Exception.Size()))
-		n22, err := m.Exception.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n22, err22 := m.Exception.MarshalTo(dAtA[i:])
+		if err22 != nil {
+			return 0, err22
 		}
 		i += n22
 	}
@@ -2025,9 +2027,9 @@ func (m *Event) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Header.Size()))
-		n23, err := m.Header.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n23, err23 := m.Header.MarshalTo(dAtA[i:])
+		if err23 != nil {
+			return 0, err23
 		}
 		i += n23
 	}
@@ -2035,9 +2037,9 @@ func (m *Event) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Input.Size()))
-		n24, err := m.Input.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n24, err24 := m.Input.MarshalTo(dAtA[i:])
+		if err24 != nil {
+			return 0, err24
 		}
 		i += n24
 	}
@@ -2045,9 +2047,9 @@ func (m *Event) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Output.Size()))
-		n25, err := m.Output.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n25, err25 := m.Output.MarshalTo(dAtA[i:])
+		if err25 != nil {
+			return 0, err25
 		}
 		i += n25
 	}
@@ -2055,9 +2057,9 @@ func (m *Event) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x22
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Call.Size()))
-		n26, err := m.Call.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n26, err26 := m.Call.MarshalTo(dAtA[i:])
+		if err26 != nil {
+			return 0, err26
 		}
 		i += n26
 	}
@@ -2065,9 +2067,9 @@ func (m *Event) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2a
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.Log.Size()))
-		n27, err := m.Log.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n27, err27 := m.Log.MarshalTo(dAtA[i:])
+		if err27 != nil {
+			return 0, err27
 		}
 		i += n27
 	}
@@ -2075,9 +2077,9 @@ func (m *Event) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x32
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.GovernAccount.Size()))
-		n28, err := m.GovernAccount.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n28, err28 := m.GovernAccount.MarshalTo(dAtA[i:])
+		if err28 != nil {
+			return 0, err28
 		}
 		i += n28
 	}
@@ -2117,9 +2119,9 @@ func (m *Result) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.NameEntry.Size()))
-		n29, err := m.NameEntry.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n29, err29 := m.NameEntry.MarshalTo(dAtA[i:])
+		if err29 != nil {
+			return 0, err29
 		}
 		i += n29
 	}
@@ -2127,9 +2129,9 @@ func (m *Result) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x22
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.PermArgs.Size()))
-		n30, err := m.PermArgs.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n30, err30 := m.PermArgs.MarshalTo(dAtA[i:])
+		if err30 != nil {
+			return 0, err30
 		}
 		i += n30
 	}
@@ -2157,17 +2159,17 @@ func (m *LogEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(m.Address.Size()))
-	n31, err := m.Address.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n31, err31 := m.Address.MarshalTo(dAtA[i:])
+	if err31 != nil {
+		return 0, err31
 	}
 	i += n31
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(m.Data.Size()))
-	n32, err := m.Data.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n32, err32 := m.Data.MarshalTo(dAtA[i:])
+	if err32 != nil {
+		return 0, err32
 	}
 	i += n32
 	if len(m.Topics) > 0 {
@@ -2207,18 +2209,18 @@ func (m *CallEvent) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.CallData.Size()))
-		n33, err := m.CallData.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n33, err33 := m.CallData.MarshalTo(dAtA[i:])
+		if err33 != nil {
+			return 0, err33
 		}
 		i += n33
 	}
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(m.Origin.Size()))
-	n34, err := m.Origin.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n34, err34 := m.Origin.MarshalTo(dAtA[i:])
+	if err34 != nil {
+		return 0, err34
 	}
 	i += n34
 	if m.StackDepth != 0 {
@@ -2229,9 +2231,9 @@ func (m *CallEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(m.Return.Size()))
-	n35, err := m.Return.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n35, err35 := m.Return.MarshalTo(dAtA[i:])
+	if err35 != nil {
+		return 0, err35
 	}
 	i += n35
 	if m.CallType != 0 {
@@ -2264,9 +2266,9 @@ func (m *GovernAccountEvent) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintExec(dAtA, i, uint64(m.AccountUpdate.Size()))
-		n36, err := m.AccountUpdate.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n36, err36 := m.AccountUpdate.MarshalTo(dAtA[i:])
+		if err36 != nil {
+			return 0, err36
 		}
 		i += n36
 	}
@@ -2294,9 +2296,9 @@ func (m *InputEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(m.Address.Size()))
-	n37, err := m.Address.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n37, err37 := m.Address.MarshalTo(dAtA[i:])
+	if err37 != nil {
+		return 0, err37
 	}
 	i += n37
 	if m.XXX_unrecognized != nil {
@@ -2323,9 +2325,9 @@ func (m *OutputEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(m.Address.Size()))
-	n38, err := m.Address.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n38, err38 := m.Address.MarshalTo(dAtA[i:])
+	if err38 != nil {
+		return 0, err38
 	}
 	i += n38
 	if m.XXX_unrecognized != nil {
@@ -2352,25 +2354,25 @@ func (m *CallData) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(m.Caller.Size()))
-	n39, err := m.Caller.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n39, err39 := m.Caller.MarshalTo(dAtA[i:])
+	if err39 != nil {
+		return 0, err39
 	}
 	i += n39
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(m.Callee.Size()))
-	n40, err := m.Callee.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n40, err40 := m.Callee.MarshalTo(dAtA[i:])
+	if err40 != nil {
+		return 0, err40
 	}
 	i += n40
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintExec(dAtA, i, uint64(m.Data.Size()))
-	n41, err := m.Data.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n41, err41 := m.Data.MarshalTo(dAtA[i:])
+	if err41 != nil {
+		return 0, err41
 	}
 	i += n41
 	if m.Value != 0 {
@@ -2876,14 +2878,7 @@ func (m *CallData) Size() (n int) {
 }
 
 func sovExec(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozExec(x uint64) (n int) {
 	return sovExec(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/execution/names/names.pb.go
+++ b/execution/names/names.pb.go
@@ -5,12 +5,14 @@ package names
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
 	github_com_hyperledger_burrow_crypto "github.com/hyperledger/burrow/crypto"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -145,9 +147,9 @@ func (m *Entry) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintNames(dAtA, i, uint64(m.Owner.Size()))
-	n1, err := m.Owner.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n1, err1 := m.Owner.MarshalTo(dAtA[i:])
+	if err1 != nil {
+		return 0, err1
 	}
 	i += n1
 	if len(m.Data) > 0 {
@@ -202,14 +204,7 @@ func (m *Entry) Size() (n int) {
 }
 
 func sovNames(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozNames(x uint64) (n int) {
 	return sovNames(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/genesis/spec/spec.pb.go
+++ b/genesis/spec/spec.pb.go
@@ -5,6 +5,10 @@ package spec
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
@@ -12,8 +16,6 @@ import (
 	balance "github.com/hyperledger/burrow/acm/balance"
 	crypto "github.com/hyperledger/burrow/crypto"
 	github_com_hyperledger_burrow_crypto "github.com/hyperledger/burrow/crypto"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -169,9 +171,9 @@ func (m *TemplateAccount) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintSpec(dAtA, i, uint64(m.Address.Size()))
-		n1, err := m.Address.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n1, err1 := m.Address.MarshalTo(dAtA[i:])
+		if err1 != nil {
+			return 0, err1
 		}
 		i += n1
 	}
@@ -179,9 +181,9 @@ func (m *TemplateAccount) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintSpec(dAtA, i, uint64(m.PublicKey.Size()))
-		n2, err := m.PublicKey.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n2, err2 := m.PublicKey.MarshalTo(dAtA[i:])
+		if err2 != nil {
+			return 0, err2
 		}
 		i += n2
 	}
@@ -231,9 +233,9 @@ func (m *TemplateAccount) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x3a
 		i++
 		i = encodeVarintSpec(dAtA, i, uint64(m.Code.Size()))
-		n3, err := m.Code.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n3, err3 := m.Code.MarshalTo(dAtA[i:])
+		if err3 != nil {
+			return 0, err3
 		}
 		i += n3
 	}
@@ -299,14 +301,7 @@ func (m *TemplateAccount) Size() (n int) {
 }
 
 func sovSpec(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozSpec(x uint64) (n int) {
 	return sovSpec(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/keys/keys.pb.go
+++ b/keys/keys.pb.go
@@ -6,12 +6,16 @@ package keys
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
 	crypto "github.com/hyperledger/burrow/crypto"
 	grpc "google.golang.org/grpc"
-	math "math"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1342,6 +1346,44 @@ type KeysServer interface {
 	AddName(context.Context, *AddNameRequest) (*AddNameResponse, error)
 }
 
+// UnimplementedKeysServer can be embedded to have forward compatible implementations.
+type UnimplementedKeysServer struct {
+}
+
+func (*UnimplementedKeysServer) GenerateKey(ctx context.Context, req *GenRequest) (*GenResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GenerateKey not implemented")
+}
+func (*UnimplementedKeysServer) PublicKey(ctx context.Context, req *PubRequest) (*PubResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PublicKey not implemented")
+}
+func (*UnimplementedKeysServer) Sign(ctx context.Context, req *SignRequest) (*SignResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Sign not implemented")
+}
+func (*UnimplementedKeysServer) Verify(ctx context.Context, req *VerifyRequest) (*VerifyResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Verify not implemented")
+}
+func (*UnimplementedKeysServer) Import(ctx context.Context, req *ImportRequest) (*ImportResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Import not implemented")
+}
+func (*UnimplementedKeysServer) ImportJSON(ctx context.Context, req *ImportJSONRequest) (*ImportResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ImportJSON not implemented")
+}
+func (*UnimplementedKeysServer) Export(ctx context.Context, req *ExportRequest) (*ExportResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Export not implemented")
+}
+func (*UnimplementedKeysServer) Hash(ctx context.Context, req *HashRequest) (*HashResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Hash not implemented")
+}
+func (*UnimplementedKeysServer) RemoveName(ctx context.Context, req *RemoveNameRequest) (*RemoveNameResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RemoveName not implemented")
+}
+func (*UnimplementedKeysServer) List(ctx context.Context, req *ListRequest) (*ListResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method List not implemented")
+}
+func (*UnimplementedKeysServer) AddName(ctx context.Context, req *AddNameRequest) (*AddNameResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddName not implemented")
+}
+
 func RegisterKeysServer(s *grpc.Server, srv KeysServer) {
 	s.RegisterService(&_Keys_serviceDesc, srv)
 }
@@ -2026,14 +2068,7 @@ func (m *AddNameRequest) Size() (n int) {
 }
 
 func sovKeys(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozKeys(x uint64) (n int) {
 	return sovKeys(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/permission/permission.pb.go
+++ b/permission/permission.pb.go
@@ -5,12 +5,14 @@ package permission
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
 	github_com_hyperledger_burrow_crypto "github.com/hyperledger/burrow/crypto"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -271,9 +273,9 @@ func (m *AccountPermissions) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintPermission(dAtA, i, uint64(m.Base.Size()))
-	n1, err := m.Base.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n1, err1 := m.Base.MarshalTo(dAtA[i:])
+	if err1 != nil {
+		return 0, err1
 	}
 	i += n1
 	if len(m.Roles) > 0 {
@@ -346,9 +348,9 @@ func (m *PermArgs) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintPermission(dAtA, i, uint64(m.Target.Size()))
-		n2, err := m.Target.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n2, err2 := m.Target.MarshalTo(dAtA[i:])
+		if err2 != nil {
+			return 0, err2
 		}
 		i += n2
 	}
@@ -444,14 +446,7 @@ func (m *PermArgs) Size() (n int) {
 }
 
 func sovPermission(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozPermission(x uint64) (n int) {
 	return sovPermission(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/rpc/rpc.pb.go
+++ b/rpc/rpc.pb.go
@@ -5,6 +5,9 @@ package rpc
 
 import (
 	fmt "fmt"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
@@ -12,7 +15,6 @@ import (
 	bcm "github.com/hyperledger/burrow/bcm"
 	github_com_hyperledger_burrow_binary "github.com/hyperledger/burrow/binary"
 	tendermint "github.com/hyperledger/burrow/consensus/tendermint"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -195,14 +197,7 @@ func (m *ResultStatus) Size() (n int) {
 }
 
 func sovRpc(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozRpc(x uint64) (n int) {
 	return sovRpc(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/rpc/rpcdump/rpcdump.pb.go
+++ b/rpc/rpcdump/rpcdump.pb.go
@@ -6,12 +6,16 @@ package rpcdump
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
 	dump "github.com/hyperledger/burrow/dump"
 	grpc "google.golang.org/grpc"
-	math "math"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -152,6 +156,14 @@ type DumpServer interface {
 	GetDump(*GetDumpParam, Dump_GetDumpServer) error
 }
 
+// UnimplementedDumpServer can be embedded to have forward compatible implementations.
+type UnimplementedDumpServer struct {
+}
+
+func (*UnimplementedDumpServer) GetDump(req *GetDumpParam, srv Dump_GetDumpServer) error {
+	return status.Errorf(codes.Unimplemented, "method GetDump not implemented")
+}
+
 func RegisterDumpServer(s *grpc.Server, srv DumpServer) {
 	s.RegisterService(&_Dump_serviceDesc, srv)
 }
@@ -207,14 +219,7 @@ func (m *GetDumpParam) Size() (n int) {
 }
 
 func sovRpcdump(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozRpcdump(x uint64) (n int) {
 	return sovRpcdump(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/rpc/rpcevents/rpcevents.pb.go
+++ b/rpc/rpcevents/rpcevents.pb.go
@@ -6,14 +6,18 @@ package rpcevents
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
 	github_com_hyperledger_burrow_binary "github.com/hyperledger/burrow/binary"
 	exec "github.com/hyperledger/burrow/execution/exec"
 	grpc "google.golang.org/grpc"
-	io "io"
-	math "math"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -762,6 +766,20 @@ type ExecutionEventsServer interface {
 	Events(*BlocksRequest, ExecutionEvents_EventsServer) error
 }
 
+// UnimplementedExecutionEventsServer can be embedded to have forward compatible implementations.
+type UnimplementedExecutionEventsServer struct {
+}
+
+func (*UnimplementedExecutionEventsServer) Stream(req *BlocksRequest, srv ExecutionEvents_StreamServer) error {
+	return status.Errorf(codes.Unimplemented, "method Stream not implemented")
+}
+func (*UnimplementedExecutionEventsServer) Tx(ctx context.Context, req *TxRequest) (*exec.TxExecution, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Tx not implemented")
+}
+func (*UnimplementedExecutionEventsServer) Events(req *BlocksRequest, srv ExecutionEvents_EventsServer) error {
+	return status.Errorf(codes.Unimplemented, "method Events not implemented")
+}
+
 func RegisterExecutionEventsServer(s *grpc.Server, srv ExecutionEventsServer) {
 	s.RegisterService(&_ExecutionEvents_serviceDesc, srv)
 }
@@ -904,9 +922,9 @@ func (m *TxRequest) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintRpcevents(dAtA, i, uint64(m.TxHash.Size()))
-	n1, err := m.TxHash.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n1, err1 := m.TxHash.MarshalTo(dAtA[i:])
+	if err1 != nil {
+		return 0, err1
 	}
 	i += n1
 	if m.Wait {
@@ -944,9 +962,9 @@ func (m *BlocksRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintRpcevents(dAtA, i, uint64(m.BlockRange.Size()))
-		n2, err := m.BlockRange.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n2, err2 := m.BlockRange.MarshalTo(dAtA[i:])
+		if err2 != nil {
+			return 0, err2
 		}
 		i += n2
 	}
@@ -1125,9 +1143,9 @@ func (m *BlockRange) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintRpcevents(dAtA, i, uint64(m.Start.Size()))
-		n3, err := m.Start.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n3, err3 := m.Start.MarshalTo(dAtA[i:])
+		if err3 != nil {
+			return 0, err3
 		}
 		i += n3
 	}
@@ -1135,9 +1153,9 @@ func (m *BlockRange) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintRpcevents(dAtA, i, uint64(m.End.Size()))
-		n4, err := m.End.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n4, err4 := m.End.MarshalTo(dAtA[i:])
+		if err4 != nil {
+			return 0, err4
 		}
 		i += n4
 	}
@@ -1314,14 +1332,7 @@ func (m *BlockRange) Size() (n int) {
 }
 
 func sovRpcevents(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozRpcevents(x uint64) (n int) {
 	return sovRpcevents(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/rpc/rpcquery/rpcquery.pb.go
+++ b/rpc/rpcquery/rpcquery.pb.go
@@ -6,6 +6,9 @@ package rpcquery
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
@@ -18,7 +21,8 @@ import (
 	payload "github.com/hyperledger/burrow/txs/payload"
 	types "github.com/tendermint/tendermint/abci/types"
 	grpc "google.golang.org/grpc"
-	math "math"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1167,6 +1171,50 @@ type QueryServer interface {
 	GetBlockHeader(context.Context, *GetBlockParam) (*types.Header, error)
 }
 
+// UnimplementedQueryServer can be embedded to have forward compatible implementations.
+type UnimplementedQueryServer struct {
+}
+
+func (*UnimplementedQueryServer) Status(ctx context.Context, req *StatusParam) (*rpc.ResultStatus, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Status not implemented")
+}
+func (*UnimplementedQueryServer) GetAccount(ctx context.Context, req *GetAccountParam) (*acm.Account, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetAccount not implemented")
+}
+func (*UnimplementedQueryServer) GetMetadata(ctx context.Context, req *GetMetadataParam) (*MetadataResult, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetMetadata not implemented")
+}
+func (*UnimplementedQueryServer) GetStorage(ctx context.Context, req *GetStorageParam) (*StorageValue, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetStorage not implemented")
+}
+func (*UnimplementedQueryServer) ListAccounts(req *ListAccountsParam, srv Query_ListAccountsServer) error {
+	return status.Errorf(codes.Unimplemented, "method ListAccounts not implemented")
+}
+func (*UnimplementedQueryServer) GetName(ctx context.Context, req *GetNameParam) (*names.Entry, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetName not implemented")
+}
+func (*UnimplementedQueryServer) ListNames(req *ListNamesParam, srv Query_ListNamesServer) error {
+	return status.Errorf(codes.Unimplemented, "method ListNames not implemented")
+}
+func (*UnimplementedQueryServer) GetValidatorSet(ctx context.Context, req *GetValidatorSetParam) (*ValidatorSet, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetValidatorSet not implemented")
+}
+func (*UnimplementedQueryServer) GetValidatorSetHistory(ctx context.Context, req *GetValidatorSetHistoryParam) (*ValidatorSetHistory, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetValidatorSetHistory not implemented")
+}
+func (*UnimplementedQueryServer) GetProposal(ctx context.Context, req *GetProposalParam) (*payload.Ballot, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetProposal not implemented")
+}
+func (*UnimplementedQueryServer) ListProposals(req *ListProposalsParam, srv Query_ListProposalsServer) error {
+	return status.Errorf(codes.Unimplemented, "method ListProposals not implemented")
+}
+func (*UnimplementedQueryServer) GetStats(ctx context.Context, req *GetStatsParam) (*Stats, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetStats not implemented")
+}
+func (*UnimplementedQueryServer) GetBlockHeader(ctx context.Context, req *GetBlockParam) (*types.Header, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetBlockHeader not implemented")
+}
+
 func RegisterQueryServer(s *grpc.Server, srv QueryServer) {
 	s.RegisterService(&_Query_serviceDesc, srv)
 }
@@ -1790,14 +1838,7 @@ func (m *GetBlockParam) Size() (n int) {
 }
 
 func sovRpcquery(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozRpcquery(x uint64) (n int) {
 	return sovRpcquery(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/rpc/rpctransact/rpctransact.pb.go
+++ b/rpc/rpctransact/rpctransact.pb.go
@@ -6,6 +6,11 @@ package rpctransact
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+	time "time"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
@@ -17,9 +22,8 @@ import (
 	txs "github.com/hyperledger/burrow/txs"
 	payload "github.com/hyperledger/burrow/txs/payload"
 	grpc "google.golang.org/grpc"
-	io "io"
-	math "math"
-	time "time"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -440,6 +444,47 @@ type TransactServer interface {
 	NameTxAsync(context.Context, *payload.NameTx) (*txs.Receipt, error)
 }
 
+// UnimplementedTransactServer can be embedded to have forward compatible implementations.
+type UnimplementedTransactServer struct {
+}
+
+func (*UnimplementedTransactServer) BroadcastTxSync(ctx context.Context, req *TxEnvelopeParam) (*exec.TxExecution, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BroadcastTxSync not implemented")
+}
+func (*UnimplementedTransactServer) BroadcastTxAsync(ctx context.Context, req *TxEnvelopeParam) (*txs.Receipt, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BroadcastTxAsync not implemented")
+}
+func (*UnimplementedTransactServer) SignTx(ctx context.Context, req *TxEnvelopeParam) (*TxEnvelope, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SignTx not implemented")
+}
+func (*UnimplementedTransactServer) FormulateTx(ctx context.Context, req *payload.Any) (*TxEnvelope, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method FormulateTx not implemented")
+}
+func (*UnimplementedTransactServer) CallTxSync(ctx context.Context, req *payload.CallTx) (*exec.TxExecution, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CallTxSync not implemented")
+}
+func (*UnimplementedTransactServer) CallTxAsync(ctx context.Context, req *payload.CallTx) (*txs.Receipt, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CallTxAsync not implemented")
+}
+func (*UnimplementedTransactServer) CallTxSim(ctx context.Context, req *payload.CallTx) (*exec.TxExecution, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CallTxSim not implemented")
+}
+func (*UnimplementedTransactServer) CallCodeSim(ctx context.Context, req *CallCodeParam) (*exec.TxExecution, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CallCodeSim not implemented")
+}
+func (*UnimplementedTransactServer) SendTxSync(ctx context.Context, req *payload.SendTx) (*exec.TxExecution, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SendTxSync not implemented")
+}
+func (*UnimplementedTransactServer) SendTxAsync(ctx context.Context, req *payload.SendTx) (*txs.Receipt, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SendTxAsync not implemented")
+}
+func (*UnimplementedTransactServer) NameTxSync(ctx context.Context, req *payload.NameTx) (*exec.TxExecution, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method NameTxSync not implemented")
+}
+func (*UnimplementedTransactServer) NameTxAsync(ctx context.Context, req *payload.NameTx) (*txs.Receipt, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method NameTxAsync not implemented")
+}
+
 func RegisterTransactServer(s *grpc.Server, srv TransactServer) {
 	s.RegisterService(&_Transact_serviceDesc, srv)
 }
@@ -735,9 +780,9 @@ func (m *CallCodeParam) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintRpctransact(dAtA, i, uint64(m.FromAddress.Size()))
-	n1, err := m.FromAddress.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n1, err1 := m.FromAddress.MarshalTo(dAtA[i:])
+	if err1 != nil {
+		return 0, err1
 	}
 	i += n1
 	if len(m.Code) > 0 {
@@ -777,9 +822,9 @@ func (m *TxEnvelope) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintRpctransact(dAtA, i, uint64(m.Envelope.Size()))
-		n2, err := m.Envelope.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n2, err2 := m.Envelope.MarshalTo(dAtA[i:])
+		if err2 != nil {
+			return 0, err2
 		}
 		i += n2
 	}
@@ -808,9 +853,9 @@ func (m *TxEnvelopeParam) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintRpctransact(dAtA, i, uint64(m.Envelope.Size()))
-		n3, err := m.Envelope.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n3, err3 := m.Envelope.MarshalTo(dAtA[i:])
+		if err3 != nil {
+			return 0, err3
 		}
 		i += n3
 	}
@@ -818,18 +863,18 @@ func (m *TxEnvelopeParam) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintRpctransact(dAtA, i, uint64(m.Payload.Size()))
-		n4, err := m.Payload.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n4, err4 := m.Payload.MarshalTo(dAtA[i:])
+		if err4 != nil {
+			return 0, err4
 		}
 		i += n4
 	}
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintRpctransact(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.Timeout)))
-	n5, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Timeout, dAtA[i:])
-	if err != nil {
-		return 0, err
+	n5, err5 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Timeout, dAtA[i:])
+	if err5 != nil {
+		return 0, err5
 	}
 	i += n5
 	if m.XXX_unrecognized != nil {
@@ -908,14 +953,7 @@ func (m *TxEnvelopeParam) Size() (n int) {
 }
 
 func sovRpctransact(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozRpctransact(x uint64) (n int) {
 	return sovRpctransact(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/storage/storage.pb.go
+++ b/storage/storage.pb.go
@@ -5,11 +5,13 @@ package storage
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -164,14 +166,7 @@ func (m *CommitID) Size() (n int) {
 }
 
 func sovStorage(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozStorage(x uint64) (n int) {
 	return sovStorage(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/txs/payload/payload.pb.go
+++ b/txs/payload/payload.pb.go
@@ -5,6 +5,10 @@ package payload
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
@@ -12,8 +16,6 @@ import (
 	github_com_hyperledger_burrow_crypto "github.com/hyperledger/burrow/crypto"
 	spec "github.com/hyperledger/burrow/genesis/spec"
 	permission "github.com/hyperledger/burrow/permission"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1121,9 +1123,9 @@ func (m *Any) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.CallTx.Size()))
-		n1, err := m.CallTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n1, err1 := m.CallTx.MarshalTo(dAtA[i:])
+		if err1 != nil {
+			return 0, err1
 		}
 		i += n1
 	}
@@ -1131,9 +1133,9 @@ func (m *Any) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.SendTx.Size()))
-		n2, err := m.SendTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n2, err2 := m.SendTx.MarshalTo(dAtA[i:])
+		if err2 != nil {
+			return 0, err2
 		}
 		i += n2
 	}
@@ -1141,9 +1143,9 @@ func (m *Any) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.NameTx.Size()))
-		n3, err := m.NameTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n3, err3 := m.NameTx.MarshalTo(dAtA[i:])
+		if err3 != nil {
+			return 0, err3
 		}
 		i += n3
 	}
@@ -1151,9 +1153,9 @@ func (m *Any) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x22
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.PermsTx.Size()))
-		n4, err := m.PermsTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n4, err4 := m.PermsTx.MarshalTo(dAtA[i:])
+		if err4 != nil {
+			return 0, err4
 		}
 		i += n4
 	}
@@ -1161,9 +1163,9 @@ func (m *Any) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2a
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.GovTx.Size()))
-		n5, err := m.GovTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n5, err5 := m.GovTx.MarshalTo(dAtA[i:])
+		if err5 != nil {
+			return 0, err5
 		}
 		i += n5
 	}
@@ -1171,9 +1173,9 @@ func (m *Any) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x32
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.BondTx.Size()))
-		n6, err := m.BondTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n6, err6 := m.BondTx.MarshalTo(dAtA[i:])
+		if err6 != nil {
+			return 0, err6
 		}
 		i += n6
 	}
@@ -1181,9 +1183,9 @@ func (m *Any) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x3a
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.UnbondTx.Size()))
-		n7, err := m.UnbondTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n7, err7 := m.UnbondTx.MarshalTo(dAtA[i:])
+		if err7 != nil {
+			return 0, err7
 		}
 		i += n7
 	}
@@ -1191,9 +1193,9 @@ func (m *Any) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x42
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.BatchTx.Size()))
-		n8, err := m.BatchTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n8, err8 := m.BatchTx.MarshalTo(dAtA[i:])
+		if err8 != nil {
+			return 0, err8
 		}
 		i += n8
 	}
@@ -1201,9 +1203,9 @@ func (m *Any) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x4a
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.ProposalTx.Size()))
-		n9, err := m.ProposalTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n9, err9 := m.ProposalTx.MarshalTo(dAtA[i:])
+		if err9 != nil {
+			return 0, err9
 		}
 		i += n9
 	}
@@ -1231,9 +1233,9 @@ func (m *TxInput) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintPayload(dAtA, i, uint64(m.Address.Size()))
-	n10, err := m.Address.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n10, err10 := m.Address.MarshalTo(dAtA[i:])
+	if err10 != nil {
+		return 0, err10
 	}
 	i += n10
 	if m.Amount != 0 {
@@ -1270,9 +1272,9 @@ func (m *TxOutput) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintPayload(dAtA, i, uint64(m.Address.Size()))
-	n11, err := m.Address.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n11, err11 := m.Address.MarshalTo(dAtA[i:])
+	if err11 != nil {
+		return 0, err11
 	}
 	i += n11
 	if m.Amount != 0 {
@@ -1305,9 +1307,9 @@ func (m *CallTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.Input.Size()))
-		n12, err := m.Input.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n12, err12 := m.Input.MarshalTo(dAtA[i:])
+		if err12 != nil {
+			return 0, err12
 		}
 		i += n12
 	}
@@ -1315,9 +1317,9 @@ func (m *CallTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.Address.Size()))
-		n13, err := m.Address.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n13, err13 := m.Address.MarshalTo(dAtA[i:])
+		if err13 != nil {
+			return 0, err13
 		}
 		i += n13
 	}
@@ -1334,17 +1336,17 @@ func (m *CallTx) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x2a
 	i++
 	i = encodeVarintPayload(dAtA, i, uint64(m.Data.Size()))
-	n14, err := m.Data.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n14, err14 := m.Data.MarshalTo(dAtA[i:])
+	if err14 != nil {
+		return 0, err14
 	}
 	i += n14
 	dAtA[i] = 0x32
 	i++
 	i = encodeVarintPayload(dAtA, i, uint64(m.WASM.Size()))
-	n15, err := m.WASM.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n15, err15 := m.WASM.MarshalTo(dAtA[i:])
+	if err15 != nil {
+		return 0, err15
 	}
 	i += n15
 	if len(m.ContractMeta) > 0 {
@@ -1383,9 +1385,9 @@ func (m *ContractMeta) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintPayload(dAtA, i, uint64(m.CodeHash.Size()))
-	n16, err := m.CodeHash.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n16, err16 := m.CodeHash.MarshalTo(dAtA[i:])
+	if err16 != nil {
+		return 0, err16
 	}
 	i += n16
 	if len(m.Meta) > 0 {
@@ -1464,18 +1466,18 @@ func (m *PermsTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.Input.Size()))
-		n17, err := m.Input.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n17, err17 := m.Input.MarshalTo(dAtA[i:])
+		if err17 != nil {
+			return 0, err17
 		}
 		i += n17
 	}
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintPayload(dAtA, i, uint64(m.PermArgs.Size()))
-	n18, err := m.PermArgs.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n18, err18 := m.PermArgs.MarshalTo(dAtA[i:])
+	if err18 != nil {
+		return 0, err18
 	}
 	i += n18
 	if m.XXX_unrecognized != nil {
@@ -1503,9 +1505,9 @@ func (m *NameTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.Input.Size()))
-		n19, err := m.Input.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n19, err19 := m.Input.MarshalTo(dAtA[i:])
+		if err19 != nil {
+			return 0, err19
 		}
 		i += n19
 	}
@@ -1551,9 +1553,9 @@ func (m *BondTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.Input.Size()))
-		n20, err := m.Input.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n20, err20 := m.Input.MarshalTo(dAtA[i:])
+		if err20 != nil {
+			return 0, err20
 		}
 		i += n20
 	}
@@ -1582,9 +1584,9 @@ func (m *UnbondTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.Input.Size()))
-		n21, err := m.Input.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n21, err21 := m.Input.MarshalTo(dAtA[i:])
+		if err21 != nil {
+			return 0, err21
 		}
 		i += n21
 	}
@@ -1592,9 +1594,9 @@ func (m *UnbondTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.Output.Size()))
-		n22, err := m.Output.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n22, err22 := m.Output.MarshalTo(dAtA[i:])
+		if err22 != nil {
+			return 0, err22
 		}
 		i += n22
 	}
@@ -1668,9 +1670,9 @@ func (m *ProposalTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.Input.Size()))
-		n23, err := m.Input.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n23, err23 := m.Input.MarshalTo(dAtA[i:])
+		if err23 != nil {
+			return 0, err23
 		}
 		i += n23
 	}
@@ -1683,9 +1685,9 @@ func (m *ProposalTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.ProposalHash.Size()))
-		n24, err := m.ProposalHash.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n24, err24 := m.ProposalHash.MarshalTo(dAtA[i:])
+		if err24 != nil {
+			return 0, err24
 		}
 		i += n24
 	}
@@ -1693,9 +1695,9 @@ func (m *ProposalTx) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x22
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.Proposal.Size()))
-		n25, err := m.Proposal.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n25, err25 := m.Proposal.MarshalTo(dAtA[i:])
+		if err25 != nil {
+			return 0, err25
 		}
 		i += n25
 	}
@@ -1768,9 +1770,9 @@ func (m *Vote) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintPayload(dAtA, i, uint64(m.Address.Size()))
-	n26, err := m.Address.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n26, err26 := m.Address.MarshalTo(dAtA[i:])
+	if err26 != nil {
+		return 0, err26
 	}
 	i += n26
 	if m.VotingWeight != 0 {
@@ -1815,9 +1817,9 @@ func (m *Proposal) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.BatchTx.Size()))
-		n27, err := m.BatchTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n27, err27 := m.BatchTx.MarshalTo(dAtA[i:])
+		if err27 != nil {
+			return 0, err27
 		}
 		i += n27
 	}
@@ -1846,9 +1848,9 @@ func (m *Ballot) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.Proposal.Size()))
-		n28, err := m.Proposal.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n28, err28 := m.Proposal.MarshalTo(dAtA[i:])
+		if err28 != nil {
+			return 0, err28
 		}
 		i += n28
 	}
@@ -1856,9 +1858,9 @@ func (m *Ballot) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintPayload(dAtA, i, uint64(m.FinalizingTx.Size()))
-		n29, err := m.FinalizingTx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n29, err29 := m.FinalizingTx.MarshalTo(dAtA[i:])
+		if err29 != nil {
+			return 0, err29
 		}
 		i += n29
 	}
@@ -2284,14 +2286,7 @@ func (m *Ballot) Size() (n int) {
 }
 
 func sovPayload(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozPayload(x uint64) (n int) {
 	return sovPayload(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/txs/txs.pb.go
+++ b/txs/txs.pb.go
@@ -5,6 +5,10 @@ package txs
 
 import (
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	golang_proto "github.com/golang/protobuf/proto"
@@ -12,8 +16,6 @@ import (
 	crypto "github.com/hyperledger/burrow/crypto"
 	github_com_hyperledger_burrow_crypto "github.com/hyperledger/burrow/crypto"
 	github_com_hyperledger_burrow_txs_payload "github.com/hyperledger/burrow/txs/payload"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -281,9 +283,9 @@ func (m *Envelope) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintTxs(dAtA, i, uint64(m.Tx.Size()))
-		n1, err := m.Tx.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n1, err1 := m.Tx.MarshalTo(dAtA[i:])
+		if err1 != nil {
+			return 0, err1
 		}
 		i += n1
 	}
@@ -312,9 +314,9 @@ func (m *Signatory) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintTxs(dAtA, i, uint64(m.Address.Size()))
-		n2, err := m.Address.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n2, err2 := m.Address.MarshalTo(dAtA[i:])
+		if err2 != nil {
+			return 0, err2
 		}
 		i += n2
 	}
@@ -322,9 +324,9 @@ func (m *Signatory) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintTxs(dAtA, i, uint64(m.PublicKey.Size()))
-		n3, err := m.PublicKey.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n3, err3 := m.PublicKey.MarshalTo(dAtA[i:])
+		if err3 != nil {
+			return 0, err3
 		}
 		i += n3
 	}
@@ -332,9 +334,9 @@ func (m *Signatory) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x22
 		i++
 		i = encodeVarintTxs(dAtA, i, uint64(m.Signature.Size()))
-		n4, err := m.Signature.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		n4, err4 := m.Signature.MarshalTo(dAtA[i:])
+		if err4 != nil {
+			return 0, err4
 		}
 		i += n4
 	}
@@ -367,9 +369,9 @@ func (m *Receipt) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintTxs(dAtA, i, uint64(m.TxHash.Size()))
-	n5, err := m.TxHash.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n5, err5 := m.TxHash.MarshalTo(dAtA[i:])
+	if err5 != nil {
+		return 0, err5
 	}
 	i += n5
 	if m.CreatesContract {
@@ -385,9 +387,9 @@ func (m *Receipt) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintTxs(dAtA, i, uint64(m.ContractAddress.Size()))
-	n6, err := m.ContractAddress.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	n6, err6 := m.ContractAddress.MarshalTo(dAtA[i:])
+	if err6 != nil {
+		return 0, err6
 	}
 	i += n6
 	if m.XXX_unrecognized != nil {
@@ -474,14 +476,7 @@ func (m *Receipt) Size() (n int) {
 }
 
 func sovTxs(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTxs(x uint64) (n int) {
 	return sovTxs(uint64((x << 1) ^ uint64((int64(x) >> 63))))


### PR DESCRIPTION
Merging these commits into single PR since they are stacked so I don't have to rebase multiple PRs

Query:
- Added a benchmark to check against regression

ABI:

I wanted to be able to integration test vent and noticed there was no `PackEvent`. When I went to add this I saw that ABI had become a bit overgrown and hard to follow so I factored it out into a few different files. Outside the reorganisation:

- Implemented `PackEvent`
- Added tests for event packing
- Reduced public API service by making `Pack*` and `Unpack*` work with variadic args or a struct combing the functionality of `PackIntoStruct` (I didn't want us maintain `PackEventStruct` `UnpackEventStruct` and all the other variants.
- Supported packing of uint8, int8, and big.Int (we were unpacking big ints, but didn't support packing them)
- Made `pack` elide indexed fields (i.e. fields that go into Log topics)
in the same way that `unpack` does
