### PR TITLE
Fix for downstream API:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 ## [0.29.5] - 2019-12-09
 ### Security
 - [Tendermint] Upgraded to v0.32.8, checkTxAsync now includes node ID
+		
+### Changed
+- [Vent] Sync every block height to DB and send height notification from _vent_chain table so downstream can check DB sync without --blocks
+- [RPC/Query] GetName now returns GRPC NotFound status (rather than unknown) when a requested key is not set.
+
+### Fixed
+- [Execution] Simulated calls (e.g. query contracts) now returns the height of the state on which the query was run. Useful for downstream sync.
+- 
 
 
 ## [0.29.4] - 2019-11-22

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ test_truffle:
 .PHONY:	test_integration_vent
 test_integration_vent:
 	# Include sqlite adapter with tests - will build with CGO but that's probably fine
-	go test -v -tags 'integration sqlite' ./vent/...
+	go test -count=1 -v -tags 'integration sqlite' ./vent/...
 
 .PHONY:	test_integration_vent_postgres
 test_integration_vent_postgres:
@@ -212,7 +212,7 @@ test_restore:
 
 .PHONY: test_integration
 test_integration:
-	@go test -v -tags integration ./integration/...
+	@go test -count=1 -v -tags integration ./integration/...
 
 .PHONY: test_integration_all
 test_integration_all: test_keys test_deploy test_integration_vent_postgres test_restore test_truffle test_integration

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,11 @@
 ### Security
 - [Tendermint] Upgraded to v0.32.8, checkTxAsync now includes node ID
+		
+### Changed
+- [Vent] Sync every block height to DB and send height notification from _vent_chain table so downstream can check DB sync without --blocks
+- [RPC/Query] GetName now returns GRPC NotFound status (rather than unknown) when a requested key is not set.
+
+### Fixed
+- [Execution] Simulated calls (e.g. query contracts) now returns the height of the state on which the query was run. Useful for downstream sync.
+- 
 

--- a/execution/simulated_call.go
+++ b/execution/simulated_call.go
@@ -36,6 +36,9 @@ func CallSim(reader acmstate.Reader, blockchain bcm.BlockchainInfo, fromAddress,
 		Data:     data,
 		GasLimit: contexts.GasLimit,
 	}))
+
+	// Set height for downstream synchronisation purposes
+	txe.Height = blockchain.LastBlockHeight()
 	err := exe.Execute(txe, txe.Envelope.Tx.Payload)
 	if err != nil {
 		return nil, err

--- a/project/history.go
+++ b/project/history.go
@@ -51,8 +51,15 @@ var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "htt
 		"0.29.5 - 2019-12-09",
 		`### Security
 - [Tendermint] Upgraded to v0.32.8, checkTxAsync now includes node ID
-`,
+		
+### Changed
+- [Vent] Sync every block height to DB and send height notification from _vent_chain table so downstream can check DB sync without --blocks
+- [RPC/Query] GetName now returns GRPC NotFound status (rather than unknown) when a requested key is not set.
 
+### Fixed
+- [Execution] Simulated calls (e.g. query contracts) now returns the height of the state on which the query was run. Useful for downstream sync.
+- 
+`,
 		"0.29.4 - 2019-11-22",
 		`### Changed
 - [Build] Move to solidity 0.5.12

--- a/rpc/rpcquery/query_server.go
+++ b/rpc/rpcquery/query_server.go
@@ -22,6 +22,8 @@ import (
 	"github.com/hyperledger/burrow/txs/payload"
 	"github.com/tendermint/tendermint/abci/types"
 	tmtypes "github.com/tendermint/tendermint/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type queryServer struct {
@@ -150,7 +152,7 @@ func (qs *queryServer) ListAccounts(param *ListAccountsParam, stream Query_ListA
 func (qs *queryServer) GetName(ctx context.Context, param *GetNameParam) (entry *names.Entry, err error) {
 	entry, err = qs.state.GetName(param.Name)
 	if entry == nil && err == nil {
-		err = fmt.Errorf("name %s not found", param.Name)
+		err = status.Error(codes.NotFound, fmt.Sprintf("name %s not found", param.Name))
 	}
 	return
 }

--- a/vent/service/block_consumer.go
+++ b/vent/service/block_consumer.go
@@ -126,16 +126,11 @@ func NewBlockConsumer(projection *sqlsol.Projection, opt sqlsol.SpecOpt, getEven
 
 		// upsert rows in specific SQL event tables and update block number
 		// store block data in SQL tables (if any)
-		if blockData.PendingRows(fromBlock) {
-			// gets block data to upsert
-			blk := blockData.Data
-
-			for name, rows := range blk.Tables {
-				logger.InfoMsg("Upserting rows in SQL table", "height", fromBlock, "table", name, "action", "UPSERT", "rows", rows)
-			}
-
-			eventCh <- blk
+		for name, rows := range blockData.Data.Tables {
+			logger.InfoMsg("Upserting rows in SQL table", "height", fromBlock, "table", name, "action", "UPSERT", "rows", rows)
 		}
+
+		eventCh <- blockData.Data
 		return nil
 	}
 }

--- a/vent/service/consumer_postgres_test.go
+++ b/vent/service/consumer_postgres_test.go
@@ -4,7 +4,6 @@ package service_test
 
 import (
 	"encoding/json"
-	"strconv"
 	"testing"
 	"time"
 
@@ -78,10 +77,10 @@ func TestPostgresConsumer(t *testing.T) {
 			require.NoError(t, err)
 
 			type payload struct {
-				Height string `json:"_height"`
+				Height uint64 `json:"_height"`
 			}
 
-			var height uint64
+			heightCh := make(chan uint64)
 			notifications := make(map[string]string)
 			go func() {
 				for n := range listener.Notify {
@@ -92,11 +91,9 @@ func TestPostgresConsumer(t *testing.T) {
 						if err != nil {
 							panic(err)
 						}
-						if pl.Height != "" {
-							height, err = strconv.ParseUint(pl.Height, 10, 64)
-							if err != nil {
-								panic(err)
-							}
+						if pl.Height >= txe.Height {
+							heightCh <- pl.Height
+							return
 						}
 					}
 				}
@@ -105,10 +102,15 @@ func TestPostgresConsumer(t *testing.T) {
 			runConsumer(t, cfg)
 
 			// Give events a chance
-			time.Sleep(time.Second)
-			// Assert we get expected returns
-			t.Logf("latest height: %d, txe height: %d", height, txe.Height)
-			assert.True(t, height >= txe.Height)
+			const timeout = 3 * time.Second
+			select {
+			case <-time.After(timeout):
+				t.Fatalf("timed out after %v waiting for notification", timeout)
+			case height := <-heightCh:
+				// Assert we get expected returns
+				t.Logf("latest height: %d, txe height: %d", height, txe.Height)
+				assert.True(t, height >= txe.Height)
+			}
 			assert.Equal(t, `{"_action" : "INSERT", "testdescription" : "\\x5472696767657220697421000000000000000000000000000000000000000000", "testname" : "TestTriggerEvent"}`, notifications["meta"])
 			assert.Equal(t, `{"_action" : "INSERT", "testdescription" : "\\x5472696767657220697421000000000000000000000000000000000000000000", "testkey" : "\\x544553545f4556454e5453000000000000000000000000000000000000000000", "testname" : "TestTriggerEvent"}`,
 				notifications["keyed_meta"])

--- a/vent/sqldb/system_tables.go
+++ b/vent/sqldb/system_tables.go
@@ -65,7 +65,6 @@ func (db *SQLDB) systemTablesDefinition() types.EventTables {
 					Type: types.SQLColumnTypeText,
 				},
 			},
-			NotifyChannels: map[string][]string{types.BlockHeightLabel: {columns.Height}},
 		},
 		tables.Dictionary: {
 			Name: tables.Dictionary,
@@ -117,6 +116,7 @@ func (db *SQLDB) systemTablesDefinition() types.EventTables {
 					Length: digits(maxUint64),
 				},
 			},
+			NotifyChannels: map[string][]string{types.BlockHeightLabel: {columns.Height}},
 		},
 	}
 }

--- a/vent/sqlsol/block_data.go
+++ b/vent/sqlsol/block_data.go
@@ -38,13 +38,3 @@ func (b *BlockData) GetRows(tableName string) (types.EventDataTable, error) {
 	}
 	return nil, fmt.Errorf("GetRows: tableName does not exists as a table in data structure: %s ", tableName)
 }
-
-// PendingRows returns true if the given block has at least one pending row to upsert
-func (b *BlockData) PendingRows(height uint64) bool {
-	hasRows := false
-	// TODO: understand why the guard on height is needed - what does it prevent?
-	if b.Data.BlockHeight == height && len(b.Data.Tables) > 0 {
-		hasRows = true
-	}
-	return hasRows
-}

--- a/vent/sqlsol/block_data_test.go
+++ b/vent/sqlsol/block_data_test.go
@@ -32,38 +32,3 @@ func TestGetBlockData(t *testing.T) {
 		require.EqualValues(t, 2, blk.BlockHeight)
 	})
 }
-
-func TestPendingRows(t *testing.T) {
-	t.Run("successfully returns true if a given block has pending rows to upsert", func(t *testing.T) {
-		values := make(map[string]interface{})
-		values["c1"] = "v1"
-		values["c2"] = "v2"
-
-		blockData := sqlsol.NewBlockData(99)
-		blockData.AddRow("TEST_TABLE", types.EventDataRow{Action: types.ActionUpsert, RowData: values})
-
-		hasRows := blockData.PendingRows(99)
-
-		require.Equal(t, true, hasRows)
-	})
-
-	t.Run("successfully returns false if a given block does not have pending rows to upsert", func(t *testing.T) {
-		values := make(map[string]interface{})
-		values["c1"] = "v1"
-		values["c2"] = "v2"
-
-		blockData := sqlsol.NewBlockData(99)
-		blockData.AddRow("TEST_TABLE", types.EventDataRow{Action: types.ActionUpsert, RowData: values})
-
-		hasRows := blockData.PendingRows(88)
-
-		require.Equal(t, false, hasRows)
-	})
-
-	t.Run("successfully returns false if a given block does not exists", func(t *testing.T) {
-		blockData := sqlsol.NewBlockData(0)
-		hasRows := blockData.PendingRows(999)
-
-		require.Equal(t, false, hasRows)
-	})
-}


### PR DESCRIPTION
Dumping to remember these fixes. Tests need fixing in vent.

- [Vent] fixes #1312 always synchronise block
- [RPC] fixes #1311 - provide height with simulated calls
- [RPC] return NotFound GRPC error code from name reg

Signed-off-by: Silas Davis <silas@monax.io>