### PR TITLE
docs: updating path for JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Hyperledger Burrow is a permissioned blockchain node that executes smart contrac
 
 ## JavaScript Client
 
-There is a [JavaScript API](https://github.com/hyperledger/burrow/tree/develop/js)
+There is a [JavaScript API](https://github.com/hyperledger/burrow/tree/master/js)
 
 ## Project Roadmap
 


### PR DESCRIPTION
It seems the develop branch is gone, so the link references.

