### PR TITLE
[fix]execution/evm/abi: check data length before decoding Address and Bytes with ABI

### DIFF
--- a/execution/evm/abi/primitives.go
+++ b/execution/evm/abi/primitives.go
@@ -618,6 +618,9 @@ func (e EVMBytes) pack(v interface{}) ([]byte, error) {
 }
 
 func (e EVMBytes) unpack(data []byte, offset int, v interface{}) (int, error) {
+	if len(data)-offset < ElementSize {
+		return 0, fmt.Errorf("%v: not enough data", e)
+	}
 	if e.M == 0 {
 		s := EVMString{}
 

--- a/execution/evm/abi/primitives.go
+++ b/execution/evm/abi/primitives.go
@@ -539,6 +539,9 @@ func (e EVMAddress) pack(v interface{}) ([]byte, error) {
 }
 
 func (e EVMAddress) unpack(data []byte, offset int, v interface{}) (int, error) {
+	if len(data)-offset < ElementSize {
+		return 0, fmt.Errorf("%v: not enough data", e)
+	}
 	addr, err := crypto.AddressFromBytes(data[offset+ElementSize-crypto.AddressLength : offset+ElementSize])
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Check data length before decoding `Address` and `Bytes` with ABI, or it will panic by decoding an `Address` or `Bytes` value.