### PR TITLE
Don't push dev image to latest tag in hyperledger repo

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -52,5 +52,4 @@ jobs:
         run: |
           version=$(./scripts/local_version.sh)
           echo ${DOCKER_PASS} | docker login --username ${DOCKER_USER} --password-stdin
-          docker tag ${DOCKER_REPO}:${version} ${DOCKER_REPO}:latest
-          docker push ${DOCKER_REPO}:latest
+          docker push --all-tags ${DOCKER_REPO}


### PR DESCRIPTION
Do push dev version tag to hyperledger

Signed-off-by: Silas Davis <silas@monax.io>