### PR TITLE
Do not pass direct memory reference from WASM VM

### DIFF
--- a/execution/wasm/contract.go
+++ b/execution/wasm/contract.go
@@ -181,10 +181,12 @@ func (ctx *context) ResolveFunc(module, field string) lifeExec.FunctionImport {
 			dataPtr := int(uint32(vm.GetCurrentFrame().Locals[1]))
 
 			key := bin.Word256{}
+			value := make([]byte, 32)
 
 			copy(key[:], vm.Memory[keyPtr:keyPtr+32])
+			copy(value, vm.Memory[dataPtr:dataPtr+32])
 
-			err := ctx.state.SetStorage(ctx.params.Callee, key, vm.Memory[dataPtr:dataPtr+32])
+			err := ctx.state.SetStorage(ctx.params.Callee, key, value)
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
Values passed into SetStorage should be immutable over the commit cycle

fixes #1417 

Signed-off-by: Silas Davis <silas@monax.io>