### PR TITLE
Fixed a bug for operator SDIV.

### DIFF
--- a/execution/evm/contract.go
+++ b/execution/evm/contract.go
@@ -106,7 +106,7 @@ func (c *Contract) execute(st engine.State, params engine.CallParams) ([]byte, e
 				stack.Push(Zero256)
 				c.debugf(" %v / %v = %v\n", x, y, 0)
 			} else {
-				div := new(big.Int).Div(x, y)
+				div := new(big.Int).Quo(x, y)
 				res := stack.PushBigInt(div)
 				c.debugf(" %v / %v = %v (%v)\n", x, y, div, res)
 			}


### PR DESCRIPTION
According to [Solidity Docs](https://solidity.readthedocs.io/en/latest/types.html): "In Solidity, division rounds towards zero. This mean that `int256(-5) / int256(2) == int256(-2)`."
In `big.Int`, `Div` implements [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) in which the direction of rounding depends on the sign of denominator.

| Example | Solidity/EVM | big.Int.Div() |
| :-: | :-: | :-: |
| 7/3 | 2 | 2 |
| 7/(-3) | -2 | -2 |
| (-7)/3 | -2 | -3 |
| (-7)/(-3) | 2 | 3 |

`case SDIV` in contract.go needs to be modified if we want to keep the same behavior as Solidity/EVM's.