### PR TITLE
Stop TxStack from rejecting StreamEvents from a dump/restored chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # [Hyperledger Burrow](https://github.com/hyperledger/burrow) Changelog
+## [0.31.2] - 2020-03-24
+### Fixed
+- [Dump] Stop TxStack EventStream consumer from rejecting events from dump/restored chain because they lack tx Envelopes (as they are intended to to keep dump format minimal)
+- [Genesis] Fix hash instability introduced by accidentally removing omitempty from AppHash in genesis
+
+### Added
+- [Vent] Implement throttling on Ethereum Vent consumer via --max-request-rate=<requests / time base> flag to 'vent start'
+
+
 ## [0.31.1] - 2020-03-19
 ### Changed
 - [Repo] main branch replaces master as per Hyperledger TSC guidelines
@@ -717,6 +726,7 @@ This release marks the start of Eris-DB as the full permissioned blockchain node
   - [Blockchain] Fix getBlocks to respect block height cap.
 
 
+[0.31.2]: https://github.com/hyperledger/burrow/compare/v0.31.1...v0.31.2
 [0.31.1]: https://github.com/hyperledger/burrow/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/hyperledger/burrow/compare/v0.30.5...v0.31.0
 [0.30.5]: https://github.com/hyperledger/burrow/compare/v0.30.4...v0.30.5

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,14 +1,7 @@
-### Changed
-- [Repo] main branch replaces master as per Hyperledger TSC guidelines
-
 ### Fixed
-- [Docker] Make sure default testnet mode works when running docker images
-- [Vent] Use appropriately sized database integral types for EVM integer types (i.e. numeric for uint64 and bigger)
-- [Vent] Ethereum block consumer now correctly reads to an _inclusive_ block batch end height
-- [Web3] Handle integer ChainID for web3 consistently; return hex-encoded numeric value from web3 RPC, also allow overriding of genesis-hash derived ChainID so Burrow can be connected with from metamask
+- [Dump] Stop TxStack EventStream consumer from rejecting events from dump/restored chain because they lack tx Envelopes (as they are intended to to keep dump format minimal)
+- [Genesis] Fix hash instability introduced by accidentally removing omitempty from AppHash in genesis
 
 ### Added
-- [Build] Build dev docker and JS releases by force pushing to prerelease branch
-- [Vent] Expose BlockConsumerConfig to adjust backoff and read characteristics
-- [Vent] Add vent-side continuity test over blocks (to double-check exactly once delivery of events)
+- [Vent] Implement throttling on Ethereum Vent consumer via --max-request-rate=<requests / time base> flag to 'vent start'
 

--- a/execution/exec/stream_event.go
+++ b/execution/exec/stream_event.go
@@ -245,7 +245,10 @@ func (stack *TxStack) Consume(ev *StreamEvent) (*TxExecution, error) {
 		if err != nil {
 			return nil, err
 		}
-		if txe.Envelope == nil || txe.Receipt == nil {
+		// If Origin _is_ set then it implies the transaction originates from a dump and is in an abbreviated
+		// 'pseudo transaction' for which no envelope is stored (since the dump format is intended to minimal) and we
+		// must relax the Envelope presence continuity check
+		if txe.TxHeader.Origin == nil && (txe.Envelope == nil || txe.Receipt == nil) {
 			return nil, fmt.Errorf("TxStack.Consume did not receive transaction envelope for transaction %s",
 				txe.TxHash)
 		}

--- a/project/history.go
+++ b/project/history.go
@@ -48,6 +48,15 @@ func FullVersion() string {
 // release tagging script: ./scripts/tag_release.sh
 var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "https://github.com/hyperledger/burrow").
 	MustDeclareReleases(
+		"0.31.2 - 2020-03-24",
+		`### Fixed
+- [Dump] Stop TxStack EventStream consumer from rejecting events from dump/restored chain because they lack tx Envelopes (as they are intended to to keep dump format minimal)
+- [Genesis] Fix hash instability introduced by accidentally removing omitempty from AppHash in genesis
+
+### Added
+- [Vent] Implement throttling on Ethereum Vent consumer via --max-request-rate=<requests / time base> flag to 'vent start'
+`,
+
 		"0.31.1 - 2020-03-19",
 		`### Changed
 - [Repo] main branch replaces master as per Hyperledger TSC guidelines

--- a/rpc/rpcevents/blocks.go
+++ b/rpc/rpcevents/blocks.go
@@ -72,7 +72,7 @@ func SingleBlock(height uint64) *BlockRange {
 	return AbsoluteRange(height, height+1)
 }
 
-func ConsumeBlockExecutions(stream ExecutionEvents_StreamClient, consumer func(*exec.BlockExecution) error,
+func ConsumeBlockExecutions(stream exec.EventStream, consumer func(*exec.BlockExecution) error,
 	continuityOptions ...exec.ContinuityOpt) error {
 	var be *exec.BlockExecution
 	var err error


### PR DESCRIPTION
Relax the continuity check that requires a tx Envelope for transactions
that have an Origin and therefore came from a dump of a predecessor
chain

Signed-off-by: Silas Davis <silas@monax.io>