### PR TITLE
fix encoding error of dynamic objet after uint[]

### DIFF
--- a/execution/evm/abi/abi_test.go
+++ b/execution/evm/abi/abi_test.go
@@ -139,6 +139,13 @@ func TestPacker(t *testing.T) {
 			"arrayOfBoolsPack",
 			append(pad([]byte{1}, 32, true), pad([]byte{0}, 32, true)...),
 		},
+		// test dynamic objet  uint[]
+		{
+			`[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"},{"inputs":[{"internalType":"uint256[]","name":"_tokenIds","type":"uint256[]"},{"internalType":"string","name":"_uri","type":"string"}],"name":"increase","outputs":[],"stateMutability":"nonpayable","type":"function"}]`,
+			[]interface{}{[]string{"201", "202", "203"}, "hello"},
+			"increase",
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 201, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 202, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 203, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 104, 101, 108, 108, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
 	} {
 		t.Log(test.args)
 		if output, _, err := EncodeFunctionCall(test.ABI, test.name, logging.NewNoopLogger(), test.args...); err != nil {

--- a/execution/evm/abi/packing.go
+++ b/execution/evm/abi/packing.go
@@ -233,6 +233,7 @@ func pack(argSpec []Argument, getArg func(int) interface{}) ([]byte, error) {
 					if err != nil {
 						return nil, err
 					}
+					fixedSize += len(d)
 					packedDynamic = append(packedDynamic, d...)
 				}
 			}


### PR DESCRIPTION
fix call encoding  bug 

call contract method increase of
`

    pragma solidity >=0.0.0;

    contract Counter {
        constructor() public{
        }
       function increase(uint256[] memory _tokenIds,string memory _uri) public {

        }
}
`

with parameters
 `["201","202",'203"],"hello"`
 will cause execution reverted.

it is encoded as 

`0b88819400000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000c900000000000000000000000000000000000000000000000000000000000000ca00000000000000000000000000000000000000000000000000000000000000cb000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000`

which is different from ehtereum encoding result 
`0x0b888194000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000c900000000000000000000000000000000000000000000000000000000000000ca00000000000000000000000000000000000000000000000000000000000000cb000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000`


