### PR TITLE
[Vent] Add BytesToHex flag to byte32 fields to hex string columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # [Hyperledger Burrow](https://github.com/hyperledger/burrow) Changelog
+## [0.30.5] - 2020-07-09
+### Added
+- [Vent] Add BytesToHex flag on projection field mappings that causes bytes fields (e.g. bytes32) solidity fields to be hex-encoded and mapped to varchar(64) rather than bytea/blob columns in postgres/sqlite
+
+
 ## [0.30.4] - 2020-04-05
 ### Added
 - [Build] Added Helm chart
-- [State] Account now has OpcodeBitset field to support upcoming EVM fixes
+- [State] Account now has EVMOpcodeBitset field to support upcoming EVM fixes
 
 ### Fixed
 - [JS] Github actions release of JS lib
@@ -661,6 +666,7 @@ This release marks the start of Eris-DB as the full permissioned blockchain node
   - [Blockchain] Fix getBlocks to respect block height cap.
 
 
+[0.30.5]: https://github.com/hyperledger/burrow/compare/v0.30.4...v0.30.5
 [0.30.4]: https://github.com/hyperledger/burrow/compare/v0.30.3...v0.30.4
 [0.30.3]: https://github.com/hyperledger/burrow/compare/v0.30.2...v0.30.3
 [0.30.2]: https://github.com/hyperledger/burrow/compare/v0.30.1...v0.30.2

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,7 +1,3 @@
 ### Added
-- [Build] Added Helm chart
-- [State] Account now has OpcodeBitset field to support upcoming EVM fixes
-
-### Fixed
-- [JS] Github actions release of JS lib
+- [Vent] Add BytesToHex flag on projection field mappings that causes bytes fields (e.g. bytes32) solidity fields to be hex-encoded and mapped to varchar(64) rather than bytea/blob columns in postgres/sqlite
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     ports:
       - 5432
-    environment:
-      - POSTGRES_HOST_AUTH_METHOD=trust
 
   burrow:
     build: .github

--- a/project/history.go
+++ b/project/history.go
@@ -47,7 +47,12 @@ func FullVersion() string {
 // To cut a new release add a release to the front of this slice then run the
 // release tagging script: ./scripts/tag_release.sh
 var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "https://github.com/hyperledger/burrow").
-	MustDeclareReleases("0.30.4 - 2020-04-05",
+	MustDeclareReleases(
+		"0.30.5 - 2020-07-09",
+		`### Added
+- [Vent] Add BytesToHex flag on projection field mappings that causes bytes fields (e.g. bytes32) solidity fields to be hex-encoded and mapped to varchar(64) rather than bytea/blob columns in postgres/sqlite
+`,
+		"0.30.4 - 2020-04-05",
 		`### Added
 - [Build] Added Helm chart
 - [State] Account now has EVMOpcodeBitset field to support upcoming EVM fixes

--- a/vent/service/consumer_postgres_test.go
+++ b/vent/service/consumer_postgres_test.go
@@ -111,8 +111,9 @@ func TestPostgresConsumer(t *testing.T) {
 				t.Logf("latest height: %d, txe height: %d", height, txe.Height)
 				assert.True(t, height >= txe.Height)
 			}
-			assert.Equal(t, `{"_action" : "INSERT", "testdescription" : "\\x5472696767657220697421000000000000000000000000000000000000000000", "testname" : "TestTriggerEvent"}`, notifications["meta"])
-			assert.Equal(t, `{"_action" : "INSERT", "testdescription" : "\\x5472696767657220697421000000000000000000000000000000000000000000", "testkey" : "\\x544553545f4556454e5453000000000000000000000000000000000000000000", "testname" : "TestTriggerEvent"}`,
+			assert.Equal(t, `{"_action" : "INSERT", "testdescription" : "5472696767657220697421000000000000000000000000000000000000000000", "testname" : "TestTriggerEvent"}`,
+				notifications["meta"])
+			assert.Equal(t, `{"_action" : "INSERT", "testdescription" : "5472696767657220697421000000000000000000000000000000000000000000", "testkey" : "\\x544553545f4556454e5453000000000000000000000000000000000000000000", "testname" : "TestTriggerEvent"}`,
 				notifications["keyed_meta"])
 		})
 	})

--- a/vent/service/rowbuilder.go
+++ b/vent/service/rowbuilder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hyperledger/burrow/vent/sqlsol"
 	"github.com/hyperledger/burrow/vent/types"
 	"github.com/pkg/errors"
+	"github.com/tmthrgd/go-hex"
 )
 
 // buildEventData builds event data from transactions
@@ -50,11 +51,12 @@ func buildEventData(projection *sqlsol.Projection, eventClass *types.EventClass,
 		}
 		column, err := projection.GetColumn(eventClass.TableName, fieldMapping.ColumnName)
 		if err == nil {
-			if fieldMapping.BytesToString {
-				if bs, ok := value.(*[]byte); ok {
+			if bs, ok := value.(*[]byte); ok {
+				if fieldMapping.BytesToString {
 					str := sanitiseBytesForString(*bs, logger)
-					row[column.Name] = interface{}(str)
-					continue
+					value = interface{}(str)
+				} else if fieldMapping.BytesToHex {
+					value = hex.EncodeUpperToString(*bs)
 				}
 			}
 			row[column.Name] = value

--- a/vent/test/sqlsol.go
+++ b/vent/test/sqlsol.go
@@ -109,7 +109,7 @@ func UnknownTypeJSONConfFile(t *testing.T) string {
 			},
 			"Fields"  , 
 				"ColumnName" , "ColumnName" : "testname", "Primary" : true},
-				"description", "ColumnName" : "testdescription", "Primary" : false}
+				"description", "ColumnName" : "testdescription", "Primary" : false, "BytesToHex": true}
 			}
 		}
 	]`

--- a/vent/test/sqlsol_log.json
+++ b/vent/test/sqlsol_log.json
@@ -23,6 +23,7 @@
         "ColumnName": "testdescription",
         "Type": "bytes32",
         "Primary": false,
+        "BytesToHex": true,
         "Notify": ["meta", "keyed_meta"]
       }
     ]

--- a/vent/test/sqlsol_view.json
+++ b/vent/test/sqlsol_view.json
@@ -24,6 +24,7 @@
         "ColumnName": "testdescription",
         "Type": "bytes32",
         "Primary": false,
+        "BytesToHex": true,
         "Notify": ["meta", "keyed_meta"]
       }
     ]

--- a/vent/types/event_class.go
+++ b/vent/types/event_class.go
@@ -79,6 +79,8 @@ type EventFieldMapping struct {
 	Primary bool `json:",omitempty"`
 	// Whether to convert this event field from bytes32 to string
 	BytesToString bool `json:",omitempty"`
+	// Whether to convert this event field from bytes32 to hex-encoded string
+	BytesToHex bool `json:",omitempty"`
 	// Notification channels on which submit (via a trigger) a payload that contains this column's new value (upsert) or
 	// old value (delete). The payload will contain all other values with the same channel set as a JSON object.
 	Notify []string `json:",omitempty"`


### PR DESCRIPTION
Use varchar(64) instead of bytea/blob since easier to work with and used
most places

Signed-off-by: Silas Davis <silas@monax.io>