### PR TITLE
Implement CHAINID and DIFFICULTY opcodes

### DIFF
--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -118,7 +118,7 @@ func (sig *Signature) String() string {
 }
 
 func GetEthChainID(chainID string) *big.Int {
-	return new(big.Int).SetBytes([]byte(chainID))
+	return new(big.Int).SetBytes(Keccak256([]byte(chainID)))
 }
 
 func GetEthSignatureRecoveryID(chainID string, parity *big.Int) *big.Int {

--- a/execution/engine/blockchain.go
+++ b/execution/engine/blockchain.go
@@ -12,6 +12,8 @@ type TestBlockchain struct {
 	BlockTime   time.Time
 }
 
+var _ Blockchain = (*TestBlockchain)(nil)
+
 func (b *TestBlockchain) LastBlockHeight() uint64 {
 	return b.BlockHeight
 }
@@ -27,4 +29,8 @@ func (b *TestBlockchain) BlockHash(height uint64) ([]byte, error) {
 	bs := make([]byte, 32)
 	binary.BigEndian.PutUint64(bs[24:], height)
 	return bs, nil
+}
+
+func (V *TestBlockchain) ChainID() string {
+	return "TestChain"
 }

--- a/execution/engine/callable.go
+++ b/execution/engine/callable.go
@@ -12,6 +12,7 @@ type Blockchain interface {
 	LastBlockHeight() uint64
 	LastBlockTime() time.Time
 	BlockHash(height uint64) ([]byte, error)
+	ChainID() string
 }
 
 type CallParams struct {

--- a/execution/evm/asm/opcodes.go
+++ b/execution/evm/asm/opcodes.go
@@ -71,8 +71,9 @@ const (
 	COINBASE
 	TIMESTAMP
 	BLOCKHEIGHT
-	DIFFICULTY_DEPRECATED
+	DIFFICULTY
 	GASLIMIT
+	CHAINID
 )
 
 const (
@@ -236,12 +237,13 @@ var opCodeNames = map[OpCode]string{
 	EXTCODEHASH:         "EXTCODEHASH",
 
 	// 0x40 range - block operations
-	BLOCKHASH:             "BLOCKHASH",
-	COINBASE:              "COINBASE",
-	TIMESTAMP:             "TIMESTAMP",
-	BLOCKHEIGHT:           "BLOCKHEIGHT",
-	DIFFICULTY_DEPRECATED: "DIFFICULTY_DEPRECATED",
-	GASLIMIT:              "GASLIMIT",
+	BLOCKHASH:   "BLOCKHASH",
+	COINBASE:    "COINBASE",
+	TIMESTAMP:   "TIMESTAMP",
+	BLOCKHEIGHT: "BLOCKHEIGHT",
+	DIFFICULTY:  "DIFFICULTY",
+	GASLIMIT:    "GASLIMIT",
+	CHAINID:     "CHAINID",
 
 	// 0x50 range - 'storage' and execution
 	POP:      "POP",

--- a/execution/evm/contract.go
+++ b/execution/evm/contract.go
@@ -478,9 +478,19 @@ func (c *Contract) execute(st engine.State, params engine.CallParams) ([]byte, e
 			stack.Push64(number)
 			c.debugf(" => %d\n", number)
 
+		case DIFFICULTY: // 0x44
+			// ~ hashes per solution - by convention we'll use unity since there are no misses if you are proposer
+			stack.Push(One256)
+			c.debugf(" => %v\n", One256)
+
 		case GASLIMIT: // 0x45
 			stack.PushBigInt(params.Gas)
 			c.debugf(" => %v\n", *params.Gas)
+
+		case CHAINID: // 0x46
+			id := crypto.GetEthChainID(st.Blockchain.ChainID())
+			stack.PushBigInt(id)
+			c.debugf(" => %X\n", id)
 
 		case POP: // 0x50
 			popped := stack.Pop()

--- a/execution/wasm/contract.go
+++ b/execution/wasm/contract.go
@@ -84,13 +84,7 @@ func (ctx *context) ResolveFunc(module, field string) lifeExec.FunctionImport {
 	}
 
 	switch field {
-	case "call":
-		fallthrough
-	case "callCode":
-		fallthrough
-	case "callDelegate":
-		fallthrough
-	case "callStatic":
+	case "call", "callCode", "callDelegate", "callStatic":
 		return func(vm *lifeExec.VirtualMachine) int64 {
 			gasLimit := big.NewInt(vm.GetCurrentFrame().Locals[0])
 			addressPtr := uint32(vm.GetCurrentFrame().Locals[1])


### PR DESCRIPTION
We have to adopt our own convention for CHAINID, which is now
Keccak(ChainID).

DIFFICULTY, which doesn't really make sense for Tendermint, is fixed
to one to represent 'no hashing misses' when proposing.

Signed-off-by: Silas Davis <silas@monax.io>