### PR TITLE
Solidity 0.8 fails to compile with "no binary code found in contract"

### DIFF
--- a/deploy/compile/compilers.go
+++ b/deploy/compile/compilers.go
@@ -237,7 +237,7 @@ func EVM(file string, optimize bool, workDir string, libraries map[string]string
 
 	input.Sources[file] = SolidityInputSource{Urls: []string{file}}
 	input.Settings.Optimizer.Enabled = optimize
-	input.Settings.OutputSelection.File.OutputType = []string{"abi", "evm.deployedBytecode.object", "evm.bytecode.linkReferences", "metadata", "bin", "devdoc"}
+	input.Settings.OutputSelection.File.OutputType = []string{"abi", "evm.bytecode.object", "evm.deployedBytecode.object", "evm.bytecode.linkReferences", "metadata", "bin", "devdoc"}
 	input.Settings.Libraries = make(map[string]map[string]string)
 	input.Settings.Libraries[""] = make(map[string]string)
 


### PR DESCRIPTION
evm.bytecode.object should be requested, else we might not receive it.

Should fix #1434

Signed-off-by: Sean Young <sean@mess.org>