### PR TITLE
Get rid of excessively long and generally useless EVM trace from call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # [Hyperledger Burrow](https://github.com/hyperledger/burrow) Changelog
+## [0.32.1] - 2021-05-15
+### Changed
+- [Execution] CallErrors no longer emit very long rather pointless (since there is no tooling to help interpret them currently) EVM call traces
+
+
 ## [0.32.0] - 2021-05-14
 ### Changed
 - [JS] Significant refactor/rewrite of Burrow.js into idiomatic Typescript including some breaking changes to API
@@ -747,6 +752,7 @@ This release marks the start of Eris-DB as the full permissioned blockchain node
   - [Blockchain] Fix getBlocks to respect block height cap.
 
 
+[0.32.1]: https://github.com/hyperledger/burrow/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/hyperledger/burrow/compare/v0.31.3...v0.32.0
 [0.31.3]: https://github.com/hyperledger/burrow/compare/v0.31.2...v0.31.3
 [0.31.2]: https://github.com/hyperledger/burrow/compare/v0.31.1...v0.31.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [0.32.1] - 2021-05-15
 ### Changed
 - [Execution] CallErrors no longer emit very long rather pointless (since there is no tooling to help interpret them currently) EVM call traces
+- [JS] Return byte arrays as Buffers from decode (only return fixed-width byteNN types as hex strings)
 
 
 ## [0.32.0] - 2021-05-14

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,13 +1,3 @@
 ### Changed
-- [JS] Significant refactor/rewrite of Burrow.js into idiomatic Typescript including some breaking changes to API
-- [JS] Change to use ethers.js for ABI encoding
-
-### Fixed
-- [State] Fixed cache-concurrency bug (https://github.com/hyperledger/burrow/commit/314357e0789b0ec7033a2a419b816d2f1025cad0) and ensured consistency snapshot is used when performing simulated call reads
-- [Web3] Omit empty values from JSONRPC calls
-
-### Added
-- [Tendermint] Added support for passing node options to Tendermint - e.g. custom reactors (thanks @nmanchovski!)
-- [JS] Historic events can now be requested via API
-- [JS] Contract deployments will now include ABIs via contract metadata so Burrow's ABI registry can be used
+- [Execution] CallErrors no longer emit very long rather pointless (since there is no tooling to help interpret them currently) EVM call traces
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,4 @@
 ### Changed
 - [Execution] CallErrors no longer emit very long rather pointless (since there is no tooling to help interpret them currently) EVM call traces
+- [JS] Return byte arrays as Buffers from decode (only return fixed-width byteNN types as hex strings)
 

--- a/execution/contexts/call_context.go
+++ b/execution/contexts/call_context.go
@@ -229,8 +229,7 @@ func (ctx *CallContext) Deliver(inAcc, outAcc *acm.Account, value uint64) error 
 			ctx.Logger.InfoMsg("Error on EVM execution",
 				structure.ErrorKey, err)
 
-			ctx.txe.PushError(errors.Wrapf(err, "call error: %v\nEVM call trace: %s",
-				err, ctx.txe.CallTrace()))
+			ctx.txe.PushError(err)
 		} else {
 			ctx.Logger.TraceMsg("Successful execution")
 			if createContract {

--- a/js/src/convert.ts
+++ b/js/src/convert.ts
@@ -48,13 +48,17 @@ export function withoutArrayElements(result: Result): Record<string, unknown> {
 function abiToBurrow(arg: unknown, type: string): unknown {
   if (/address/.test(type)) {
     return recApply(unprefixedHexString, arg as NestedArray<string>);
-  } else if (/bytes/.test(type)) {
+  } else if (/bytes[0-9]+/.test(type)) {
+    // Handle bytes32 differently - for legacy reasons they are used as identifiers and represented as hex strings
     return recApply(unprefixedHexString, arg as NestedArray<string>);
+  } else if (/bytes/.test(type)) {
+    return recApply(toBuffer, arg as NestedArray<string>);
   } else if (/int/.test(type)) {
     return recApply(numberToBurrow, arg as NestedArray<BigNumber>);
   }
   return arg;
 }
+
 
 function burrowToAbi(arg: unknown, type: string): unknown {
   if (/address/.test(type)) {

--- a/project/history.go
+++ b/project/history.go
@@ -47,7 +47,11 @@ func FullVersion() string {
 // To cut a new release add a release to the front of this slice then run the
 // release tagging script: ./scripts/tag_release.sh
 var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "https://github.com/hyperledger/burrow").
-	MustDeclareReleases("0.32.0 - 2021-05-14",
+	MustDeclareReleases("0.32.1 - 2021-05-15",
+		`### Changed
+- [Execution] CallErrors no longer emit very long rather pointless (since there is no tooling to help interpret them currently) EVM call traces
+`,
+		"0.32.0 - 2021-05-14",
 		`### Changed
 - [JS] Significant refactor/rewrite of Burrow.js into idiomatic Typescript including some breaking changes to API
 - [JS] Change to use ethers.js for ABI encoding

--- a/project/history.go
+++ b/project/history.go
@@ -50,6 +50,7 @@ var History relic.ImmutableHistory = relic.NewHistory("Hyperledger Burrow", "htt
 	MustDeclareReleases("0.32.1 - 2021-05-15",
 		`### Changed
 - [Execution] CallErrors no longer emit very long rather pointless (since there is no tooling to help interpret them currently) EVM call traces
+- [JS] Return byte arrays as Buffers from decode (only return fixed-width byteNN types as hex strings)
 `,
 		"0.32.0 - 2021-05-14",
 		`### Changed


### PR DESCRIPTION
errors

Signed-off-by: Silas Davis <silas@monax.io>