### PR TITLE
Use burrow side ABIs when available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ commit_hash.txt
 tests/keys/
 .output.json
 vendor/
+node_modules

--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -305,6 +305,16 @@ When the contract interface object is created via deploy, the default address is
 `Object` - The return data object is a contract interface, which refers to the contract which is deployed at `contract.address`. (This functionality used to be called `new`.)
 
 ##### burrow.contracts.new
+```burrow.contracts.address(address)```
+
+Returns a new contract interface object, without having to pass in the ABI. The ABI is retrieved from burrow; the contract must have been deployed with burrow deploy 0.28.0 or later.
+
+###### Parameters
+3. `String` - Hex encoded address of the default contract you want the interface to access
+###### Returns
+`Object` - The return data object is a contract interface.
+
+##### burrow.contracts.new
 ```burrow.contracts.new(abi, [bytecode[, address]])```
 
 Returns a new contract interface object. All you really need to create an interface is the abi, however you can also include the bytecode of the contract. If you do so you can create new contracts of this type by calling `contract._constructor(...)` which will deploy a new contract and return its address. If you provide an address, then this will be the default contract address used however you can also omit this at be sure to use the `.at()` and `.atSim()` versions of functions. Also note you must provide bytecode is you wish to provide address, though bytecode argument can be null.

--- a/js/lib/contractManager.js
+++ b/js/lib/contractManager.js
@@ -91,4 +91,22 @@ ContractManager.prototype.new = function (abi, byteCode, address, handlers) {
   return new Contract(abi, address, byteCode, this.burrow, handlers)
 }
 
+/**
+ * Creates a contract object interface from an address without ABI.
+ * The contract must be deployed using a recent burrow deploy which registers
+ * metadata.
+ *
+ * @method address
+ * @param {string} address - default contract address [can be null]
+ * @returns {Contract} returns contract interface object
+ */
+ContractManager.prototype.address = function (address, handlers) {
+  handlers = Object.assign({}, this.handlers, handlers)
+  return this.burrow.query.GetMetadata({ Address: Buffer.from(address, 'hex') })
+    .then((data) => {
+      const abi = JSON.parse(data.Metadata).Abi
+      return this.burrow.contracts.new(abi, null, address, handlers)
+    })
+}
+
 module.exports = ContractManager

--- a/js/test/Abis/index.js
+++ b/js/test/Abis/index.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const assert = require('assert')
+const test = require('../../lib/test')
+
+const Test = test.Test()
+
+describe('Abi', function () {
+  this.timeout(10 * 1000)
+  let burrow
+
+  before(Test.before(function (_burrow) {
+    burrow = _burrow
+  }))
+
+  after(Test.after())
+
+  it('Call contract via burrow side Abi', Test.it(function () {
+    return burrow.namereg.get('random')
+      .then((data) => {
+        let address = data.Data
+        return burrow.contracts.address(address)
+      })
+      .then((contract) => {
+        return contract.getRandomNumber()
+      })
+      .then((data) => {
+        assert.equal(data[0], 55)
+      })
+  }))
+})

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "precommit": "standard --fix js/**/*.js",
     "pretest": "standard --fix js/**/*.js",
-    "test": "./tests/js.sh"
+    "test": "./tests/js/js.sh"
   },
   "standard": {
     "globals": [

--- a/tests/js/deploy.yaml
+++ b/tests/js/deploy.yaml
@@ -1,0 +1,12 @@
+jobs:
+
+- name: randomDeploy
+  deploy:
+      contract: random.sol
+
+- name: randomRegister
+  register:
+       name: random
+       data: $randomDeploy
+       amount: 5000
+       fee: 2000

--- a/tests/js/js.sh
+++ b/tests/js/js.sh
@@ -16,15 +16,20 @@
 # run_pkgs_tests.sh [appXX]
 
 
-export script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "$script_dir/test_runner.sh"
+export jsscript_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$jsscript_dir/../test_runner.sh"
 
 export js_dir="${script_dir}/../js"
 
+
 perform_js_tests(){
+  cd "$jsscript_dir"
+  # First deploy a solidity file using burrow deploy so it has metadata
+  $burrow_bin deploy --chain=$BURROW_HOST:$BURROW_GRPC_PORT -a $key1_addr deploy.yaml
   cd "$js_dir"
   test_account="{\"address\": \"$key1_addr\"}"
   echo "Using test account:"
+  echo $test_account
   account="$test_account" mocha --bail --exit --recursive ${1}
   test_exit=$?
 }

--- a/tests/js/random.sol
+++ b/tests/js/random.sol
@@ -1,0 +1,7 @@
+pragma solidity >=0.0.0;
+
+contract random {
+	function getRandomNumber() public pure returns (uint) {
+		return 55;
+	}
+}


### PR DESCRIPTION
This introduces a new function burrow.contracts.address(address)
which sets up the contract with just the address.

Contracts must be deployed using burrow deploy on a recent version
(>=0.28.0).

Signed-off-by: Sean Young <sean.young@monax.io>