### PR TITLE
Split out metadata cache and interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # [Hyperledger Burrow](https://github.com/hyperledger/burrow) Changelog
+## [0.29.1] - 2019-10-10
+### Changed
+- [State] Split metadata and account state to be kinder to downstream EVM integrators
+
+
 ## [0.29.0] - 2019-10-08
 ### Changed
 - [Config] Reverted rename of ValidatorAddress to Address in config (each Burrow node has a specific validator key it uses for signing whether or not it is running as a validator right now)
@@ -578,6 +583,7 @@ This release marks the start of Eris-DB as the full permissioned blockchain node
   - [Blockchain] Fix getBlocks to respect block height cap.
 
 
+[0.29.1]: https://github.com/hyperledger/burrow/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/hyperledger/burrow/compare/v0.28.2...v0.29.0
 [0.28.2]: https://github.com/hyperledger/burrow/compare/v0.28.1...v0.28.2
 [0.28.1]: https://github.com/hyperledger/burrow/compare/v0.28.0...v0.28.1

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,24 +1,3 @@
 ### Changed
-- [Config] Reverted rename of ValidatorAddress to Address in config (each Burrow node has a specific validator key it uses for signing whether or not it is running as a validator right now)
-
-### Fixed 
-- [EVM] Return integer overflow error code (not stack overflow) for integer overflow errors
-- [Docs] Fix broken examples
-- [Deploy] Set input on QueryContract jobs correctly
-- [EVM] Fix byte-printing for DebugOpcodes run mode
-- [Crypto] Use Tendermint-compatible secp256k1 addressing
-- [Natives] Make natives first class contracts and establish Dispatcher and Callable as a common calling convention for natives, EVM, and WASM (pending for WASM).
-- [Natives] Fix Ethereum precompile addresses (addresses were padded on right instead of the left)
-
-
-### Added
-- [Web3] Implemented Ethereum web3 JSON RPC including sendRawTransaction!
-- [Docs] Much docs (see also: https://www.hyperledger.org/blog/2019/10/08/burrow-the-boring-blockchain)
-- [Docs] Generate github pages docs index with docsify: https://hyperledger.github.io/burrow/
-- [JS] Publish burrow.js to @hyperledger/burrow
-- [State] Store EVM ABI and contract metadata on-chain see [GetMetadata](https://github.com/hyperledger/burrow/blob/e80aad5d8fac1f67dbfec61ea75670f9a38c61a1/protobuf/rpcquery.proto#L25)
-- [Tendermint] Upgrade to v0.32.3
-- [Execution] Added IdentifyTx for introducing nodes (binding their NodeID to ValidatorAddress)
-- [Natives] Implement Ethereum precompile number 5 - modular exponentiation
-
+- [State] Split metadata and account state to be kinder to downstream EVM integrators
 

--- a/acm/acmstate/metadata_cache.go
+++ b/acm/acmstate/metadata_cache.go
@@ -1,0 +1,82 @@
+package acmstate
+
+import (
+	"sync"
+)
+
+type metadataInfo struct {
+	metadata string
+	updated  bool
+}
+
+type MetadataCache struct {
+	backend MetadataReader
+	m       sync.Map
+}
+
+func NewMetadataCache(backend MetadataReader) *MetadataCache {
+	return &MetadataCache{
+		backend: backend,
+	}
+}
+
+func (cache *MetadataCache) SetMetadata(metahash MetadataHash, metadata string) error {
+	cache.m.Store(metahash, &metadataInfo{updated: true, metadata: metadata})
+	return nil
+}
+
+func (cache *MetadataCache) GetMetadata(metahash MetadataHash) (string, error) {
+	metaInfo, err := cache.getMetadata(metahash)
+	if err != nil {
+		return "", err
+	}
+
+	return metaInfo.metadata, nil
+}
+
+// Syncs changes to the backend in deterministic order. Sends storage updates before updating
+// the account they belong so that storage values can be taken account of in the update.
+func (cache *MetadataCache) Sync(st MetadataWriter) error {
+	var err error
+	cache.m.Range(func(key, value interface{}) bool {
+		hash := key.(MetadataHash)
+		info := value.(*metadataInfo)
+		if info.updated {
+			err = st.SetMetadata(hash, info.metadata)
+			if err != nil {
+				return false
+			}
+		}
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cache *MetadataCache) Flush(output MetadataWriter, backend MetadataReader) error {
+	err := cache.Sync(output)
+	if err != nil {
+		return err
+	}
+	cache.m = sync.Map{}
+	return nil
+}
+
+// Get the cache accountInfo item creating it if necessary
+func (cache *MetadataCache) getMetadata(metahash MetadataHash) (*metadataInfo, error) {
+	value, ok := cache.m.Load(metahash)
+	if !ok {
+		metadata, err := cache.backend.GetMetadata(metahash)
+		if err != nil {
+			return nil, err
+		}
+		metaInfo := &metadataInfo{
+			metadata: metadata,
+		}
+		cache.m.Store(metahash, metaInfo)
+		return metaInfo, nil
+	}
+	return value.(*metadataInfo), nil
+}

--- a/acm/acmstate/state.go
+++ b/acm/acmstate/state.go
@@ -110,12 +110,12 @@ type StorageIterable interface {
 	IterateStorage(address crypto.Address, consumer func(key binary.Word256, value []byte) error) (err error)
 }
 
-type MetadataGetter interface {
+type MetadataReader interface {
 	// Get an Metadata by its hash. This is content-addressed
 	GetMetadata(metahash MetadataHash) (string, error)
 }
 
-type MetadataSetter interface {
+type MetadataWriter interface {
 	// Set an Metadata according to it keccak-256 hash.
 	SetMetadata(metahash MetadataHash, metadata string) error
 }
@@ -135,7 +135,6 @@ type AccountStatsGetter interface {
 type Reader interface {
 	AccountGetter
 	StorageGetter
-	MetadataGetter
 }
 
 type Iterable interface {
@@ -158,13 +157,17 @@ type IterableStatsReader interface {
 type Writer interface {
 	AccountUpdater
 	StorageSetter
-	MetadataSetter
 }
 
 // Read and write account and storage state
 type ReaderWriter interface {
 	Reader
 	Writer
+}
+
+type MetadataReaderWriter interface {
+	MetadataReader
+	MetadataWriter
 }
 
 type IterableReaderWriter interface {

--- a/core/processes.go
+++ b/core/processes.go
@@ -309,12 +309,8 @@ func GRPCLauncher(kern *Kernel, conf *rpc.ServerConfig, keyConfig *keys.KeysConf
 				}
 				keys.RegisterKeysServer(grpcServer, ks)
 			}
-
-			nameRegState := kern.State
-			nodeRegState := kern.State
-			proposalRegState := kern.State
-			rpcquery.RegisterQueryServer(grpcServer, rpcquery.NewQueryServer(kern.State, nameRegState, nodeRegState, proposalRegState,
-				kern.Blockchain, kern.State, nodeView, kern.Logger))
+			rpcquery.RegisterQueryServer(grpcServer, rpcquery.NewQueryServer(kern.State, kern.Blockchain, nodeView,
+				kern.Logger))
 
 			txCodec := txs.NewProtobufCodec()
 			rpctransact.RegisterTransactServer(grpcServer,

--- a/execution/native/account.go
+++ b/execution/native/account.go
@@ -155,7 +155,7 @@ func Transfer(st acmstate.ReaderWriter, from, to crypto.Address, amount uint64) 
 	})
 }
 
-func UpdateContractMeta(st acmstate.ReaderWriter, address crypto.Address, payloadMeta []*payload.ContractMeta) error {
+func UpdateContractMeta(st acmstate.ReaderWriter, metaSt acmstate.MetadataWriter, address crypto.Address, payloadMeta []*payload.ContractMeta) error {
 	if len(payloadMeta) == 0 {
 		return nil
 	}
@@ -171,7 +171,7 @@ func UpdateContractMeta(st acmstate.ReaderWriter, address crypto.Address, payloa
 			MetadataHash: metahash[:],
 			CodeHash:     abi.CodeHash,
 		}
-		err = st.SetMetadata(metahash, abi.Meta)
+		err = metaSt.SetMetadata(metahash, abi.Meta)
 		if err != nil {
 			return errors.Errorf(errors.Codes.IllegalWrite,
 				"cannot update metadata for %v: %v", address, err)

--- a/execution/native/state.go
+++ b/execution/native/state.go
@@ -64,14 +64,6 @@ func (s *State) SetStorage(address crypto.Address, key binary.Word256, value []b
 	return s.backend.SetStorage(address, key, value)
 }
 
-func (s *State) GetMetadata(metahash acmstate.MetadataHash) (string, error) {
-	return s.backend.GetMetadata(metahash)
-}
-
-func (s *State) SetMetadata(metahash acmstate.MetadataHash, metadata string) error {
-	return s.backend.SetMetadata(metahash, metadata)
-}
-
 func (s *State) ensureNonNative(address crypto.Address, action string) error {
 	contract := s.natives.GetByAddress(address)
 	if contract != nil {

--- a/execution/simulated_call.go
+++ b/execution/simulated_call.go
@@ -20,11 +20,12 @@ func CallSim(reader acmstate.Reader, blockchain bcm.BlockchainInfo, fromAddress,
 
 	cache := acmstate.NewCache(reader)
 	exe := contexts.CallContext{
-		EVM:        evm.Default(),
-		RunCall:    true,
-		State:      cache,
-		Blockchain: blockchain,
-		Logger:     logger,
+		EVM:           evm.Default(),
+		RunCall:       true,
+		State:         cache,
+		MetadataState: acmstate.NewMemoryState(),
+		Blockchain:    blockchain,
+		Logger:        logger,
 	}
 
 	txe := exec.NewTxExecution(txs.Enclose(blockchain.ChainID(), &payload.CallTx{

--- a/execution/state/state.go
+++ b/execution/state/state.go
@@ -93,6 +93,7 @@ type Updatable interface {
 	proposal.Writer
 	registry.Writer
 	validator.Writer
+	acmstate.MetadataWriter
 	AddBlock(blockExecution *exec.BlockExecution) error
 }
 

--- a/integration/rpctransact/call_test.go
+++ b/integration/rpctransact/call_test.go
@@ -310,7 +310,7 @@ func testCallTx(t *testing.T, kern *core.Kernel, cli rpctransact.TransactClient)
 			qcli := rpctest.NewQueryClient(t, kern.GRPCListenAddress().String())
 			res, err := qcli.GetMetadata(context.Background(), &rpcquery.GetMetadataParam{Address: &addressA})
 			require.NoError(t, err)
-			assert.Equal(t, res.Metadata, string(solidity.Abi_A))
+			assert.Equal(t, string(solidity.Abi_A), res.Metadata)
 			// CreateB
 			spec, err := abi.ReadSpec(solidity.Abi_A)
 			require.NoError(t, err)
@@ -323,7 +323,7 @@ func testCallTx(t *testing.T, kern *core.Kernel, cli rpctransact.TransactClient)
 			// check ABI for contract B
 			res, err = qcli.GetMetadata(context.Background(), &rpcquery.GetMetadataParam{Address: &addressB})
 			require.NoError(t, err)
-			assert.Equal(t, res.Metadata, string(solidity.Abi_B))
+			assert.Equal(t, string(solidity.Abi_B), res.Metadata)
 			// CreateC
 			spec, err = abi.ReadSpec(solidity.Abi_B)
 			require.NoError(t, err)
@@ -336,7 +336,7 @@ func testCallTx(t *testing.T, kern *core.Kernel, cli rpctransact.TransactClient)
 			// check abi for contract C
 			res, err = qcli.GetMetadata(context.Background(), &rpcquery.GetMetadataParam{Address: &addressC})
 			require.NoError(t, err)
-			assert.Equal(t, res.Metadata, string(solidity.Abi_C))
+			assert.Equal(t, string(solidity.Abi_C), res.Metadata)
 			return
 		})
 

--- a/project/history.go
+++ b/project/history.go
@@ -48,6 +48,10 @@ func FullVersion() string {
 // release tagging script: ./scripts/tag_release.sh
 var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "https://github.com/hyperledger/burrow").
 	MustDeclareReleases(
+		"0.29.1 - 2019-10-10",
+		`### Changed
+- [State] Split metadata and account state to be kinder to downstream EVM integrators
+`,
 		"0.29.0 - 2019-10-08",
 		`### Changed
 - [Config] Reverted rename of ValidatorAddress to Address in config (each Burrow node has a specific validator key it uses for signing whether or not it is running as a validator right now)

--- a/rpc/rpcquery/query_server.go
+++ b/rpc/rpcquery/query_server.go
@@ -25,40 +25,40 @@ import (
 )
 
 type queryServer struct {
-	accounts    acmstate.IterableStatsReader
-	nameReg     names.IterableReader
-	nodeReg     registry.IterableReader
-	proposalReg proposal.IterableReader
-	blockchain  bcm.BlockchainInfo
-	validators  validator.History
-	nodeView    *tendermint.NodeView
-	logger      *logging.Logger
+	state      QueryState
+	blockchain bcm.BlockchainInfo
+	nodeView   *tendermint.NodeView
+	logger     *logging.Logger
 }
 
 var _ QueryServer = &queryServer{}
 
-func NewQueryServer(state acmstate.IterableStatsReader, nameReg names.IterableReader, nodeReg registry.IterableReader, proposalReg proposal.IterableReader,
-	blockchain bcm.BlockchainInfo, validators validator.History, nodeView *tendermint.NodeView, logger *logging.Logger) *queryServer {
+type QueryState interface {
+	acmstate.IterableStatsReader
+	acmstate.MetadataReader
+	names.IterableReader
+	registry.IterableReader
+	proposal.IterableReader
+	validator.History
+}
+
+func NewQueryServer(state QueryState, blockchain bcm.BlockchainInfo, nodeView *tendermint.NodeView, logger *logging.Logger) *queryServer {
 	return &queryServer{
-		accounts:    state,
-		nameReg:     nameReg,
-		nodeReg:     nodeReg,
-		proposalReg: proposalReg,
-		blockchain:  blockchain,
-		validators:  validators,
-		nodeView:    nodeView,
-		logger:      logger,
+		state:      state,
+		blockchain: blockchain,
+		nodeView:   nodeView,
+		logger:     logger,
 	}
 }
 
 func (qs *queryServer) Status(ctx context.Context, param *StatusParam) (*rpc.ResultStatus, error) {
-	return rpc.Status(qs.blockchain, qs.validators, qs.nodeView, param.BlockTimeWithin, param.BlockSeenTimeWithin)
+	return rpc.Status(qs.blockchain, qs.state, qs.nodeView, param.BlockTimeWithin, param.BlockSeenTimeWithin)
 }
 
 // Account state
 
 func (qs *queryServer) GetAccount(ctx context.Context, param *GetAccountParam) (*acm.Account, error) {
-	acc, err := qs.accounts.GetAccount(param.Address)
+	acc, err := qs.state.GetAccount(param.Address)
 	if acc == nil {
 		acc = &acm.Account{}
 	}
@@ -72,14 +72,14 @@ func (qs *queryServer) GetMetadata(ctx context.Context, param *GetMetadataParam)
 	var contractMeta *acm.ContractMeta
 	var err error
 	if param.Address != nil {
-		acc, err := qs.accounts.GetAccount(*param.Address)
+		acc, err := qs.state.GetAccount(*param.Address)
 		if err != nil {
 			return metadata, err
 		}
 		if acc != nil && acc.CodeHash != nil {
 			codehash := acc.CodeHash
 			if acc.Forebear != nil {
-				acc, err = qs.accounts.GetAccount(*acc.Forebear)
+				acc, err = qs.state.GetAccount(*acc.Forebear)
 				if err != nil {
 					return metadata, err
 				}
@@ -116,13 +116,13 @@ func (qs *queryServer) GetMetadata(ctx context.Context, param *GetMetadataParam)
 	} else {
 		var metadataHash acmstate.MetadataHash
 		copy(metadataHash[:], contractMeta.MetadataHash)
-		metadata.Metadata, err = qs.accounts.GetMetadata(metadataHash)
+		metadata.Metadata, err = qs.state.GetMetadata(metadataHash)
 	}
 	return metadata, err
 }
 
 func (qs *queryServer) GetStorage(ctx context.Context, param *GetStorageParam) (*StorageValue, error) {
-	val, err := qs.accounts.GetStorage(param.Address, param.Key)
+	val, err := qs.state.GetStorage(param.Address, param.Key)
 	return &StorageValue{Value: val}, err
 }
 
@@ -132,7 +132,7 @@ func (qs *queryServer) ListAccounts(param *ListAccountsParam, stream Query_ListA
 		return err
 	}
 	var streamErr error
-	err = qs.accounts.IterateAccounts(func(acc *acm.Account) error {
+	err = qs.state.IterateAccounts(func(acc *acm.Account) error {
 		if qry.Matches(acc) {
 			return stream.Send(acc)
 		} else {
@@ -148,7 +148,7 @@ func (qs *queryServer) ListAccounts(param *ListAccountsParam, stream Query_ListA
 // Names
 
 func (qs *queryServer) GetName(ctx context.Context, param *GetNameParam) (entry *names.Entry, err error) {
-	entry, err = qs.nameReg.GetName(param.Name)
+	entry, err = qs.state.GetName(param.Name)
 	if entry == nil && err == nil {
 		err = fmt.Errorf("name %s not found", param.Name)
 	}
@@ -161,7 +161,7 @@ func (qs *queryServer) ListNames(param *ListNamesParam, stream Query_ListNamesSe
 		return err
 	}
 	var streamErr error
-	err = qs.nameReg.IterateNames(func(entry *names.Entry) error {
+	err = qs.state.IterateNames(func(entry *names.Entry) error {
 		if qry.Matches(entry) {
 			return stream.Send(entry)
 		} else {
@@ -177,7 +177,7 @@ func (qs *queryServer) ListNames(param *ListNamesParam, stream Query_ListNamesSe
 // Validators
 
 func (qs *queryServer) GetValidatorSet(ctx context.Context, param *GetValidatorSetParam) (*ValidatorSet, error) {
-	set := validator.Copy(qs.validators.Validators(0))
+	set := validator.Copy(qs.state.Validators(0))
 	return &ValidatorSet{
 		Set: set.Validators(),
 	}, nil
@@ -197,7 +197,7 @@ func (qs *queryServer) GetValidatorSetHistory(ctx context.Context, param *GetVal
 	}
 	history := &ValidatorSetHistory{}
 	for i := 0; i < lookback; i++ {
-		set := validator.Copy(qs.validators.Validators(i))
+		set := validator.Copy(qs.state.Validators(i))
 		vs := &ValidatorSet{
 			Height: height - uint64(i),
 			Set:    set.Validators(),
@@ -209,7 +209,7 @@ func (qs *queryServer) GetValidatorSetHistory(ctx context.Context, param *GetVal
 
 func (qs *queryServer) GetNetworkRegistry(ctx context.Context, param *GetNetworkRegistryParam) (*NetworkRegistry, error) {
 	rv := make([]*RegisteredValidator, 0)
-	err := qs.nodeReg.IterateNodes(func(id crypto.Address, rn *registry.NodeIdentity) error {
+	err := qs.state.IterateNodes(func(id crypto.Address, rn *registry.NodeIdentity) error {
 		rv = append(rv, &RegisteredValidator{
 			Address: rn.ValidatorPublicKey.GetAddress(),
 			Node:    rn,
@@ -222,7 +222,7 @@ func (qs *queryServer) GetNetworkRegistry(ctx context.Context, param *GetNetwork
 // Proposals
 
 func (qs *queryServer) GetProposal(ctx context.Context, param *GetProposalParam) (proposal *payload.Ballot, err error) {
-	proposal, err = qs.proposalReg.GetProposal(param.Hash)
+	proposal, err = qs.state.GetProposal(param.Hash)
 	if proposal == nil && err == nil {
 		err = fmt.Errorf("proposal %x not found", param.Hash)
 	}
@@ -231,7 +231,7 @@ func (qs *queryServer) GetProposal(ctx context.Context, param *GetProposalParam)
 
 func (qs *queryServer) ListProposals(param *ListProposalsParam, stream Query_ListProposalsServer) error {
 	var streamErr error
-	err := qs.proposalReg.IterateProposals(func(hash []byte, ballot *payload.Ballot) error {
+	err := qs.state.IterateProposals(func(hash []byte, ballot *payload.Ballot) error {
 		if !param.GetProposed() || ballot.ProposalState == payload.Ballot_PROPOSED {
 			return stream.Send(&ProposalResult{Hash: hash, Ballot: ballot})
 		} else {
@@ -245,7 +245,7 @@ func (qs *queryServer) ListProposals(param *ListProposalsParam, stream Query_Lis
 }
 
 func (qs *queryServer) GetStats(ctx context.Context, param *GetStatsParam) (*Stats, error) {
-	stats := qs.accounts.GetAccountStats()
+	stats := qs.state.GetAccountStats()
 
 	return &Stats{
 		AccountsWithCode:    stats.AccountsWithCode,


### PR DESCRIPTION
Hooray another cache I hear you say.

We let this slide originally because it was convenient. But it forces downstream to implement no-op metadata interfaces even though they are not needed by the EVM. It's cleaner for us to keep these separate and only have the EVM ask for what it needs.