### PR TITLE
Improve OS portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ build_burrow_debug:
 .PHONY: install
 install: build_burrow
 	mkdir -p ${BIN_PATH}
-	install -T ${REPO}/bin/burrow ${BIN_PATH}/burrow
+	install ${REPO}/bin/burrow ${BIN_PATH}/burrow
 
 # build burrow with checks for race conditions
 .PHONY: build_race_db

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 
 # ----------------------------------------------------------
 
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 REPO := $(shell pwd)
 
 # Our own Go files containing the compiled bytecode of solidity files as a constant

--- a/js/test.sh
+++ b/js/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export this="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$this/../tests/test_runner.sh"

--- a/scripts/commit_hash.sh
+++ b/scripts/commit_hash.sh
@@ -4,7 +4,7 @@
 commit=$(git describe --tags)
 dirty=$(git ls-files -m)
 if [[ -n ${dirty} ]]; then
-    commit="$commit+dirty.$(echo ${dirty} | git hash-object --stdin | head -c8)"
+    commit="$commit+dirty.$(echo ${dirty} | git hash-object --stdin | dd bs=8 count=1 status=none)"
 fi
 echo "$commit"
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/tests/dump/test.sh
+++ b/tests/dump/test.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # Test the dump restore functionality
 #

--- a/tests/dump/test.sh
+++ b/tests/dump/test.sh
@@ -48,7 +48,7 @@ echo -e "${title//?/-}\n${title}\n${title//?/-}\n"
 
 $burrow_bin dump remote -b dump.bin
 $burrow_bin dump remote dump.json
-height=$(head -1  dump.json | jq .Height)
+height=$(head -n 1  dump.json | jq .Height)
 
 kill $burrow_pid
 

--- a/tests/keys_server/test.sh
+++ b/tests/keys_server/test.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # tests
 # run the suite with and without the daemon

--- a/tests/web3/truffle.sh
+++ b/tests/web3/truffle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 chain=$(mktemp -d)
 cd $chain


### PR DESCRIPTION
Tiny fixes for the issues mentioned in #1453, namely:

* use `/usr/bin/env bash` instead of calling `/bin/bash` directly (which may not always be there)
* use `dd` instead of `head -c`, which is not portable
* use `head -n` instead of the historical `head -<count>` syntax
* do not use non-portable `-T` flag with `install`