### PR TITLE
publish to npm with auth token

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -2,11 +2,11 @@ name: master
 on:
   push:
     branches:
-      - master
+    - master
 
 jobs:
   cover:
-    name: Coverage
+    name: coverage
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-go@v1
@@ -23,12 +23,12 @@ jobs:
         file: ./coverage.txt
 
   docker:
-    name: Docker
+    name: docker
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - run: make docker_build
-    - name: Publish Quay Image
+    - name: publish
       env:
         DOCKER_REPO: "hyperledger/burrow"
         DOCKER_REPO_DEV: "quay.io/monax/burrow"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: release
 on:
   push:
     tags:
@@ -6,11 +6,11 @@ on:
 
 jobs:
   go:
-    name: GoReleaser
+    name: goreleaser
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Publish
+    - name: publish
       uses: docker://goreleaser/goreleaser
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -19,33 +19,28 @@ jobs:
       if: success()
 
   js:
-    name: NPM
+    name: npm
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
-    - name: Publish
+    - name: publish
       env:
-        NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
-        NPM_USER: ${{ secrets.NPM_USER }}
-        NPM_PASS: ${{ secrets.NPM_PASS }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
-        git config --global user.name "${NPM_USER}"
-        git config --global user.email "${NPM_EMAIL}"
-        npm install -g npm-cli-login
-        npm-cli-login
         npm version from-git
+        npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
         npm publish --access public .
 
   docker:
-    name: Docker
+    name: docker
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - run: make docker_build
-    - name: Publish
+    - name: publish
       env:
         DOCKER_REPO: "hyperledger/burrow"
         DOCKER_USER: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,12 @@
 name: test
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+
 jobs:
   unit:
-    name: Unit
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-go@v1
@@ -18,21 +22,18 @@ jobs:
         path: bin
 
   integration:
-    name: Integration
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - run: make test_integration
 
   vent:
-    name: Vent
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - run: docker-compose run burrow make test_integration_vent
 
   docker:
-    name: Docker
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -41,7 +42,6 @@ jobs:
         DOCKER_REPO: "hyperledger/burrow"
 
   keys:
-    name: Keys
     runs-on: ubuntu-latest
     needs: unit
     steps:
@@ -51,13 +51,12 @@ jobs:
         name: burrow
         path: bin
     - run: chmod +x $(pwd)/bin/*
-    - name: Test
+    - name: test
       run: |
         export PATH=${PATH}:$(pwd)/bin
         make test_keys
 
   truffle:
-    name: Truffle
     runs-on: ubuntu-latest
     needs: unit
     steps:
@@ -70,13 +69,12 @@ jobs:
         name: burrow
         path: bin
     - run: chmod +x $(pwd)/bin/*
-    - name: Test
+    - name: test
       run: |
         export PATH=${PATH}:$(pwd)/bin
         make test_truffle
 
   deploy:
-    name: Deploy
     runs-on: ubuntu-latest
     needs: unit
     steps:
@@ -86,13 +84,12 @@ jobs:
         name: burrow
         path: bin
     - run: chmod +x $(pwd)/bin/*
-    - name: Test
+    - name: test
       run: |
         export PATH=${PATH}:$(pwd)/bin
         make test_deploy
 
   restore:
-    name: Dump - Restore
     runs-on: ubuntu-latest
     needs: unit
     steps:
@@ -102,13 +99,12 @@ jobs:
         name: burrow
         path: bin
     - run: chmod +x $(pwd)/bin/*
-    - name: Test
+    - name: test
       run: |
         export PATH=${PATH}:$(pwd)/bin
         make test_restore
 
-  test_js:
-    name: JS API
+  js:
     runs-on: ubuntu-latest
     needs: unit
     steps:
@@ -121,7 +117,7 @@ jobs:
         name: burrow
         path: bin
     - run: chmod +x $(pwd)/bin/*
-    - name: Test
+    - name: test
       run: |
         export PATH=${PATH}:$(pwd)/bin
         make npm_install


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Previously, we published to NPM via a maintainer account `billings`. Since this appears to have been removed, we should instead publish via an auth token retrieved from another maintainer's account. This is set in GitHub settings and activated via `.npmrc`.